### PR TITLE
Add configurable sanitizer support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,24 @@ option(ENABLE_LOG "Enable logging" ON)
 option(ENABLE_PROF "Enable profiler" ON)
 option(ENABLE_TESTS "Build tests" ON)
 
+# Sanitizer toggles (semicolons to enable multiple: address;thread;leak;memory;hwaddress;safe-stack;cfi)
+set(SIM_SANITIZERS "" CACHE STRING "Sanitizers to enable for all targets")
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Sanitizers
+if (SIM_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+  message(STATUS "Enabling sanitizers: ${SIM_SANITIZERS}")
+  string(REPLACE ";" "," _san_flags "${SIM_SANITIZERS}")
+  add_compile_options(-fsanitize=${_san_flags} -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=${_san_flags} -fno-omit-frame-pointer)
+  if (SIM_SANITIZERS MATCHES "cfi")
+    add_compile_options(-flto)
+    add_link_options(-flto)
+  endif()
+endif()
 
 # Recommended warnings (clang/gcc)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")

--- a/docs/sanitizers.md
+++ b/docs/sanitizers.md
@@ -1,0 +1,25 @@
+# Sanitizer Support
+
+This project can be built with a variety of LLVM sanitizers to help debug
+memory and concurrency issues before deploying to real hardware.
+
+## Enabling
+
+Pass a semicolon-separated list via `SIM_SANITIZERS` when configuring CMake:
+
+```bash
+cmake -B build -DSIM_SANITIZERS="address;thread" -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+```
+
+Sanitizers are available when using Clang or GCC. Supported entries include:
+
+- `address` – AddressSanitizer for buffer overflows and use-after-free.
+- `leak` – LeakSanitizer for detecting memory leaks.
+- `memory` – MemorySanitizer for uninitialized reads (clang only).
+- `thread` – ThreadSanitizer for data races.
+- `hwaddress` – HWAddressSanitizer for tagged memory (AArch64).
+- `safe-stack` – SafeStack for protecting the return stack.
+- `cfi` – Control Flow Integrity (requires LTO).
+
+Multiple sanitizers may be combined when they are compatible.


### PR DESCRIPTION
## Summary
- Allow enabling LLVM sanitizers via `SIM_SANITIZERS` CMake option
- Document sanitizer usage and supported options

## Testing
- `cmake -S . -B build -DENABLE_TESTS=ON` *(fails: external/googletest missing)*
- `git submodule update --init --recursive` *(fails: 403 fetching googletest)*
- `cmake -S . -B build -DENABLE_TESTS=OFF`
- `cmake --build build`
- `cmake -S . -B build-asan -DENABLE_TESTS=OFF -DSIM_SANITIZERS=address`
- `cmake --build build-asan`


