### PR TITLE
ci: add hardened toolchain matrix and fuzz harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,13 @@ on:
   pull_request:
 
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-latest
+    container: ubuntu:22.04
     strategy:
+      fail-fast: false
       matrix:
+        compiler: [gcc, clang]
         build_type: [Debug, RelWithDebInfo]
         include:
           - build_type: Debug
@@ -21,9 +24,18 @@ jobs:
         with:
           submodules: recursive
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake
+        run: apt-get update && apt-get install -y build-essential cmake clang
+      - name: Set up compiler
+        run: |
+          if [ "${{matrix.compiler}}" = "clang" ]; then
+            echo "CC=clang" >> $GITHUB_ENV
+            echo "CXX=clang++" >> $GITHUB_ENV
+          else
+            echo "CC=gcc" >> $GITHUB_ENV
+            echo "CXX=g++" >> $GITHUB_ENV
+          fi
       - name: Configure
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DENABLE_TESTS=ON -DSIM_SANITIZERS='${{matrix.sanitizers}}'
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DENABLE_TESTS=ON -DENABLE_RAPIDCHECK=ON -DSIM_SANITIZERS='${{matrix.sanitizers}}' -DSIM_WERROR=ON
       - name: Build
         run: cmake --build build --config ${{matrix.build_type}} -- -j2
       - name: Test
@@ -32,3 +44,45 @@ jobs:
           UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
           GTEST_DEATH_TEST_STYLE: threadsafe
         run: ctest --test-dir build -C ${{matrix.build_type}} --output-on-failure
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: spdx-json
+          output-file: sbom-${{matrix.compiler}}-${{matrix.build_type}}.spdx.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sbom-${{matrix.compiler}}-${{matrix.build_type}}
+          path: sbom-${{matrix.compiler}}-${{matrix.build_type}}.spdx.json
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        if: github.event_name == 'pull_request'
+
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        build_type: [Debug, RelWithDebInfo]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Configure
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DENABLE_TESTS=ON -DSIM_WERROR=ON
+      - name: Build
+        run: cmake --build build --config ${{matrix.build_type}} -- /m
+      - name: Test
+        run: ctest --test-dir build -C ${{matrix.build_type}} --output-on-failure
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: .
+          format: spdx-json
+          output-file: sbom-windows-${{matrix.build_type}}.spdx.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sbom-windows-${{matrix.build_type}}
+          path: sbom-windows-${{matrix.build_type}}.spdx.json
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        if: github.event_name == 'pull_request'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,17 @@ project(car_sim_core LANGUAGES CXX)
 option(ENABLE_LOG "Enable logging" ON)
 option(ENABLE_PROF "Enable profiler" ON)
 option(ENABLE_TESTS "Build tests" ON)
+option(ENABLE_RAPIDCHECK "Enable RapidCheck property tests" OFF)
 
 # Sanitizer toggles (semicolons to enable multiple: address;thread;leak;memory;hwaddress;safe-stack;cfi)
 set(SIM_SANITIZERS "" CACHE STRING "Sanitizers to enable for all targets")
+
+# Hardened build switches
+option(SIM_WERROR "Treat warnings as errors" ON)
+option(SIM_ENABLE_LTO "Enable link time optimization" OFF)
+option(SIM_LTO_THIN "Use ThinLTO when LTO is enabled" OFF)
+set(SIM_PGO "" CACHE STRING "Profile guided optimisation mode: gen or use")
+set(SIM_PGO_PROFILE "" CACHE FILEPATH "Profile data path for PGO")
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -26,9 +34,42 @@ if (SIM_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
   endif()
 endif()
 
+# LTO
+if (SIM_ENABLE_LTO)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+    if (SIM_LTO_THIN)
+      add_compile_options(-flto=thin)
+      add_link_options(-flto=thin)
+    else()
+      add_compile_options(-flto)
+      add_link_options(-flto)
+    endif()
+  elseif (MSVC)
+    add_compile_options(/GL)
+    add_link_options(/LTCG)
+  endif()
+endif()
+
+# PGO
+if (SIM_PGO STREQUAL "gen")
+  add_compile_options(-fprofile-generate=${SIM_PGO_PROFILE})
+  add_link_options(-fprofile-generate=${SIM_PGO_PROFILE})
+elseif(SIM_PGO STREQUAL "use")
+  add_compile_options(-fprofile-use=${SIM_PGO_PROFILE} -fprofile-correction)
+  add_link_options(-fprofile-use=${SIM_PGO_PROFILE} -fprofile-correction)
+endif()
+
 # Recommended warnings (clang/gcc)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
     add_compile_options(-Wall -Wextra -Wpedantic -Wconversion -Wshadow -Wnon-virtual-dtor)
+endif()
+
+if (SIM_WERROR)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+    add_compile_options(-Werror)
+  elseif (MSVC)
+    add_compile_options(/WX)
+  endif()
 endif()
 
 # --- GoogleTest integration ---
@@ -36,15 +77,29 @@ endif()
 # expecting a checked out submodule. This keeps the repository light and
 # avoids build failures when the submodule is missing.
 if (ENABLE_TESTS)
-    include(FetchContent)
-    FetchContent_Declare(
-        googletest
-        URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
-    )
-    # For Windows: Prevent overriding the parent project's compiler/linker
-    # settings on MSVC.
-    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
+    if (EXISTS "${CMAKE_SOURCE_DIR}/external/googletest/CMakeLists.txt")
+        add_subdirectory(external/googletest)
+    else()
+        include(FetchContent)
+        FetchContent_Declare(
+            googletest
+            URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+        )
+        # For Windows: Prevent overriding the parent project's compiler/linker
+        # settings on MSVC.
+        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+        FetchContent_MakeAvailable(googletest)
+    endif()
+
+    if (ENABLE_RAPIDCHECK)
+        include(FetchContent)
+        FetchContent_Declare(
+            rapidcheck
+            GIT_REPOSITORY https://github.com/emil-e/rapidcheck.git
+            GIT_TAG master
+        )
+        FetchContent_MakeAvailable(rapidcheck)
+    endif()
 endif()
 
 # Header-only core library

--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -579,7 +579,7 @@ private:
 
   int decidePreSteps(double slopeMsPerFrame) const {
     // warmup
-    if (costCount_ < std::max(settings_.predictiveWarmup, 2))
+    if (costCount_ < static_cast<std::size_t>(std::max(settings_.predictiveWarmup, 2)))
       return 0;
 
     // If trend isn't strong, do nothing

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,13 +17,6 @@ static std::size_t parseSize(const char* s, std::size_t def)
     unsigned long long v = std::strtoull(s, &e, 10);
     return (e && *e == 0) ? static_cast<std::size_t>(v) : def;
 }
-static double parseDouble(const char* s, double def)
-{
-    if (!s) return def;
-    char* e = nullptr;
-    double v = std::strtod(s, &e);
-    return (e && *e == 0) ? v : def;
-}
 
 int main(int argc, char** argv)
 {
@@ -64,9 +57,9 @@ int main(int argc, char** argv)
 
     /* -------------- subsystems ------------------ */
     sim.addSerialSubsystem(input, [&](int64_t f, SimCore::Seconds dt){
-        double t = f * dt.count();
+        double t = static_cast<double>(f) * dt.count();
         for (std::size_t i = 0; i < N; ++i)
-            thr[i] = 0.5 + 0.05 * std::sin(t + i * 0.0005);
+            thr[i] = 0.5 + 0.05 * std::sin(t + static_cast<double>(i) * 0.0005);
     });
 
     sim.addParallelRangeTask(physics, [&](std::size_t b, std::size_t e,
@@ -89,7 +82,7 @@ int main(int argc, char** argv)
         if (f % 1000 == 0) {
             double sum = 0.0;
             for (double v : cars.vel) sum += v;
-            double avg = sum / cars.size();
+            double avg = sum / static_cast<double>(cars.size());
             LOG_INFO(&logger, "[REDUCE] frame={} avgVel={:.4f}", f, avg);
         }
     });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,8 +28,15 @@ set(TEST_SOURCES
     test_hal.cpp
 )
 
+if (ENABLE_RAPIDCHECK)
+    list(APPEND TEST_SOURCES test_jobqueue_property.cpp)
+endif()
+
 add_executable(simcore_tests ${TEST_SOURCES})
 target_link_libraries(simcore_tests PRIVATE simcore gtest gtest_main gmock)
+if (ENABLE_RAPIDCHECK)
+    target_link_libraries(simcore_tests PRIVATE rapidcheck rapidcheck_gtest)
+endif()
 target_include_directories(simcore_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/tests
@@ -42,6 +49,13 @@ if (SIM_ENABLE_AVX2 AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU" AND CMAKE_SYST
   add_compile_options(-mavx2 -mfma)
 endif()
 
+option(SIM_BUILD_FUZZERS "Build libFuzzer harnesses" OFF)
+if (SIM_BUILD_FUZZERS AND CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_executable(jobqueue_fuzz jobqueue_fuzz.cpp)
+    target_link_libraries(jobqueue_fuzz PRIVATE simcore)
+    target_compile_options(jobqueue_fuzz PRIVATE -fsanitize=fuzzer,address,undefined)
+    target_link_options(jobqueue_fuzz PRIVATE -fsanitize=fuzzer,address,undefined)
+endif()
 
 # --- affinity test -------------------------------------------------
 if (UNIX AND NOT APPLE)   # linux

--- a/tests/jobqueue_fuzz.cpp
+++ b/tests/jobqueue_fuzz.cpp
@@ -1,0 +1,15 @@
+#include <cstddef>
+#include <cstdint>
+#include "simcore/job_queue.hpp"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    BoundedMPMCQueue<uint8_t> q(size + 1);
+    for (size_t i = 0; i < size; ++i) {
+        q.try_push(data[i]);
+    }
+    uint8_t out = 0;
+    while (q.try_pop(out)) {
+        // consume
+    }
+    return 0;
+}

--- a/tests/test_jobqueue_property.cpp
+++ b/tests/test_jobqueue_property.cpp
@@ -1,0 +1,17 @@
+#include <rapidcheck/gtest.h>
+#include "simcore/job_queue.hpp"
+#include <vector>
+
+RC_GTEST_PROP(JobQueueProperty, PushPopPreservesOrder, (const std::vector<int>& data)) {
+    BoundedMPMCQueue<int> q(data.size() + 1);
+    for (int v : data) {
+        RC_ASSERT(q.try_push(v));
+    }
+    for (int v : data) {
+        int out = 0;
+        RC_ASSERT(q.try_pop(out));
+        RC_ASSERT(out == v);
+    }
+    int dummy = 0;
+    RC_ASSERT(!q.try_pop(dummy));
+}


### PR DESCRIPTION
## Summary
- support Werror, LTO, and PGO toggles in CMake
- add optional RapidCheck property test and libFuzzer harness for job queue
- expand CI to run GCC/Clang/MSVC, enable sanitizers, and publish SBOM artifacts

## Testing
- `cmake -B build -S . -DENABLE_TESTS=ON -DSIM_WERROR=ON` *(fails: HTTP 403 fetching googletest)*
- `cmake -B build -S . -DENABLE_TESTS=OFF -DSIM_WERROR=ON`
- `cmake --build build -- -j2`


------
https://chatgpt.com/codex/tasks/task_e_68b9d861c808832b8e879fc107d63bcd