### PR TITLE
Add basic platform HAL with threading and fence utilities

### DIFF
--- a/include/simcore/hal.hpp
+++ b/include/simcore/hal.hpp
@@ -1,0 +1,95 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <memory>
+#include <thread>
+#include <cstdlib>
+
+namespace simcore::hal {
+
+// Memory allocation flags (pinned/hugepage currently no-op)
+enum class MemFlags : uint32_t {
+    none     = 0,
+    pinned   = 1u << 0,
+    hugepage = 1u << 1,
+};
+
+inline void* alloc(std::size_t bytes, MemFlags /*flags*/ = MemFlags::none) {
+    constexpr std::size_t align = 64;
+    std::size_t size = (bytes + align - 1) / align * align;
+    void* ptr = nullptr;
+#if defined(_MSC_VER)
+    ptr = _aligned_malloc(size, align);
+    if (!ptr) throw std::bad_alloc();
+#else
+    if (posix_memalign(&ptr, align, size) != 0) throw std::bad_alloc();
+#endif
+    return ptr;
+}
+
+inline void free(void* ptr) {
+#if defined(_MSC_VER)
+    _aligned_free(ptr);
+#else
+    std::free(ptr);
+#endif
+}
+
+// Thread helpers
+using Thread = std::thread;
+
+template <typename Fn, typename... Args>
+Thread create_thread(Fn&& fn, Args&&... args) {
+    return Thread(std::forward<Fn>(fn), std::forward<Args>(args)...);
+}
+
+inline void join(Thread& t) {
+    if (t.joinable()) t.join();
+}
+
+// Fence primitive
+class Fence {
+public:
+    Fence()
+        : promise_(std::make_shared<std::promise<void>>()),
+          future_(promise_->get_future().share()) {}
+
+    void signal() { promise_->set_value(); }
+
+    bool wait_for(std::chrono::milliseconds timeout) {
+        return future_.wait_for(timeout) == std::future_status::ready;
+    }
+
+    bool is_signaled() const {
+        return future_.wait_for(std::chrono::milliseconds(0)) ==
+               std::future_status::ready;
+    }
+
+private:
+    std::shared_ptr<std::promise<void>> promise_;
+    std::shared_future<void> future_;
+};
+
+inline Fence fence_create() { return Fence{}; }
+
+inline void fence_signal(Fence& f) { f.signal(); }
+
+inline bool fence_wait(Fence& f, std::chrono::milliseconds timeout) {
+    return f.wait_for(timeout);
+}
+
+// Timer utilities
+using Clock = std::chrono::steady_clock;
+using TimePoint = Clock::time_point;
+using Duration = Clock::duration;
+
+inline TimePoint now() { return Clock::now(); }
+
+inline Duration elapsed(TimePoint start, TimePoint end) { return end - start; }
+
+} // namespace simcore::hal
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ set(TEST_SOURCES
     test_rate_governor.cpp
     test_hazard_ptr.cpp
     test_physics_integrators.cpp
+    test_hal.cpp
 )
 
 add_executable(simcore_tests ${TEST_SOURCES})

--- a/tests/test_hal.cpp
+++ b/tests/test_hal.cpp
@@ -1,0 +1,34 @@
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include "simcore/hal.hpp"
+
+using namespace std::chrono_literals;
+
+TEST(HAL, ThreadAndFence) {
+    std::atomic<int> value{0};
+    simcore::hal::Fence fence = simcore::hal::fence_create();
+    simcore::hal::Thread t = simcore::hal::create_thread([&]() {
+        value.store(1, std::memory_order_release);
+        simcore::hal::fence_signal(fence);
+    });
+    EXPECT_TRUE(simcore::hal::fence_wait(fence, 1000ms));
+    simcore::hal::join(t);
+    EXPECT_EQ(value.load(std::memory_order_acquire), 1);
+}
+
+TEST(HAL, AllocFree) {
+    void* p = simcore::hal::alloc(128);
+    ASSERT_NE(p, nullptr);
+    simcore::hal::free(p);
+}
+
+TEST(HAL, TimerElapsed) {
+    auto start = simcore::hal::now();
+    std::this_thread::sleep_for(10ms);
+    auto end = simcore::hal::now();
+    auto d = simcore::hal::elapsed(start, end);
+    EXPECT_GE(std::chrono::duration_cast<std::chrono::milliseconds>(d).count(), 10);
+}
+


### PR DESCRIPTION
## Summary
- Introduce `simcore::hal` with aligned memory allocation, thread helpers, fences, and timers
- Exercise HAL API with new unit tests

## Testing
- `cmake -B build -S . -DENABLE_TESTS=ON` *(failed: 403 when downloading googletest)*
- `apt-get update` *(failed: 403 accessing Ubuntu mirrors)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d1b4dbe8832bb3e3de0dcb445d1b