### PR TITLE
Add worker pool backpressure guard

### DIFF
--- a/include/simcore/job_queue.hpp
+++ b/include/simcore/job_queue.hpp
@@ -1,11 +1,11 @@
 #pragma once
 #include <atomic>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <memory> // unique_ptr
 #include <new>
 #include <type_traits>
-#include <memory>   // unique_ptr
-#include <cassert>
 
 //
 // Bounded MPMC queue (Dmitry Vyukov algorithm).
@@ -13,111 +13,117 @@
 // - try_push / try_pop are lock-free
 // - size() is approximate
 //
-template <typename T>
-class BoundedMPMCQueue {
+template <typename T> class BoundedMPMCQueue {
 public:
-    explicit BoundedMPMCQueue(std::size_t capacityPow2)
-    {
-        const std::size_t cap = nextPow2(capacityPow2 ? capacityPow2 : 1);
-        capacity_ = cap;
-        mask_     = cap - 1;
+  explicit BoundedMPMCQueue(std::size_t capacityPow2) {
+    const std::size_t cap = nextPow2(capacityPow2 ? capacityPow2 : 1);
+    capacity_ = cap;
+    mask_ = cap - 1;
 
-        // allocate cells without std::vector to avoid move/copy constraints
-        buffer_.reset(new Cell[cap]);
+    // allocate cells without std::vector to avoid move/copy constraints
+    buffer_.reset(new Cell[cap]);
 
-        for (std::size_t i = 0; i < cap; ++i) {
-            buffer_[i].seq.store(i, std::memory_order_relaxed);
+    for (std::size_t i = 0; i < cap; ++i) {
+      buffer_[i].seq.store(i, std::memory_order_relaxed);
+    }
+    head_.store(0, std::memory_order_relaxed);
+    tail_.store(0, std::memory_order_relaxed);
+    sz_.store(0, std::memory_order_relaxed);
+  }
+
+  ~BoundedMPMCQueue() {
+    // Drain remaining items so their destructors run
+    T tmp;
+    while (try_pop(tmp)) {
+    }
+  }
+
+  // Non-blocking push; returns false if full
+  bool try_push(T &&v) {
+    Cell *cell;
+    std::size_t pos = tail_.load(std::memory_order_relaxed);
+    for (;;) {
+      cell = &buffer_[pos & mask_];
+      std::size_t seq = cell->seq.load(std::memory_order_acquire);
+      intptr_t dif = (intptr_t)seq - (intptr_t)pos;
+      if (dif == 0) {
+        if (tail_.compare_exchange_weak(pos, pos + 1, std::memory_order_acq_rel,
+                                        std::memory_order_relaxed)) {
+          break;
         }
-        head_.store(0, std::memory_order_relaxed);
-        tail_.store(0, std::memory_order_relaxed);
-        sz_.store(0,   std::memory_order_relaxed);
+      } else if (dif < 0) {
+        return false; // full
+      } else {
+        pos = tail_.load(std::memory_order_relaxed);
+      }
     }
+    ::new (&cell->storage) T(std::move(v));
+    cell->seq.store(pos + 1, std::memory_order_release);
+    // Track number of enqueued items; acq_rel so external observers see
+    // up-to-date counts
+    sz_.fetch_add(1, std::memory_order_acq_rel);
+    return true;
+  }
 
-    ~BoundedMPMCQueue() {
-        // Drain remaining items so their destructors run
-        T tmp;
-        while (try_pop(tmp)) {}
-    }
-
-    // Non-blocking push; returns false if full
-    bool try_push(T&& v) {
-        Cell* cell;
-        std::size_t pos = tail_.load(std::memory_order_relaxed);
-        for (;;) {
-            cell = &buffer_[pos & mask_];
-            std::size_t seq = cell->seq.load(std::memory_order_acquire);
-            intptr_t dif = (intptr_t)seq - (intptr_t)pos;
-            if (dif == 0) {
-                if (tail_.compare_exchange_weak(pos, pos+1,
-                        std::memory_order_acq_rel, std::memory_order_relaxed)) {
-                    break;
-                }
-            } else if (dif < 0) {
-                return false; // full
-            } else {
-                pos = tail_.load(std::memory_order_relaxed);
-            }
+  // Non-blocking pop; returns false if empty
+  bool try_pop(T &out) {
+    Cell *cell;
+    std::size_t pos = head_.load(std::memory_order_relaxed);
+    for (;;) {
+      cell = &buffer_[pos & mask_];
+      std::size_t seq = cell->seq.load(std::memory_order_acquire);
+      intptr_t dif = (intptr_t)seq - (intptr_t)(pos + 1);
+      if (dif == 0) {
+        if (head_.compare_exchange_weak(pos, pos + 1, std::memory_order_acq_rel,
+                                        std::memory_order_relaxed)) {
+          break;
         }
-        ::new (&cell->storage) T(std::move(v));
-        cell->seq.store(pos + 1, std::memory_order_release);
-        sz_.fetch_add(1, std::memory_order_relaxed);
-        return true;
+      } else if (dif < 0) {
+        return false; // empty
+      } else {
+        pos = head_.load(std::memory_order_relaxed);
+      }
     }
+    T *ptr = reinterpret_cast<T *>(&cell->storage);
+    out = std::move(*ptr);
+    ptr->~T();
+    cell->seq.store(pos + mask_ + 1, std::memory_order_release);
+    // Decrement outstanding item count
+    sz_.fetch_sub(1, std::memory_order_acq_rel);
+    return true;
+  }
 
-    // Non-blocking pop; returns false if empty
-    bool try_pop(T& out) {
-        Cell* cell;
-        std::size_t pos = head_.load(std::memory_order_relaxed);
-        for (;;) {
-            cell = &buffer_[pos & mask_];
-            std::size_t seq = cell->seq.load(std::memory_order_acquire);
-            intptr_t dif = (intptr_t)seq - (intptr_t)(pos + 1);
-            if (dif == 0) {
-                if (head_.compare_exchange_weak(pos, pos+1,
-                        std::memory_order_acq_rel, std::memory_order_relaxed)) {
-                    break;
-                }
-            } else if (dif < 0) {
-                return false; // empty
-            } else {
-                pos = head_.load(std::memory_order_relaxed);
-            }
-        }
-        T* ptr = reinterpret_cast<T*>(&cell->storage);
-        out = std::move(*ptr);
-        ptr->~T();
-        cell->seq.store(pos + mask_ + 1, std::memory_order_release);
-        sz_.fetch_sub(1, std::memory_order_relaxed);
-        return true;
-    }
-
-    std::size_t capacity() const { return capacity_; }
-    std::size_t size()     const { return sz_.load(std::memory_order_relaxed); }
-    bool        empty()    const { return size() == 0; }
+  std::size_t capacity() const { return capacity_; }
+  std::size_t size() const { return sz_.load(std::memory_order_acquire); }
+  bool empty() const { return sz_.load(std::memory_order_acquire) == 0; }
 
 private:
-    static std::size_t nextPow2(std::size_t x) {
-        --x;
-        x |= x >> 1;  x |= x >> 2;  x |= x >> 4;
-        x |= x >> 8;  x |= x >> 16; x |= x >> 32;
-        return x + 1;
-    }
+  static std::size_t nextPow2(std::size_t x) {
+    --x;
+    x |= x >> 1;
+    x |= x >> 2;
+    x |= x >> 4;
+    x |= x >> 8;
+    x |= x >> 16;
+    x |= x >> 32;
+    return x + 1;
+  }
 
-    struct Cell {
-        std::atomic<std::size_t> seq;
-        typename std::aligned_storage<sizeof(T), alignof(T)>::type storage;
+  struct Cell {
+    std::atomic<std::size_t> seq;
+    typename std::aligned_storage<sizeof(T), alignof(T)>::type storage;
 
-        Cell() noexcept : seq(0) {}
-        Cell(const Cell&)            = delete;
-        Cell& operator=(const Cell&) = delete;
-        Cell(Cell&&)                 = delete;
-        Cell& operator=(Cell&&)      = delete;
-    };
+    Cell() noexcept : seq(0) {}
+    Cell(const Cell &) = delete;
+    Cell &operator=(const Cell &) = delete;
+    Cell(Cell &&) = delete;
+    Cell &operator=(Cell &&) = delete;
+  };
 
-    std::unique_ptr<Cell[]>    buffer_{};
-    std::size_t                capacity_ = 0;
-    std::size_t                mask_     = 0;
-    std::atomic<std::size_t>   head_{0};
-    std::atomic<std::size_t>   tail_{0};
-    std::atomic<std::size_t>   sz_{0};
+  std::unique_ptr<Cell[]> buffer_{};
+  std::size_t capacity_ = 0;
+  std::size_t mask_ = 0;
+  std::atomic<std::size_t> head_{0};
+  std::atomic<std::size_t> tail_{0};
+  std::atomic<std::size_t> sz_{0};
 };

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -1,11 +1,11 @@
 #pragma once
+#include "job_queue.hpp"
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <functional>
 #include <thread>
 #include <vector>
-#include <chrono>
-#include "job_queue.hpp"
 
 // Simple persistent worker pool built on the lock-free queue.
 // Jobs are std::function<void()>.
@@ -18,83 +18,134 @@
 //
 class WorkerPool {
 public:
-    using Job = std::function<void()>;
+  using Job = std::function<void()>;
 
-    WorkerPool(std::size_t numThreads, std::size_t queueSizePow2 = 1024, bool verbose = false)
-    : queue_(queueSizePow2), verbose_(verbose)
-    {
-        stopping_.store(false, std::memory_order_relaxed);
-        active_.store(0, std::memory_order_relaxed);
-        threads_.reserve(numThreads);
-        for (std::size_t i = 0; i < numThreads; ++i) {
-            threads_.emplace_back([this] { this->workerLoop(); });
-        }
+  WorkerPool(std::size_t numThreads, std::size_t queueSizePow2 = 1024,
+             bool verbose = false, std::size_t maxOutstanding = 0)
+      : queue_(queueSizePow2), verbose_(verbose) {
+    stopping_.store(false, std::memory_order_relaxed);
+    active_.store(0, std::memory_order_relaxed);
+    outstanding_.store(0, std::memory_order_relaxed);
+    maxOutstanding_ = maxOutstanding ? maxOutstanding : queue_.capacity();
+    threads_.reserve(numThreads);
+    for (std::size_t i = 0; i < numThreads; ++i) {
+      threads_.emplace_back([this] { this->workerLoop(); });
     }
+  }
 
-    ~WorkerPool() { stop(); }
+  ~WorkerPool() { stop(); }
 
-    // Busy-wait enqueue (lock-free); returns after the job is on the queue.
-    void enqueue(Job j) {
-        while (!queue_.try_push(std::move(j))) {
-            // Backoff to reduce contention if the queue is temporarily full
-            std::this_thread::yield();
+  // Busy-wait enqueue (lock-free); returns after the job is on the queue.
+  void enqueue(Job j) {
+    // Reserve an outstanding slot, blocking until under the limit
+    if (maxOutstanding_ > 0) {
+      for (;;) {
+        std::size_t cur = outstanding_.load(std::memory_order_acquire);
+        if (cur >= maxOutstanding_) {
+          std::this_thread::yield();
+          continue;
         }
-    }
-
-    // Non-blocking variant; returns false if full.
-    bool try_enqueue(Job j) {
-        return queue_.try_push(std::move(j));
-    }
-
-    // Wait until queue is empty and all workers are idle.
-    void drain() {
-        using namespace std::chrono_literals;
-        for (;;) {
-            if (queue_.empty() && active_.load(std::memory_order_acquire) == 0) break;
-            std::this_thread::sleep_for(50us);
+        if (outstanding_.compare_exchange_weak(cur, cur + 1,
+                                               std::memory_order_acq_rel,
+                                               std::memory_order_relaxed)) {
+          break;
         }
+      }
+    } else {
+      outstanding_.fetch_add(1, std::memory_order_acq_rel);
     }
-
-    // Stop workers after draining; safe to call multiple times.
-    void stop() {
-        bool expected = false;
-        if (!stopping_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
-            // already stopping/stopped
-        }
-        // Give workers a chance to exit when idle; also drain any stragglers
-        drain();
-        for (auto &t : threads_) {
-            if (t.joinable()) t.join();
-        }
-        threads_.clear();
+    while (!queue_.try_push(std::move(j))) {
+      // Backoff to reduce contention if the queue is temporarily full
+      std::this_thread::yield();
     }
+  }
 
-    std::size_t approx_queue_size() const { return queue_.size(); }
-    std::size_t thread_count()       const { return threads_.size(); }
+  // Non-blocking variant; returns false if full.
+  bool try_enqueue(Job j) {
+    if (maxOutstanding_ > 0) {
+      std::size_t cur = outstanding_.load(std::memory_order_acquire);
+      while (cur < maxOutstanding_) {
+        if (outstanding_.compare_exchange_weak(cur, cur + 1,
+                                               std::memory_order_acq_rel,
+                                               std::memory_order_relaxed)) {
+          if (queue_.try_push(std::move(j))) {
+            return true;
+          }
+          // queue full; undo reservation
+          outstanding_.fetch_sub(1, std::memory_order_acq_rel);
+          return false;
+        }
+      }
+      return false;
+    } else {
+      if (!queue_.try_push(std::move(j)))
+        return false;
+      outstanding_.fetch_add(1, std::memory_order_acq_rel);
+      return true;
+    }
+  }
+
+  // Wait until queue is empty and all workers are idle.
+  void drain() {
+    using namespace std::chrono_literals;
+    for (;;) {
+      if (queue_.empty() && active_.load(std::memory_order_acquire) == 0)
+        break;
+      std::this_thread::sleep_for(50us);
+    }
+  }
+
+  // Stop workers after draining; safe to call multiple times.
+  void stop() {
+    bool expected = false;
+    if (!stopping_.compare_exchange_strong(expected, true,
+                                           std::memory_order_acq_rel)) {
+      // already stopping/stopped
+    }
+    // Give workers a chance to exit when idle; also drain any stragglers
+    drain();
+    for (auto &t : threads_) {
+      if (t.joinable())
+        t.join();
+    }
+    threads_.clear();
+  }
+
+  std::size_t approx_queue_size() const { return queue_.size(); }
+  std::size_t thread_count() const { return threads_.size(); }
+  std::size_t outstanding() const {
+    return outstanding_.load(std::memory_order_acquire);
+  }
 
 private:
-    void workerLoop() {
-        for (;;) {
-            Job job;
-            if (queue_.try_pop(job)) {
-                active_.fetch_add(1, std::memory_order_acq_rel);
-                // Guard against empty std::function (shouldn't happen, but be safe)
-                if (job) job(); else if (verbose_) {/*no-op*/ }
-                active_.fetch_sub(1, std::memory_order_acq_rel);
-                continue;
-            }
-            if (stopping_.load(std::memory_order_acquire)) {
-                // If asked to stop and nothing to do, exit.
-                if (queue_.empty() && active_.load(std::memory_order_acquire) == 0)
-                    break;
-            }
-            std::this_thread::yield();
+  void workerLoop() {
+    for (;;) {
+      Job job;
+      if (queue_.try_pop(job)) {
+        active_.fetch_add(1, std::memory_order_acq_rel);
+        // Guard against empty std::function (shouldn't happen, but be safe)
+        if (job)
+          job();
+        else if (verbose_) { /*no-op*/
         }
+        active_.fetch_sub(1, std::memory_order_acq_rel);
+        outstanding_.fetch_sub(1, std::memory_order_acq_rel);
+        continue;
+      }
+      if (stopping_.load(std::memory_order_acquire)) {
+        // If asked to stop and nothing to do, exit.
+        if (queue_.empty() && active_.load(std::memory_order_acquire) == 0)
+          break;
+      }
+      std::this_thread::yield();
     }
+  }
 
-    BoundedMPMCQueue<Job>  queue_;
-    std::vector<std::thread> threads_;
-    std::atomic<bool>        stopping_{false};
-    std::atomic<std::size_t> active_{0};
-    bool                     verbose_{false};
+  BoundedMPMCQueue<Job> queue_;
+  std::vector<std::thread> threads_;
+  std::atomic<bool> stopping_{false};
+  std::atomic<std::size_t> active_{0};
+  std::atomic<std::size_t> outstanding_{0};
+  std::size_t maxOutstanding_ = 0;
+  bool verbose_{false};
 };

--- a/tests/test_jobqueue.cpp
+++ b/tests/test_jobqueue.cpp
@@ -1,23 +1,58 @@
-#include <gtest/gtest.h>
 #include <atomic>
+#include <chrono>
+#include <gtest/gtest.h>
 #include <simcore/worker_pool.hpp>
+#include <thread>
 
 TEST(JobQueue, ExecutesEveryJob) {
-    // 4 workers, 2048-capacity queue (power-of-two)
-    WorkerPool pool(4, 2048);
+  // 4 workers, 2048-capacity queue (power-of-two)
+  WorkerPool pool(4, 2048);
 
-    std::atomic<int> counter{0};
-    constexpr int N = 20000;
+  std::atomic<int> counter{0};
+  constexpr int N = 20000;
 
-    for (int i = 0; i < N; ++i) {
-        pool.enqueue([&counter]{
-            counter.fetch_add(1, std::memory_order_relaxed);
-        });
+  for (int i = 0; i < N; ++i) {
+    pool.enqueue(
+        [&counter] { counter.fetch_add(1, std::memory_order_relaxed); });
+  }
+
+  // Wait until all jobs finished, then stop pool (join threads)
+  pool.drain();
+  pool.stop();
+
+  EXPECT_EQ(counter.load(), N);
+}
+
+TEST(JobQueue, BackpressureCapsOutstanding) {
+  // Small threshold to exercise guard
+  WorkerPool pool(/*threads*/ 3, /*queue size*/ 64, /*verbose*/ false,
+                  /*maxOutstanding*/ 4);
+
+  std::atomic<std::size_t> peak{0};
+
+  // Job that enqueues many sub-jobs mid-frame
+  pool.enqueue([&] {
+    for (int i = 0; i < 20; ++i) {
+      pool.enqueue([&] {
+        // Update peak outstanding seen
+        auto cur = pool.outstanding();
+        std::size_t prev = peak.load(std::memory_order_relaxed);
+        while (cur > prev && !peak.compare_exchange_weak(
+                                 prev, cur, std::memory_order_relaxed)) {
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      });
+      // Track after each enqueue
+      auto cur = pool.outstanding();
+      std::size_t prev = peak.load(std::memory_order_relaxed);
+      while (cur > prev && !peak.compare_exchange_weak(
+                               prev, cur, std::memory_order_relaxed)) {
+      }
     }
+  });
 
-    // Wait until all jobs finished, then stop pool (join threads)
-    pool.drain();
-    pool.stop();
+  pool.drain();
+  pool.stop();
 
-    EXPECT_EQ(counter.load(), N);
+  EXPECT_LE(peak.load(), 4u);
 }


### PR DESCRIPTION
## Summary
- track outstanding worker pool jobs and enforce a configurable limit
- strengthen job queue atomics to keep accurate counts
- test backpressure by enqueuing mid-frame tasks

## Testing
- `cmake ..` *(fails: The source directory `/workspace/cpp-rt-car/external/googletest` does not contain a CMakeLists.txt file)*
- `git submodule update --init --recursive` *(fails: unable to access 'https://github.com/google/googletest.git/' - CONNECT tunnel failed, response 403)*
- `apt-get update` *(fails: 403 Forbidden for Ubuntu package sources)*

------
https://chatgpt.com/codex/tasks/task_e_68b79c1ae6b8832b84b3db2da6dc65a3