### PR TITLE
Add physics core scaffolding with integrators and collision interfaces

### DIFF
--- a/include/simcore/physics/collision_pipeline.hpp
+++ b/include/simcore/physics/collision_pipeline.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+namespace simphys {
+
+class BroadPhase {
+public:
+    virtual ~BroadPhase() = default;
+    virtual void computePairs() = 0;
+};
+
+class SweepAndPrune : public BroadPhase {
+public:
+    void computePairs() override {}
+};
+
+class BVHBroadPhase : public BroadPhase {
+public:
+    void computePairs() override {}
+};
+
+class NarrowPhase {
+public:
+    virtual ~NarrowPhase() = default;
+    virtual void generateContacts() = 0;
+};
+
+class CollisionPipeline {
+public:
+    BroadPhase *broad{nullptr};
+    NarrowPhase *narrow{nullptr};
+    bool ccd{false};
+
+    void step() {
+        if (broad)
+            broad->computePairs();
+        if (narrow)
+            narrow->generateContacts();
+    }
+};
+
+} // namespace simphys
+

--- a/include/simcore/physics/constraint_solver.hpp
+++ b/include/simcore/physics/constraint_solver.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include <vector>
+
+namespace simphys {
+
+struct Constraint {
+    double lambda{0.0};
+};
+
+struct SolverSettings {
+    double erp{0.2};
+    double baumgarte{0.0};
+    int iterations{10};
+};
+
+class ConstraintSolver {
+public:
+    virtual ~ConstraintSolver() = default;
+    virtual void warmStart(std::vector<Constraint> &/*c*/) {}
+    virtual void solve(std::vector<Constraint> &c, const SolverSettings &s) = 0;
+};
+
+class PGSSolver : public ConstraintSolver {
+public:
+    void solve(std::vector<Constraint> &c, const SolverSettings &s) override {
+        for (int i = 0; i < s.iterations; ++i)
+            for (auto &con : c) {
+                (void)con;
+            }
+    }
+};
+
+class XPBDSolver : public ConstraintSolver {
+public:
+    void solve(std::vector<Constraint> &c, const SolverSettings &s) override {
+        for (int i = 0; i < s.iterations; ++i)
+            for (auto &con : c) {
+                (void)con;
+            }
+    }
+};
+
+struct IslandState {
+    bool sleeping{false};
+};
+
+class IslandManager {
+public:
+    void update(IslandState &island, double /*dt*/) { (void)island; }
+};
+
+} // namespace simphys
+

--- a/include/simcore/physics/integrators.hpp
+++ b/include/simcore/physics/integrators.hpp
@@ -1,0 +1,80 @@
+#pragma once
+#include <algorithm>
+#include <cmath>
+
+namespace simphys {
+
+// Generic state integration helpers. State is expected to expose
+// 'pos' and 'vel' members supporting basic arithmetic with doubles.
+
+template <class State, class AccelFn>
+void symplecticEuler(State &s, double dt, AccelFn &&accel) {
+    s.vel += accel(s) * dt;
+    s.pos += s.vel * dt;
+}
+
+template <class State, class AccelFn>
+void semiImplicitRK2(State &s, double dt, AccelFn &&accel) {
+    auto a1 = accel(s);
+    auto vHalf = s.vel + a1 * (dt * 0.5);
+    State mid{s};
+    mid.pos += vHalf * (dt * 0.5);
+    mid.vel = vHalf;
+    auto a2 = accel(mid);
+    s.vel += a2 * dt;
+    s.pos += vHalf * dt;
+}
+
+template <class State, class AccelFn>
+void rk4(State &s, double dt, AccelFn &&accel) {
+    auto a1 = accel(s);
+    auto v2 = s.vel + a1 * (dt * 0.5);
+    State s2{s};
+    s2.pos += s.vel * (dt * 0.5);
+    s2.vel = v2;
+    auto a2 = accel(s2);
+
+    auto v3 = s.vel + a2 * (dt * 0.5);
+    State s3{s};
+    s3.pos += v2 * (dt * 0.5);
+    s3.vel = v3;
+    auto a3 = accel(s3);
+
+    auto v4 = s.vel + a3 * dt;
+    State s4{s};
+    s4.pos += v3 * dt;
+    s4.vel = v4;
+    auto a4 = accel(s4);
+
+    s.pos += (s.vel + 2.0 * v2 + 2.0 * v3 + v4) * (dt / 6.0);
+    s.vel += (a1 + 2.0 * a2 + 2.0 * a3 + a4) * (dt / 6.0);
+}
+
+struct CFLAdvisor {
+    double maxVelocity{1.0};
+    double maxAcceleration{1.0};
+    double maxDistance{1.0};
+
+    double operator()(double dt) const {
+        double vStep = maxDistance / std::max(maxVelocity, 1e-9);
+        double aStep = std::sqrt(maxDistance / std::max(maxAcceleration, 1e-9));
+        return std::min({dt, vStep, aStep});
+    }
+};
+
+struct IslandConfig {
+    double cfl{1.0};
+    bool sleeping{false};
+};
+
+class SubstepScheduler {
+public:
+    static int schedule(const IslandConfig &island, double dt) {
+        if (island.sleeping)
+            return 0;
+        return std::max(1, static_cast<int>(std::ceil(dt / island.cfl)));
+    }
+};
+
+} // namespace simphys
+

--- a/include/simcore/physics_core.hpp
+++ b/include/simcore/physics_core.hpp
@@ -1,0 +1,4 @@
+#pragma once
+#include <simcore/physics/integrators.hpp>
+#include <simcore/physics/constraint_solver.hpp>
+#include <simcore/physics/collision_pipeline.hpp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_SOURCES
     test_highres_clock.cpp
     test_rate_governor.cpp
     test_hazard_ptr.cpp
+    test_physics_integrators.cpp
 )
 
 add_executable(simcore_tests ${TEST_SOURCES})

--- a/tests/test_physics_integrators.cpp
+++ b/tests/test_physics_integrators.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+#include <simcore/physics/integrators.hpp>
+#include <vector>
+#include <cmath>
+
+using namespace simphys;
+
+struct OscState {
+    double pos;
+    double vel;
+};
+
+static double accel(const OscState &s) { return -s.pos; }
+
+static double energy(const OscState &s) {
+    return 0.5 * s.pos * s.pos + 0.5 * s.vel * s.vel;
+}
+
+TEST(PhysicsIntegrators, EnergyInvariant) {
+    OscState a{1.0, 0.0}, b{1.0, 0.0}, c{1.0, 0.0};
+    double e0 = energy(a);
+    for (int i = 0; i < 1000; ++i) symplecticEuler(a, 0.01, accel);
+    for (int i = 0; i < 1000; ++i) semiImplicitRK2(b, 0.01, accel);
+    for (int i = 0; i < 1000; ++i) rk4(c, 0.01, accel);
+    EXPECT_NEAR(energy(a), e0, e0 * 0.1);
+    EXPECT_NEAR(energy(b), e0, e0 * 0.1);
+    EXPECT_NEAR(energy(c), e0, e0 * 0.1);
+}
+
+TEST(PhysicsIntegrators, StabilityDtSweep) {
+    const std::vector<double> dts = {0.005, 0.01, 0.02, 0.04};
+    for (double dt : dts) {
+        int steps = static_cast<int>(1.0 / dt);
+        OscState a{1.0, 0.0}, b{1.0, 0.0}, c{1.0, 0.0};
+        for (int i = 0; i < steps; ++i) symplecticEuler(a, dt, accel);
+        for (int i = 0; i < steps; ++i) semiImplicitRK2(b, dt, accel);
+        for (int i = 0; i < steps; ++i) rk4(c, dt, accel);
+        double e0 = 0.5; // initial energy
+        EXPECT_LT(energy(a), e0 * 4.0);
+        EXPECT_LT(energy(b), e0 * 4.0);
+        EXPECT_LT(energy(c), e0 * 4.0);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add integrator suite (symplectic Euler, semi-implicit RK2, RK4) with CFL advisor and per-island substep scheduler
- introduce constraint solver shell with PGS and XPBD stubs plus island management
- create collision pipeline interfaces including broadphase and narrowphase hooks
- add basic tests for energy invariants and dt stability across integrators

## Testing
- `cmake -S . -B build` *(fails: HTTP 403 fetching googletest)*

------
https://chatgpt.com/codex/tasks/task_e_68b9cb5f5db0832ba1f254fb8ca87559