### PR TITLE
Add robust FP helpers with Kahan sum

### DIFF
--- a/include/simcore/robust_fp.hpp
+++ b/include/simcore/robust_fp.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <iterator>
+
+namespace robust {
+
+// Return 1/sqrt(x) but clamp the denominator to avoid Inf/NaN for tiny values.
+inline double safe_rsqrt(double x, double eps = 1e-12) {
+    if (x <= eps) x = eps;
+    return 1.0 / std::sqrt(x);
+}
+
+// Classic Kahan summation for improved accuracy.
+template <class It>
+double kahan_sum(It begin, It end) {
+    double sum = 0.0;
+    double c = 0.0; // compensation
+    for (It it = begin; it != end; ++it) {
+        double y = *it - c;
+        double t = sum + y;
+        c = (t - sum) - y;
+        sum = t;
+    }
+    return sum;
+}
+
+// Compute the distance in ULPs between two doubles.
+inline std::uint64_t ulp_distance(double a, double b) {
+    std::uint64_t ia, ib;
+    std::memcpy(&ia, &a, sizeof(a));
+    std::memcpy(&ib, &b, sizeof(b));
+    // Make lexicographically ordered as two's complement
+    if (static_cast<std::int64_t>(ia) < 0) ia = 0x8000000000000000ULL - ia;
+    if (static_cast<std::int64_t>(ib) < 0) ib = 0x8000000000000000ULL - ib;
+    return (ia > ib) ? ia - ib : ib - ia;
+}
+
+} // namespace robust
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES
     test_phase_graph.cpp
     test_chunk_autotune.cpp
     test_deterministic_reduction.cpp
+    test_robust_fp.cpp
     test_budget_monitor.cpp
     test_simd.cpp
     test_rt_pool.cpp

--- a/tests/test_robust_fp.cpp
+++ b/tests/test_robust_fp.cpp
@@ -1,0 +1,33 @@
+#include <gtest/gtest.h>
+#include <simcore/robust_fp.hpp>
+#include <vector>
+#include <limits>
+
+TEST(RobustFP, SafeRsqrtFinite) {
+    double r = robust::safe_rsqrt(0.0);
+    ASSERT_TRUE(std::isfinite(r));
+    double expected = 1.0 / std::sqrt(1e-12);
+    EXPECT_DOUBLE_EQ(r, expected);
+}
+
+TEST(RobustFP, KahanImprovesSumULP) {
+    // Construct a sequence that is numerically challenging
+    std::vector<double> v;
+    for (int i = 0; i < 100000; ++i) {
+        v.push_back(1.0e-8);
+        v.push_back(1.0e-16);
+        v.push_back(-1.0e-8);
+    }
+    // naive sum
+    double naive = 0.0;
+    for (double x : v) naive += x;
+    // kahan sum
+    double kahan = robust::kahan_sum(v.begin(), v.end());
+    // reference using long double
+    long double ref = 0.0L;
+    for (double x : v) ref += static_cast<long double>(x);
+    double refd = static_cast<double>(ref);
+    auto naiveULP = robust::ulp_distance(naive, refd);
+    auto kahanULP = robust::ulp_distance(kahan, refd);
+    EXPECT_LT(kahanULP, naiveULP);
+}


### PR DESCRIPTION
## Summary
- add robust floating-point utilities: safe reciprocal sqrt, Kahan summation, ULP distance
- test Kahan summation accuracy and safe_rsqrt behavior

## Testing
- `cmake -S . -B build` *(fails: Each download failed; HTTP 403 when fetching googletest)*
- `apt-get update` *(fails: 403 Forbidden when accessing Ubuntu repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68b9acac450c832bb419f2eb4e4efc53