### PR TITLE
Add async logging sink, fault injector, and watchdog utilities

### DIFF
--- a/include/simcore/fault_injector.hpp
+++ b/include/simcore/fault_injector.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <atomic>
+#include <chrono>
+#include <random>
+#include <thread>
+#include <cstdlib>
+
+namespace fault {
+inline std::atomic<double> delayProb{0.0};
+inline std::atomic<int> maxDelayMs{0};
+inline std::atomic<double> allocFailProb{0.0};
+inline thread_local std::mt19937 rng{std::random_device{}()};
+
+inline void set_delay_probability(double p){ delayProb.store(p); }
+inline void set_max_delay_ms(int ms){ maxDelayMs.store(ms); }
+inline void maybe_delay(){
+    std::uniform_real_distribution<double> dist(0.0,1.0);
+    if (dist(rng) < delayProb.load()){
+        int ms = std::uniform_int_distribution<int>(0,maxDelayMs.load())(rng);
+        std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+    }
+}
+inline void set_alloc_failure_probability(double p){ allocFailProb.store(p); }
+inline void* maybe_fail_alloc(std::size_t sz){
+    std::uniform_real_distribution<double> dist(0.0,1.0);
+    if (dist(rng) < allocFailProb.load()) return nullptr;
+    return std::malloc(sz);
+}
+} // namespace fault

--- a/include/simcore/logger.hpp
+++ b/include/simcore/logger.hpp
@@ -10,6 +10,19 @@
 #include <fstream>
 #include <sstream>
 #include <atomic>
+#include <deque>
+#include <condition_variable>
+#include <utility>
+#ifdef _WIN32
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+#include <io.h>
+#include <fcntl.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 #ifndef LOG_DEFAULT_LEVEL
 #define LOG_DEFAULT_LEVEL 2   // Info
@@ -53,6 +66,100 @@ public:
     private:
         std::ofstream f_;
         std::mutex m_;
+    };
+
+    class AsyncRingFileSink : public Sink {
+    public:
+        explicit AsyncRingFileSink(const std::string& path,
+                                   std::size_t cap = 1024,
+                                   std::chrono::milliseconds syncEvery = std::chrono::milliseconds(100))
+            : fd_(-1), cap_(cap), syncEvery_(syncEvery) {
+#ifdef _WIN32
+            fd_ = _open(path.c_str(), _O_CREAT | _O_APPEND | _O_WRONLY, _S_IREAD | _S_IWRITE);
+#else
+            fd_ = ::open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0644);
+#endif
+            if (fd_ >= 0) {
+                worker_ = std::thread([this]{ run(); });
+            }
+        }
+        ~AsyncRingFileSink() override {
+            {
+                std::lock_guard<std::mutex> lk(m_);
+                stop_ = true;
+            }
+            cv_.notify_all();
+            if (worker_.joinable()) worker_.join();
+            flush();
+            if (fd_ >= 0) {
+#ifdef _WIN32
+                _close(fd_);
+#else
+                ::close(fd_);
+#endif
+            }
+        }
+
+        void write(const Record& r) override {
+            if (fd_ < 0) return;
+            std::lock_guard<std::mutex> lk(m_);
+            if (queue_.size() >= cap_) queue_.pop_front();
+            queue_.push_back(r.msg);
+            cv_.notify_one();
+        }
+
+    private:
+        void flush() {
+            if (fd_ >= 0) {
+#ifdef _WIN32
+                _commit(fd_);
+#else
+                ::fsync(fd_);
+#endif
+            }
+        }
+
+        void run() {
+            std::unique_lock<std::mutex> lk(m_);
+            lastSync_ = std::chrono::steady_clock::now();
+            while (!stop_ || !queue_.empty()) {
+                if (queue_.empty()) {
+                    cv_.wait(lk, [this]{ return stop_ || !queue_.empty(); });
+                    if (queue_.empty()) continue;
+                }
+                auto msg = std::move(queue_.front());
+                queue_.pop_front();
+                lk.unlock();
+#ifdef _WIN32
+                int wr = _write(fd_, msg.data(), static_cast<unsigned int>(msg.size()));
+                (void)wr;
+                int wr2 = _write(fd_, "\n", 1);
+                (void)wr2;
+#else
+                ssize_t wr = ::write(fd_, msg.data(), msg.size());
+                (void)wr;
+                ssize_t wr2 = ::write(fd_, "\n", 1);
+                (void)wr2;
+#endif
+                auto now = std::chrono::steady_clock::now();
+                if (now - lastSync_ >= syncEvery_) {
+                    flush();
+                    lastSync_ = now;
+                }
+                lk.lock();
+            }
+            flush();
+        }
+
+        int fd_;
+        std::deque<std::string> queue_;
+        std::size_t cap_;
+        std::chrono::milliseconds syncEvery_;
+        std::chrono::steady_clock::time_point lastSync_{};
+        std::mutex m_;
+        std::condition_variable cv_;
+        bool stop_ = false;
+        std::thread worker_;
     };
 
     class RingBufferSink : public Sink {

--- a/include/simcore/minidump.hpp
+++ b/include/simcore/minidump.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <string>
+#include <fstream>
+#include <vector>
+#if defined(__unix__) || defined(__APPLE__)
+#include <execinfo.h>
+#include <cstdlib>
+#endif
+
+inline void write_minidump(const std::string& path)
+{
+    std::ofstream out(path);
+    if (!out) return;
+#if defined(__unix__) || defined(__APPLE__)
+    constexpr int MAX = 64;
+    void* addrs[MAX];
+    int n = ::backtrace(addrs, MAX);
+    char** syms = ::backtrace_symbols(addrs, n);
+    for (int i=0;i<n;++i) {
+        out << syms[i] << '\n';
+    }
+    std::free(syms);
+#else
+    out << "minidump unsupported\n";
+#endif
+}

--- a/include/simcore/watchdog.hpp
+++ b/include/simcore/watchdog.hpp
@@ -1,0 +1,51 @@
+#pragma once
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+
+class Watchdog {
+public:
+    using Callback = std::function<void()>;
+    Watchdog(std::chrono::milliseconds timeout, Callback cb)
+        : timeout_(timeout), cb_(std::move(cb)), stop_(false)
+    {
+        last_ = std::chrono::steady_clock::now();
+        worker_ = std::thread([this]{ run(); });
+    }
+    ~Watchdog()
+    {
+        stop_ = true;
+        cv_.notify_all();
+        if (worker_.joinable()) worker_.join();
+    }
+    void touch()
+    {
+        std::lock_guard<std::mutex> lk(m_);
+        last_ = std::chrono::steady_clock::now();
+        cv_.notify_all();
+    }
+private:
+    void run()
+    {
+        std::unique_lock<std::mutex> lk(m_);
+        while (!stop_) {
+            if (cv_.wait_until(lk, last_ + timeout_, [this]{ return stop_.load(); })) break;
+            if (std::chrono::steady_clock::now() - last_ >= timeout_) {
+                lk.unlock();
+                cb_();
+                lk.lock();
+                last_ = std::chrono::steady_clock::now();
+            }
+        }
+    }
+    std::chrono::milliseconds timeout_;
+    Callback cb_;
+    std::atomic<bool> stop_;
+    std::chrono::steady_clock::time_point last_;
+    std::thread worker_;
+    std::mutex m_;
+    std::condition_variable cv_;
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     test_simcore_basic.cpp
     test_simcore_determinism.cpp
     test_logging.cpp
+    test_async_logger.cpp
     test_profiler.cpp
     test_adaptive_param.cpp
     test_soa.cpp
@@ -12,6 +13,7 @@ set(TEST_SOURCES
     test_deterministic_reduction.cpp
     test_robust_fp.cpp
     test_budget_monitor.cpp
+    test_fault_injection.cpp
     test_simd.cpp
     test_rt_pool.cpp
     test_rt_arena.cpp
@@ -26,6 +28,7 @@ set(TEST_SOURCES
     test_hazard_ptr.cpp
     test_physics_integrators.cpp
     test_hal.cpp
+    test_watchdog.cpp
 )
 
 if (ENABLE_RAPIDCHECK AND TARGET rapidcheck_gtest)

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+#include <simcore/logger.hpp>
+#include <fstream>
+#include <filesystem>
+#include <thread>
+
+TEST(Logger, AsyncRingFileSinkFlushes)
+{
+    namespace fs = std::filesystem;
+    auto path = fs::temp_directory_path() / "async_log_test.log";
+    {
+        Logger log;
+        auto sink = std::make_shared<Logger::AsyncRingFileSink>(path.string(), 16, std::chrono::milliseconds(10));
+        log.addSink(sink);
+        for(int i=0;i<10;++i){
+            log.info("msg{}", i);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    std::ifstream in(path);
+    std::string line;
+    int count = 0;
+    while(std::getline(in,line)) ++count;
+    EXPECT_EQ(count,10);
+    fs::remove(path);
+}

--- a/tests/test_fault_injection.cpp
+++ b/tests/test_fault_injection.cpp
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include <simcore/SimCore.hpp>
+#include <simcore/fault_injector.hpp>
+
+TEST(FaultInjection, RandomDelaysStillRun)
+{
+    SimCore::Settings s;
+    s.hz = 200.0; // 5ms
+    s.maxFrames = 100;
+    s.threads = 1;
+    s.adaptive = true;
+    s.maxCatchUp = 4;
+    SimCore sim(s);
+    auto phase = sim.addPhase("delay");
+    sim.setPhaseElementCount(phase,1);
+    fault::set_delay_probability(0.5);
+    fault::set_max_delay_ms(2); // up to 2ms delay
+    sim.addSerialSubsystem(phase, [&](int64_t, SimCore::Seconds){ fault::maybe_delay(); });
+    sim.run();
+    EXPECT_EQ(sim.frame(), s.maxFrames);
+}

--- a/tests/test_watchdog.cpp
+++ b/tests/test_watchdog.cpp
@@ -1,0 +1,14 @@
+#include <gtest/gtest.h>
+#include <simcore/watchdog.hpp>
+#include <atomic>
+#include <thread>
+
+TEST(Watchdog, TriggersCallback)
+{
+    std::atomic<bool> fired{false};
+    {
+        Watchdog wd(std::chrono::milliseconds(50), [&]{ fired = true; });
+        std::this_thread::sleep_for(std::chrono::milliseconds(80));
+    }
+    EXPECT_TRUE(fired.load());
+}


### PR DESCRIPTION
## Summary
- add `AsyncRingFileSink` with fsync for crash-safe logging
- introduce minidump helper, watchdog, and fault injector utilities
- fix watchdog stop predicate and handle `write` return values
- suppress `_open` deprecation warning by defining `_CRT_SECURE_NO_WARNINGS` before including `<io.h>`

## Testing
- `cmake -S . -B build -DENABLE_TESTS=ON` *(fails: HTTP/1.1 403 Forbidden when downloading googletest)*

------
https://chatgpt.com/codex/tasks/task_e_68ba0abf4364832bae4c42501627280c