### PR TITLE
Add CI workflow for sanitized build and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build_type: [Debug, RelWithDebInfo]
+        include:
+          - build_type: Debug
+            sanitizers: address;undefined
+          - build_type: RelWithDebInfo
+            sanitizers: ''
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DENABLE_TESTS=ON -DSIM_SANITIZERS='${{matrix.sanitizers}}'
+      - name: Build
+        run: cmake --build build --config ${{matrix.build_type}} -- -j2
+      - name: Test
+        run: ctest --test-dir build -C ${{matrix.build_type}} --output-on-failure


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that builds and tests the project
- run Debug tests with Address/Undefined sanitizers and Release-style tests without sanitizers

## Testing
- `cmake -S . -B build -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DSIM_SANITIZERS="address;undefined"` (fails: The source directory /workspace/cpp-rt-car/external/googletest does not contain a CMakeLists.txt file)

------
https://chatgpt.com/codex/tasks/task_e_68b78d769578832babdbb34495abac9e