### PR TITLE
Add sparse/dense mapping and branchless lookup for CarSoA

### DIFF
--- a/include/simcore/car_soa.hpp
+++ b/include/simcore/car_soa.hpp
@@ -4,24 +4,98 @@
 #include <cassert>
 
 /* -----------------------------------------------------------------
-   Minimal struct‑of‑arrays for our dummy “car” example.
-   Extend with more fields later (acc, steering, …).
+   Struct-of-arrays storage for the dummy "car" example.
+   Now maintains sparse/dense mappings so systems can query only the
+   components they need.
    ----------------------------------------------------------------- */
 struct CarSoA
 {
+    // dense component storage
     std::vector<double> pos;   // metres
     std::vector<double> vel;   // m/s
+    // entity mappings
+    std::vector<std::size_t> sparse;  // entity -> dense index + 1 (0 = missing)
+    std::vector<std::size_t> dense;   // dense index -> entity id
 
-    explicit CarSoA(std::size_t n = 0)          { resize(n); }
+    double defaultPos{0.0};
+    double defaultVel{0.0};
 
-    void         resize(std::size_t n)          { pos.resize(n); vel.resize(n); }
-    std::size_t  size()   const                 { return pos.size(); }
-
-    // helper accessors
-    double  position(std::size_t i) const       { return pos[i]; }
-    double  velocity(std::size_t i) const       { return vel[i]; }
-    void    set(std::size_t i, double p, double v)
+    CarSoA() = default;
+    explicit CarSoA(std::size_t n)
     {
-        pos[i] = p;  vel[i] = v;
+        reserve(n);
+        for (std::size_t i = 0; i < n; ++i)
+            insert(i, 0.0, 0.0);
+    }
+
+    void reserve(std::size_t n)
+    {
+        pos.reserve(n);
+        vel.reserve(n);
+        dense.reserve(n);
+        sparse.reserve(n);
+    }
+
+    std::size_t size() const { return pos.size(); }
+
+    bool has(std::size_t id) const
+    {
+        return id < sparse.size() && sparse[id] != 0;
+    }
+
+    void insert(std::size_t id, double p, double v)
+    {
+        if (id >= sparse.size())
+            sparse.resize(id + 1, 0);
+        assert(sparse[id] == 0 && "entity already present");
+        std::size_t idx = pos.size();
+        pos.push_back(p);
+        vel.push_back(v);
+        dense.push_back(id);
+        sparse[id] = idx + 1;               // store index+1 (0 reserved for missing)
+    }
+
+    void remove(std::size_t id)
+    {
+        assert(id < sparse.size());
+        std::size_t idxp1 = sparse[id];
+        assert(idxp1 != 0 && "entity missing");
+        std::size_t idx = idxp1 - 1;
+        std::size_t last = pos.size() - 1;
+        if (idx != last)
+        {
+            pos[idx] = pos[last];
+            vel[idx] = vel[last];
+            std::size_t moved = dense[last];
+            dense[idx] = moved;
+            sparse[moved] = idx + 1;
+        }
+        pos.pop_back();
+        vel.pop_back();
+        dense.pop_back();
+        sparse[id] = 0;
+    }
+
+    // Branchless lookup: return pointer to component or default value.
+    double* lookup_position(std::size_t id)
+    {
+        std::size_t idxp1 = (id < sparse.size()) ? sparse[id] : 0;
+        return idxp1 ? &pos[idxp1 - 1] : &defaultPos;
+    }
+    const double* lookup_position(std::size_t id) const
+    {
+        std::size_t idxp1 = (id < sparse.size()) ? sparse[id] : 0;
+        return idxp1 ? &pos[idxp1 - 1] : &defaultPos;
+    }
+    double* lookup_velocity(std::size_t id)
+    {
+        std::size_t idxp1 = (id < sparse.size()) ? sparse[id] : 0;
+        return idxp1 ? &vel[idxp1 - 1] : &defaultVel;
+    }
+    const double* lookup_velocity(std::size_t id) const
+    {
+        std::size_t idxp1 = (id < sparse.size()) ? sparse[id] : 0;
+        return idxp1 ? &vel[idxp1 - 1] : &defaultVel;
     }
 };
+

--- a/tests/test_soa.cpp
+++ b/tests/test_soa.cpp
@@ -1,25 +1,53 @@
 #include <gtest/gtest.h>
 #include <simcore/car_soa.hpp>
 
-TEST(SoAData, ContiguousAndCorrect)
+// basic insertion/removal and mapping checks
+TEST(CarSoA, InsertRemove)
 {
-    constexpr std::size_t N = 1024;
-    CarSoA cars(N);
+    CarSoA cars;
+    cars.insert(2, 1.0, 2.0);
+    cars.insert(5, 3.0, 4.0);
 
-    /* write pattern */
+    EXPECT_EQ(cars.size(), 2u);
+    EXPECT_EQ(*cars.lookup_position(2), 1.0);
+    EXPECT_EQ(*cars.lookup_velocity(5), 4.0);
+
+    // missing component: should point to default without branching
+    EXPECT_EQ(cars.lookup_position(3), &cars.defaultPos);
+    EXPECT_EQ(*cars.lookup_velocity(3), 0.0);
+
+    cars.remove(2);
+    EXPECT_EQ(cars.size(), 1u);
+    EXPECT_EQ(cars.lookup_position(2), &cars.defaultPos);
+    ASSERT_EQ(cars.dense[0], 5u); // remaining entity id
+}
+
+// verify dense arrays stay contiguous
+TEST(CarSoA, ContiguousStorage)
+{
+    constexpr std::size_t N = 128;
+    CarSoA cars;
     for (std::size_t i = 0; i < N; ++i)
-        cars.set(i, double(i), double(i * 2));
+        cars.insert(i, double(i), double(i * 2));
 
-    /* verify */
     for (std::size_t i = 0; i < N; ++i) {
-        EXPECT_EQ(cars.position(i), double(i));
-        EXPECT_EQ(cars.velocity(i), double(i * 2));
+        EXPECT_EQ(*cars.lookup_position(i), double(i));
+        EXPECT_EQ(*cars.lookup_velocity(i), double(i * 2));
     }
 
-    /* contiguous check: difference of adjacent addresses = sizeof(double) */
-    const double* base = cars.pos.data();
     for (std::size_t i = 1; i < N; ++i)
         ASSERT_EQ(reinterpret_cast<const char*>(&cars.pos[i]) -
                   reinterpret_cast<const char*>(&cars.pos[i - 1]),
                   sizeof(double));
 }
+
+// ensure lookup can be used without branching for missing ids
+TEST(CarSoA, BranchlessLookup)
+{
+    CarSoA cars;
+    cars.insert(7, 3.0, 4.0); // ensure sparse size >= 8
+    double v = *cars.lookup_velocity(3); // entity 3 missing
+    EXPECT_EQ(v, 0.0);
+    EXPECT_EQ(cars.lookup_velocity(3), &cars.defaultVel);
+}
+


### PR DESCRIPTION
## Summary
- Rework `CarSoA` to maintain sparse and dense arrays mapping entity IDs to dense indices
- Add insert/remove APIs and branchless lookups that default to zero when components are missing
- Expand SoA tests to cover insertion/removal, contiguous storage, and branchless queries

## Testing
- `cmake ..` *(fails: external/googletest missing)*
- `git submodule update --init external/googletest` *(fails: CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b79c125d04832b9e847ede4702bcf9