### PR TITLE
Refactor CarSoA with block-based storage

### DIFF
--- a/include/simcore/car_soa.hpp
+++ b/include/simcore/car_soa.hpp
@@ -2,6 +2,7 @@
 #include <vector>
 #include <cstddef>
 #include <cassert>
+#include <utility>
 
 /* -----------------------------------------------------------------
    Minimal struct‑of‑arrays for our dummy “car” example.
@@ -9,19 +10,57 @@
    ----------------------------------------------------------------- */
 struct CarSoA
 {
-    std::vector<double> pos;   // metres
-    std::vector<double> vel;   // m/s
+    static constexpr std::size_t block_size = 128;
+
+    struct alignas(64) Block
+    {
+        alignas(64) double pos[block_size];   // metres
+        alignas(64) double vel[block_size];   // m/s
+    };
+
+    std::vector<Block> m_blocks;
+    std::size_t        m_size = 0;   // number of valid elements
 
     explicit CarSoA(std::size_t n = 0)          { resize(n); }
 
-    void         resize(std::size_t n)          { pos.resize(n); vel.resize(n); }
-    std::size_t  size()   const                 { return pos.size(); }
+    void resize(std::size_t n)
+    {
+        m_size = n;
+        std::size_t nblocks = (n + block_size - 1) / block_size;
+        m_blocks.resize(nblocks);
+    }
+
+    std::size_t size() const                   { return m_size; }
 
     // helper accessors
-    double  position(std::size_t i) const       { return pos[i]; }
-    double  velocity(std::size_t i) const       { return vel[i]; }
+    double& position(std::size_t i)
+    {
+        auto [b, o] = split(i); return m_blocks[b].pos[o];
+    }
+    double  position(std::size_t i) const
+    {
+        auto [b, o] = split(i); return m_blocks[b].pos[o];
+    }
+    double& velocity(std::size_t i)
+    {
+        auto [b, o] = split(i); return m_blocks[b].vel[o];
+    }
+    double  velocity(std::size_t i) const
+    {
+        auto [b, o] = split(i); return m_blocks[b].vel[o];
+    }
     void    set(std::size_t i, double p, double v)
     {
-        pos[i] = p;  vel[i] = v;
+        auto [b, o] = split(i);
+        m_blocks[b].pos[o] = p;  m_blocks[b].vel[o] = v;
+    }
+
+    std::vector<Block>&       blocks()       { return m_blocks; }
+    const std::vector<Block>& blocks() const { return m_blocks; }
+
+private:
+    static std::pair<std::size_t, std::size_t> split(std::size_t i)
+    {
+        return { i / block_size, i % block_size };
     }
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,8 +79,8 @@ int main(int argc, char** argv)
                                           int64_t, SimCore::Seconds dt) {
         double dts = dt.count();
         for (std::size_t i = b; i < e; ++i) {
-            cars.vel[i] += (force[i] / 1200.0) * dts;
-            cars.pos[i] += cars.vel[i] * dts;
+            cars.velocity(i) += (force[i] / 1200.0) * dts;
+            cars.position(i) += cars.velocity(i) * dts;
         }
     });
 
@@ -88,7 +88,8 @@ int main(int argc, char** argv)
     sim.addReductionTask(physics, [&](int64_t f, SimCore::Seconds){
         if (f % 1000 == 0) {
             double sum = 0.0;
-            for (double v : cars.vel) sum += v;
+            for (std::size_t i = 0; i < cars.size(); ++i)
+                sum += cars.velocity(i);
             double avg = sum / cars.size();
             LOG_INFO(&logger, "[REDUCE] frame={} avgVel={:.4f}", f, avg);
         }
@@ -96,6 +97,6 @@ int main(int argc, char** argv)
 
     sim.run();
 
-    std::cout << "Final pos0=" << cars.pos[0] << "\n";
+    std::cout << "Final pos0=" << cars.position(0) << "\n";
     return 0;
 }

--- a/tests/test_soa.cpp
+++ b/tests/test_soa.cpp
@@ -1,25 +1,45 @@
 #include <gtest/gtest.h>
 #include <simcore/car_soa.hpp>
+#include <cstdint>
 
-TEST(SoAData, ContiguousAndCorrect)
+// Verify basic block characteristics
+TEST(CarSoA, BlockLayout)
 {
-    constexpr std::size_t N = 1024;
+    EXPECT_EQ(CarSoA::block_size, 128u);
+
+    CarSoA::Block blk{};
+    EXPECT_EQ(sizeof(blk.pos) / sizeof(double), CarSoA::block_size);
+    EXPECT_EQ(sizeof(blk.vel) / sizeof(double), CarSoA::block_size);
+
+    EXPECT_EQ(alignof(CarSoA::Block), 64u);
+    EXPECT_EQ(reinterpret_cast<std::uintptr_t>(blk.pos) % 64, 0u);
+    EXPECT_EQ(reinterpret_cast<std::uintptr_t>(blk.vel) % 64, 0u);
+}
+
+// Ensure iteration across blocks including padded tail
+TEST(CarSoA, IterationWithPadding)
+{
+    constexpr std::size_t N = CarSoA::block_size * 2 + 5;
     CarSoA cars(N);
 
-    /* write pattern */
     for (std::size_t i = 0; i < N; ++i)
-        cars.set(i, double(i), double(i * 2));
+        cars.set(i, static_cast<double>(i), static_cast<double>(i * 2));
 
-    /* verify */
     for (std::size_t i = 0; i < N; ++i) {
-        EXPECT_EQ(cars.position(i), double(i));
-        EXPECT_EQ(cars.velocity(i), double(i * 2));
+        EXPECT_EQ(cars.position(i), static_cast<double>(i));
+        EXPECT_EQ(cars.velocity(i), static_cast<double>(i * 2));
     }
 
-    /* contiguous check: difference of adjacent addresses = sizeof(double) */
-    const double* base = cars.pos.data();
-    for (std::size_t i = 1; i < N; ++i)
-        ASSERT_EQ(reinterpret_cast<const char*>(&cars.pos[i]) -
-                  reinterpret_cast<const char*>(&cars.pos[i - 1]),
-                  sizeof(double));
+    std::size_t idx = 0;
+    for (const auto& blk : cars.blocks()) {
+        for (std::size_t j = 0; j < CarSoA::block_size; ++j) {
+            if (idx < N) {
+                EXPECT_EQ(blk.pos[j], static_cast<double>(idx));
+                EXPECT_EQ(blk.vel[j], static_cast<double>(idx * 2));
+            }
+            ++idx;
+        }
+    }
+    EXPECT_EQ(idx, cars.blocks().size() * CarSoA::block_size);
 }
+


### PR DESCRIPTION
## Summary
- redesign CarSoA to store data in 64-byte-aligned blocks of 128 cars
- update example main to use new accessors
- add tests for block layout, alignment and iteration over padded blocks

## Testing
- ❌ `cmake -S . -B build` *(missing googletest submodule, clone blocked)*
- ❌ `git submodule update --init --recursive` *(unable to access googletest repository: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b79c0c48f0832b9f84ef0e6d7eb124