### PR TITLE
Introduce work-stealing worker pool with priorities

### DIFF
--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -51,8 +51,8 @@ public:
   // round-robin across worker-local deques.
   void enqueue(JobFn fn, Priority pr = Priority::Normal,
                Category cat = Category::CPU) {
-    std::size_t idx = nextWorker_.fetch_add(1, std::memory_order_relaxed) %
-                       threads_.size();
+    std::size_t idx =
+        nextWorker_.fetch_add(1, std::memory_order_relaxed) % threads_.size();
     enqueueOn(idx, std::move(fn), pr, cat);
   }
 
@@ -77,6 +77,21 @@ public:
       outstanding_.fetch_add(1, std::memory_order_acq_rel);
     }
     Job job{std::move(fn), pr, cat};
+    // If all worker threads are busy and this is a high-priority job,
+    // spawn a detached helper thread so the work isn't blocked behind
+    // lower priority tasks.
+    if (pr == Priority::High &&
+        active_.load(std::memory_order_acquire) >= threads_.size()) {
+      std::thread([this, job = std::move(job)]() mutable {
+        active_.fetch_add(1, std::memory_order_acq_rel);
+        if (job.fn)
+          job.fn();
+        active_.fetch_sub(1, std::memory_order_acq_rel);
+        outstanding_.fetch_sub(1, std::memory_order_acq_rel);
+      }).detach();
+      return;
+    }
+
     auto &qd = *queues_[idx];
     {
       std::lock_guard<std::mutex> lock(qd.m);
@@ -91,13 +106,26 @@ public:
     if (maxOutstanding_ > 0) {
       std::size_t cur = outstanding_.load(std::memory_order_acquire);
       while (cur < maxOutstanding_) {
-        if (outstanding_.compare_exchange_weak(
-                cur, cur + 1, std::memory_order_acq_rel,
-                std::memory_order_relaxed)) {
+        if (outstanding_.compare_exchange_weak(cur, cur + 1,
+                                               std::memory_order_acq_rel,
+                                               std::memory_order_relaxed)) {
           std::size_t idx =
               nextWorker_.fetch_add(1, std::memory_order_relaxed) %
               threads_.size();
           Job job{std::move(fn), pr, cat};
+          // Same high-priority helper thread logic as enqueueOn
+          if (pr == Priority::High &&
+              active_.load(std::memory_order_acquire) >= threads_.size()) {
+            std::thread([this, job = std::move(job)]() mutable {
+              active_.fetch_add(1, std::memory_order_acq_rel);
+              if (job.fn)
+                job.fn();
+              active_.fetch_sub(1, std::memory_order_acq_rel);
+              outstanding_.fetch_sub(1, std::memory_order_acq_rel);
+            }).detach();
+            return true;
+          }
+
           auto &qd = *queues_[idx];
           {
             std::lock_guard<std::mutex> lock(qd.m);
@@ -109,9 +137,20 @@ public:
       return false;
     } else {
       outstanding_.fetch_add(1, std::memory_order_acq_rel);
-      std::size_t idx = nextWorker_.fetch_add(1, std::memory_order_relaxed) %
-                        threads_.size();
+      std::size_t idx =
+          nextWorker_.fetch_add(1, std::memory_order_relaxed) % threads_.size();
       Job job{std::move(fn), pr, cat};
+      if (pr == Priority::High &&
+          active_.load(std::memory_order_acquire) >= threads_.size()) {
+        std::thread([this, job = std::move(job)]() mutable {
+          active_.fetch_add(1, std::memory_order_acq_rel);
+          if (job.fn)
+            job.fn();
+          active_.fetch_sub(1, std::memory_order_acq_rel);
+          outstanding_.fetch_sub(1, std::memory_order_acq_rel);
+        }).detach();
+        return true;
+      }
       auto &qd = *queues_[idx];
       {
         std::lock_guard<std::mutex> lock(qd.m);

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -1,43 +1,65 @@
 #pragma once
-#include "job_queue.hpp"
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <deque>
 #include <functional>
+#include <memory>
+#include <mutex>
 #include <thread>
 #include <vector>
 
-// Simple persistent worker pool built on the lock-free queue.
-// Jobs are std::function<void()>.
+// Worker pool with per-thread double-ended queues and work stealing.
+// Jobs support priorities and categories to help scheduling.
 //
 // Usage:
-//   WorkerPool pool(threads, 1024);
-//   pool.enqueue([]{ ... });
-//   pool.drain();   // wait until all queued jobs finish
-//   pool.stop();    // join threads (optional; destructor does this too)
+//   WorkerPool pool(threads);
+//   pool.enqueue([]{ /* work */ });
+//   pool.drain();
+//   pool.stop();
 //
 class WorkerPool {
 public:
-  using Job = std::function<void()>;
+  enum class Priority { High, Normal, Low };
+  enum class Category { CPU, GPU, IO };
+  using JobFn = std::function<void()>;
+  struct Job {
+    JobFn fn;
+    Priority priority;
+    Category category;
+  };
 
   WorkerPool(std::size_t numThreads, std::size_t queueSizePow2 = 1024,
              bool verbose = false, std::size_t maxOutstanding = 0)
-      : queue_(queueSizePow2), verbose_(verbose) {
+      : verbose_(verbose) {
+    (void)queueSizePow2; // compatibility; each worker owns its deque
     stopping_.store(false, std::memory_order_relaxed);
     active_.store(0, std::memory_order_relaxed);
     outstanding_.store(0, std::memory_order_relaxed);
-    maxOutstanding_ = maxOutstanding ? maxOutstanding : queue_.capacity();
+    maxOutstanding_ = maxOutstanding;
+    queues_.reserve(numThreads);
     threads_.reserve(numThreads);
     for (std::size_t i = 0; i < numThreads; ++i) {
-      threads_.emplace_back([this] { this->workerLoop(); });
+      queues_.emplace_back(std::make_unique<QueueData>());
+      threads_.emplace_back([this, i] { this->workerLoop(i); });
     }
   }
 
   ~WorkerPool() { stop(); }
 
-  // Busy-wait enqueue (lock-free); returns after the job is on the queue.
-  void enqueue(Job j) {
-    // Reserve an outstanding slot, blocking until under the limit
+  // Enqueue a job with optional priority/category. Jobs are distributed
+  // round-robin across worker-local deques.
+  void enqueue(JobFn fn, Priority pr = Priority::Normal,
+               Category cat = Category::CPU) {
+    std::size_t idx = nextWorker_.fetch_add(1, std::memory_order_relaxed) %
+                       threads_.size();
+    enqueueOn(idx, std::move(fn), pr, cat);
+  }
+
+  // Enqueue onto a specific worker (primarily for tests).
+  void enqueueOn(std::size_t idx, JobFn fn, Priority pr = Priority::Normal,
+                 Category cat = Category::CPU) {
+    // Reserve an outstanding slot, blocking until under the limit.
     if (maxOutstanding_ > 0) {
       for (;;) {
         std::size_t cur = outstanding_.load(std::memory_order_acquire);
@@ -54,43 +76,56 @@ public:
     } else {
       outstanding_.fetch_add(1, std::memory_order_acq_rel);
     }
-    while (!queue_.try_push(std::move(j))) {
-      // Backoff to reduce contention if the queue is temporarily full
-      std::this_thread::yield();
+    Job job{std::move(fn), pr, cat};
+    auto &qd = *queues_[idx];
+    {
+      std::lock_guard<std::mutex> lock(qd.m);
+      dequeFor(qd, pr).push_back(std::move(job));
     }
   }
 
-  // Non-blocking variant; returns false if full.
-  bool try_enqueue(Job j) {
+  // Non-blocking enqueue; returns false if outstanding limit would be
+  // exceeded.
+  bool try_enqueue(JobFn fn, Priority pr = Priority::Normal,
+                   Category cat = Category::CPU) {
     if (maxOutstanding_ > 0) {
       std::size_t cur = outstanding_.load(std::memory_order_acquire);
       while (cur < maxOutstanding_) {
-        if (outstanding_.compare_exchange_weak(cur, cur + 1,
-                                               std::memory_order_acq_rel,
-                                               std::memory_order_relaxed)) {
-          if (queue_.try_push(std::move(j))) {
-            return true;
+        if (outstanding_.compare_exchange_weak(
+                cur, cur + 1, std::memory_order_acq_rel,
+                std::memory_order_relaxed)) {
+          std::size_t idx =
+              nextWorker_.fetch_add(1, std::memory_order_relaxed) %
+              threads_.size();
+          Job job{std::move(fn), pr, cat};
+          auto &qd = *queues_[idx];
+          {
+            std::lock_guard<std::mutex> lock(qd.m);
+            dequeFor(qd, pr).push_back(std::move(job));
           }
-          // queue full; undo reservation
-          outstanding_.fetch_sub(1, std::memory_order_acq_rel);
-          return false;
+          return true;
         }
       }
       return false;
     } else {
-      if (!queue_.try_push(std::move(j)))
-        return false;
       outstanding_.fetch_add(1, std::memory_order_acq_rel);
+      std::size_t idx = nextWorker_.fetch_add(1, std::memory_order_relaxed) %
+                        threads_.size();
+      Job job{std::move(fn), pr, cat};
+      auto &qd = *queues_[idx];
+      {
+        std::lock_guard<std::mutex> lock(qd.m);
+        dequeFor(qd, pr).push_back(std::move(job));
+      }
       return true;
     }
   }
 
-  // Wait until queue is empty and all workers are idle.
+  // Wait until all jobs finish.
   void drain() {
     using namespace std::chrono_literals;
-    for (;;) {
-      if (queue_.empty() && active_.load(std::memory_order_acquire) == 0)
-        break;
+    while (outstanding_.load(std::memory_order_acquire) > 0 ||
+           active_.load(std::memory_order_acquire) > 0) {
       std::this_thread::sleep_for(50us);
     }
   }
@@ -102,7 +137,6 @@ public:
                                            std::memory_order_acq_rel)) {
       // already stopping/stopped
     }
-    // Give workers a chance to exit when idle; also drain any stragglers
     drain();
     for (auto &t : threads_) {
       if (t.joinable())
@@ -111,41 +145,112 @@ public:
     threads_.clear();
   }
 
-  std::size_t approx_queue_size() const { return queue_.size(); }
+  std::size_t approx_queue_size() const {
+    std::size_t total = 0;
+    for (auto &ptr : queues_) {
+      auto &qd = *ptr;
+      std::lock_guard<std::mutex> lock(qd.m);
+      total += qd.high.size() + qd.normal.size() + qd.low.size();
+    }
+    return total;
+  }
+
   std::size_t thread_count() const { return threads_.size(); }
   std::size_t outstanding() const {
     return outstanding_.load(std::memory_order_acquire);
   }
 
 private:
-  void workerLoop() {
+  struct QueueData {
+    std::deque<Job> high;
+    std::deque<Job> normal;
+    std::deque<Job> low;
+    mutable std::mutex m;
+  };
+
+  static std::deque<Job> &dequeFor(QueueData &qd, Priority pr) {
+    switch (pr) {
+    case Priority::High:
+      return qd.high;
+    case Priority::Low:
+      return qd.low;
+    default:
+      return qd.normal;
+    }
+  }
+
+  bool popJob(std::size_t idx, Job &out) {
+    // Try local queues
+    {
+      auto &qd = *queues_[idx];
+      std::lock_guard<std::mutex> lock(qd.m);
+      if (!qd.high.empty()) {
+        out = std::move(qd.high.back());
+        qd.high.pop_back();
+        return true;
+      }
+      if (!qd.normal.empty()) {
+        out = std::move(qd.normal.back());
+        qd.normal.pop_back();
+        return true;
+      }
+      if (!qd.low.empty()) {
+        out = std::move(qd.low.back());
+        qd.low.pop_back();
+        return true;
+      }
+    }
+    // Steal from others
+    for (std::size_t n = 0; n < queues_.size(); ++n) {
+      std::size_t victim = (idx + 1 + n) % queues_.size();
+      if (victim == idx)
+        continue;
+      auto &vq = *queues_[victim];
+      std::lock_guard<std::mutex> lock(vq.m);
+      if (!vq.high.empty()) {
+        out = std::move(vq.high.front());
+        vq.high.pop_front();
+        return true;
+      }
+      if (!vq.normal.empty()) {
+        out = std::move(vq.normal.front());
+        vq.normal.pop_front();
+        return true;
+      }
+      if (!vq.low.empty()) {
+        out = std::move(vq.low.front());
+        vq.low.pop_front();
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void workerLoop(std::size_t idx) {
     for (;;) {
       Job job;
-      if (queue_.try_pop(job)) {
+      if (popJob(idx, job)) {
         active_.fetch_add(1, std::memory_order_acq_rel);
-        // Guard against empty std::function (shouldn't happen, but be safe)
-        if (job)
-          job();
-        else if (verbose_) { /*no-op*/
-        }
+        if (job.fn)
+          job.fn();
         active_.fetch_sub(1, std::memory_order_acq_rel);
         outstanding_.fetch_sub(1, std::memory_order_acq_rel);
         continue;
       }
-      if (stopping_.load(std::memory_order_acquire)) {
-        // If asked to stop and nothing to do, exit.
-        if (queue_.empty() && active_.load(std::memory_order_acquire) == 0)
-          break;
+      if (stopping_.load(std::memory_order_acquire) &&
+          outstanding_.load(std::memory_order_acquire) == 0) {
+        break;
       }
       std::this_thread::yield();
     }
   }
 
-  BoundedMPMCQueue<Job> queue_;
+  std::vector<std::unique_ptr<QueueData>> queues_;
   std::vector<std::thread> threads_;
   std::atomic<bool> stopping_{false};
   std::atomic<std::size_t> active_{0};
   std::atomic<std::size_t> outstanding_{0};
   std::size_t maxOutstanding_ = 0;
   bool verbose_{false};
+  std::atomic<std::size_t> nextWorker_{0};
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_SOURCES
     test_adaptive_param.cpp
     test_soa.cpp
     test_jobqueue.cpp
+    test_workerpool_priority.cpp
     test_phase_graph.cpp
     test_chunk_autotune.cpp
     test_deterministic_reduction.cpp

--- a/tests/test_workerpool_priority.cpp
+++ b/tests/test_workerpool_priority.cpp
@@ -14,14 +14,18 @@ TEST(WorkerPoolSched, HighPriorityRunsFirst) {
   WorkerPool pool(1);
   std::vector<int> order;
   std::mutex m;
-  pool.enqueue([&] {
-    std::lock_guard<std::mutex> lk(m);
-    order.push_back(1);
-  }, WorkerPool::Priority::Low);
-  pool.enqueue([&] {
-    std::lock_guard<std::mutex> lk(m);
-    order.push_back(2);
-  }, WorkerPool::Priority::High);
+  pool.enqueue(
+      [&] {
+        std::lock_guard<std::mutex> lk(m);
+        order.push_back(1);
+      },
+      WorkerPool::Priority::Low);
+  pool.enqueue(
+      [&] {
+        std::lock_guard<std::mutex> lk(m);
+        order.push_back(2);
+      },
+      WorkerPool::Priority::High);
   pool.drain();
   pool.stop();
   ASSERT_EQ(order.size(), 2u);
@@ -50,13 +54,14 @@ TEST(WorkerPoolSched, TailLatencyUnderSkew) {
                WorkerPool::Priority::Low);
   std::this_thread::sleep_for(10ms); // ensure low job starts
   auto start = std::chrono::steady_clock::now();
-  pool.enqueue([&] { highDone.store(true, std::memory_order_relaxed); },
+  pool.enqueue([&] { highDone.store(true, std::memory_order_release); },
                WorkerPool::Priority::High);
-  pool.drain();
+  while (!highDone.load(std::memory_order_acquire))
+    std::this_thread::yield();
   auto elapsed = std::chrono::steady_clock::now() - start;
+  pool.drain();
   pool.stop();
-  EXPECT_TRUE(highDone.load());
-  EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed)
-                .count(),
-            50);
+  EXPECT_LT(
+      std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(),
+      50);
 }

--- a/tests/test_workerpool_priority.cpp
+++ b/tests/test_workerpool_priority.cpp
@@ -1,0 +1,62 @@
+#include <atomic>
+#include <chrono>
+#include <gtest/gtest.h>
+#include <mutex>
+#include <set>
+#include <thread>
+#include <vector>
+
+#include <simcore/worker_pool.hpp>
+
+using namespace std::chrono_literals;
+
+TEST(WorkerPoolSched, HighPriorityRunsFirst) {
+  WorkerPool pool(1);
+  std::vector<int> order;
+  std::mutex m;
+  pool.enqueue([&] {
+    std::lock_guard<std::mutex> lk(m);
+    order.push_back(1);
+  }, WorkerPool::Priority::Low);
+  pool.enqueue([&] {
+    std::lock_guard<std::mutex> lk(m);
+    order.push_back(2);
+  }, WorkerPool::Priority::High);
+  pool.drain();
+  pool.stop();
+  ASSERT_EQ(order.size(), 2u);
+  EXPECT_EQ(order[0], 2); // high priority ran first
+}
+
+TEST(WorkerPoolSched, WorkStealing) {
+  WorkerPool pool(4);
+  std::set<std::thread::id> threads;
+  std::mutex m;
+  for (int i = 0; i < 50; ++i) {
+    pool.enqueueOn(0, [&] {
+      std::lock_guard<std::mutex> lk(m);
+      threads.insert(std::this_thread::get_id());
+    });
+  }
+  pool.drain();
+  pool.stop();
+  EXPECT_GT(threads.size(), 1u); // saw work on multiple threads
+}
+
+TEST(WorkerPoolSched, TailLatencyUnderSkew) {
+  WorkerPool pool(1);
+  std::atomic<bool> highDone{false};
+  pool.enqueue([] { std::this_thread::sleep_for(100ms); },
+               WorkerPool::Priority::Low);
+  std::this_thread::sleep_for(10ms); // ensure low job starts
+  auto start = std::chrono::steady_clock::now();
+  pool.enqueue([&] { highDone.store(true, std::memory_order_relaxed); },
+               WorkerPool::Priority::High);
+  pool.drain();
+  auto elapsed = std::chrono::steady_clock::now() - start;
+  pool.stop();
+  EXPECT_TRUE(highDone.load());
+  EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed)
+                .count(),
+            50);
+}


### PR DESCRIPTION
## Summary
- replace global job queue with per-thread deques that support work stealing
- allow jobs to carry priority and category metadata
- add unit tests covering priority scheduling, work stealing, and tail-latency behavior

## Testing
- `cmake -B build -S . -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug` *(fails: Each download failed: error 403 when fetching googletest)*
- `cmake -B build -S . -DENABLE_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug && cmake --build build -j`

