### PR TITLE
Add high-resolution clock and rate governor

### DIFF
--- a/include/simcore/highres_clock.hpp
+++ b/include/simcore/highres_clock.hpp
@@ -1,0 +1,98 @@
+#pragma once
+#include <atomic>
+#include <cstdint>
+#include <chrono>
+#include <thread>
+#include <functional>
+
+// High resolution monotonic clock with optional TSC backing.
+// Calibrates TSC frequency at init and falls back to std::chrono on drift.
+class HighResClock {
+public:
+    using tsc_reader_t = uint64_t (*)();
+
+    // Initialise the clock. If no reader is supplied a platform default is used.
+    static void init(tsc_reader_t reader = nullptr) {
+        tsc_reader_ = reader ? reader : &default_tsc_reader;
+        ref_start_ns_ = to_ns(std::chrono::steady_clock::now());
+        last_ns_.store(ref_start_ns_);
+
+        // Attempt TSC calibration.
+        if (tsc_reader_) {
+            uint64_t t0 = tsc_reader_();
+            auto ref0 = std::chrono::steady_clock::now();
+            // Sleep briefly to establish frequency.
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            uint64_t t1 = tsc_reader_();
+            auto ref1 = std::chrono::steady_clock::now();
+            auto secs = std::chrono::duration<double>(ref1 - ref0).count();
+            if (secs > 0.0 && t1 > t0) {
+                tsc_freq_ = static_cast<double>(t1 - t0) / secs; // cycles/sec
+                tsc_start_ = t1;
+                ref_start_ns_ = to_ns(ref1);
+                last_ns_.store(ref_start_ns_);
+                tsc_ok_.store(true);
+            }
+        }
+    }
+
+    // Nanoseconds since an arbitrary epoch (monotonic).
+    static uint64_t now_ns() {
+        auto ref_now = std::chrono::steady_clock::now();
+        uint64_t ns_ref = to_ns(ref_now);
+
+        if (tsc_ok_.load(std::memory_order_relaxed)) {
+            uint64_t t = tsc_reader_();
+            uint64_t ns = ref_start_ns_ +
+                static_cast<uint64_t>((static_cast<double>(t - tsc_start_) * 1e9) / tsc_freq_);
+            // Drift check every ~4096 calls.
+            if ((++calls_ & 0xfff) == 0) {
+                int64_t diff = static_cast<int64_t>(ns) - static_cast<int64_t>(ns_ref);
+                if (diff > 1000000 || diff < -1000000) { // 1ms threshold
+                    tsc_ok_.store(false);
+                    return ensure_monotonic(ns_ref);
+                }
+            }
+            return ensure_monotonic(ns);
+        }
+        return ensure_monotonic(ns_ref);
+    }
+
+    static bool using_tsc() { return tsc_ok_.load(); }
+    static void set_tsc_reader(tsc_reader_t r) { tsc_reader_ = r; }
+
+private:
+    static uint64_t to_ns(std::chrono::steady_clock::time_point tp) {
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(tp.time_since_epoch()).count();
+    }
+    static uint64_t ensure_monotonic(uint64_t ns) {
+        uint64_t last = last_ns_.load();
+        while (ns <= last && !last_ns_.compare_exchange_weak(last, last + 1)) {
+        }
+        if (ns <= last) ns = last + 1;
+        last_ns_.store(ns);
+        return ns;
+    }
+
+    // Default TSC reader (x86); returns 0 on unsupported platforms.
+    static uint64_t default_tsc_reader() {
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
+        return __rdtsc();
+#elif defined(__i386__) || defined(__x86_64__)
+        unsigned int lo, hi;
+        __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+        return (static_cast<uint64_t>(hi) << 32) | lo;
+#else
+        return 0;
+#endif
+    }
+
+    static inline std::atomic<bool> tsc_ok_{false};
+    static inline tsc_reader_t tsc_reader_ = nullptr;
+    static inline double tsc_freq_ = 0.0;
+    static inline uint64_t tsc_start_ = 0;
+    static inline uint64_t ref_start_ns_ = 0;
+    static inline std::atomic<uint64_t> last_ns_{0};
+    static inline std::atomic<uint64_t> calls_{0};
+};
+

--- a/include/simcore/rate_governor.hpp
+++ b/include/simcore/rate_governor.hpp
@@ -1,0 +1,36 @@
+#pragma once
+#include <algorithm>
+
+// Simple PI based rate governor. Controls a scale factor so that
+// compute_ms stays within frame_ms. Includes hysteresis and clamping.
+class RateGovernor {
+public:
+    RateGovernor(double frame_ms, double kp=0.1, double ki=0.01,
+                 double floor=0.5, double ceiling=1.0, double hysteresis=0.05)
+        : frame_ms_(frame_ms), kp_(kp), ki_(ki),
+          floor_(floor), ceiling_(ceiling), hyst_(hysteresis) {}
+
+    // Update with the last frame's compute time. Returns new scale factor.
+    double update(double compute_ms) {
+        double ratio = compute_ms / (frame_ms_ * scale_);
+        double error = ratio - 1.0;
+        if (std::abs(error) < hyst_) return scale_;
+        integral_ += error;
+        double delta = kp_ * error + ki_ * integral_;
+        scale_ = std::clamp(scale_ - delta, floor_, ceiling_);
+        return scale_;
+    }
+
+    double scale() const { return scale_; }
+
+private:
+    double frame_ms_;
+    double kp_;
+    double ki_;
+    double floor_;
+    double ceiling_;
+    double hyst_;
+    double integral_ = 0.0;
+    double scale_ = 1.0;
+};
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,8 @@ set(TEST_SOURCES
     test_small_array_balance.cpp
     test_phase_telemetry.cpp
     test_aligned_allocator.cpp
+    test_highres_clock.cpp
+    test_rate_governor.cpp
 )
 
 add_executable(simcore_tests ${TEST_SOURCES})

--- a/tests/test_highres_clock.cpp
+++ b/tests/test_highres_clock.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+#include <thread>
+#include "simcore/highres_clock.hpp"
+
+TEST(HighResClock, MonotonicMockedTSC) {
+    HighResClock::init([](){ static uint64_t c=0; return c+=100; });
+    uint64_t a = HighResClock::now_ns();
+    uint64_t b = HighResClock::now_ns();
+    EXPECT_LT(a, b);
+    uint64_t c = HighResClock::now_ns();
+    EXPECT_LT(b, c);
+}
+
+TEST(HighResClock, DriftDisablesTSC) {
+    static uint64_t c = 0;
+    static bool slow = false;
+    auto reader = [](){ if (slow) c += 10; else c += 1000; return c; };
+    HighResClock::init(reader);
+    ASSERT_TRUE(HighResClock::using_tsc());
+    (void)HighResClock::now_ns();
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    (void)HighResClock::now_ns();
+    slow = true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    for (int i=0;i<5000;i++) HighResClock::now_ns();
+    EXPECT_FALSE(HighResClock::using_tsc());
+}

--- a/tests/test_rate_governor.cpp
+++ b/tests/test_rate_governor.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+#include "simcore/rate_governor.hpp"
+
+TEST(RateGovernor, AdversarialBurstRecovers) {
+    RateGovernor rg(16.0); // 16ms frame
+    // warmup stable frames
+    for(int i=0;i<5;i++) {
+        double s = rg.update(10.0);
+        EXPECT_NEAR(s, 1.0, 0.1);
+    }
+    // adversarial burst
+    double s = rg.update(40.0);
+    EXPECT_LT(s, 1.0);
+    // subsequent frames should recover
+    for(int i=0;i<40;i++) {
+        s = rg.update(10.0);
+    }
+    EXPECT_GT(s, 0.95);
+}
+


### PR DESCRIPTION
## Summary
- Provide high resolution clock abstraction with TSC calibration and drift fallback
- Introduce PI-based rate governor to regulate frame workload
- Add unit tests for clock and governor

## Testing
- `cmake -S . -B build` *(fails: HTTPS 403 when fetching googletest)*
- `cmake -S . -B build -Dgoogletest_SOURCE_DIR=external/googletest` *(fails: HTTPS 403 when fetching googletest)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b9aa586980832ba17a0c3d0e61931d