### PR TITLE
Add architecture docs and minimal code samples

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,27 @@
+# Architecture Overview
+
+## Phase DAG
+```
+[Input] -> [Simulation] -> [Output]
+               |
+         [Physics]
+               |
+        [Constraint]
+```
+
+The engine processes data in a directed acyclic graph (DAG). Each node
+represents a phase; edges model dependencies and data flow.
+
+## Memory Layout
+```
+struct Car {
+    // Structure of Arrays (SoA)
+    float pos_x[N];
+    float pos_y[N];
+    float vel_x[N];
+    float vel_y[N];
+}
+```
+
+Physics kernels operate on SoA buffers to maximise cache and SIMD
+performance. Array dimensions align to cache lines for predictable access.

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -1,0 +1,20 @@
+# Contributor & Operations Guide
+
+## Development
+1. Configure the project:
+   ```bash
+   cmake -B build -S . -DENABLE_TESTS=ON
+   ```
+2. Build and run tests:
+   ```bash
+   cmake --build build -j
+   (cd build && ctest --output-on-failure)
+   ```
+
+## Style
+- Follow C++20 core guidelines.
+- Run all tests before submitting a PR.
+
+## Operations
+- Logs and profiles can be toggled with `ENABLE_LOG` and `ENABLE_PROF` in CMake.
+- For sanitizer builds, use `-DSIM_SANITIZERS=address;undefined`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+# Minimal Samples
+
+This directory contains tiny programs illustrating core simulation concepts.
+
+- `particles_on_plane.cpp` – integrates a particle falling under gravity.
+- `tyre_belt_on_drum.cpp` – scalar math kernel for belt tension around a drum.
+- `gpu_offload_demo.cpp` – demonstrates OpenMP target offload.
+
+Build a sample with `g++ -std=c++20 -I../include <file.cpp> -o <prog>`.
+The GPU demo additionally requires OpenMP offload support (`-fopenmp`).

--- a/examples/gpu_offload_demo.cpp
+++ b/examples/gpu_offload_demo.cpp
@@ -1,0 +1,16 @@
+#include <vector>
+#include <iostream>
+
+int main() {
+    const int N = 1024;
+    std::vector<float> data(N, 1.0f);
+
+#ifdef _OPENMP
+#pragma omp target teams distribute parallel for map(tofrom: data[0:N])
+    for (int i = 0; i < N; ++i) {
+        data[i] *= 2.0f;
+    }
+#endif
+
+    std::cout << "data[0]=" << data[0] << "\n";
+}

--- a/examples/particles_on_plane.cpp
+++ b/examples/particles_on_plane.cpp
@@ -1,0 +1,28 @@
+#include <simcore/physics/integrators.hpp>
+#include <iostream>
+
+struct Vec2 {
+    double x{}, y{};
+    Vec2 operator+(const Vec2 &o) const { return {x + o.x, y + o.y}; }
+    Vec2 &operator+=(const Vec2 &o) { x += o.x; y += o.y; return *this; }
+    Vec2 operator*(double s) const { return {x * s, y * s}; }
+};
+
+struct Particle {
+    Vec2 pos{}; // metres
+    Vec2 vel{}; // metres/second
+};
+
+int main() {
+    using simphys::symplecticEuler;
+
+    Particle p{{0.0, 10.0}, {1.0, 0.0}}; // start 10m up, moving sideways
+    auto gravity = [](const Particle &) { return Vec2{0.0, -9.81}; };
+    double dt = 0.016; // 60 Hz
+
+    for (int step = 0; step < 60; ++step) {
+        symplecticEuler(p, dt, gravity);
+        std::cout << "t=" << (step + 1) * dt
+                  << "s pos=(" << p.pos.x << ", " << p.pos.y << ")\n";
+    }
+}

--- a/examples/tyre_belt_on_drum.cpp
+++ b/examples/tyre_belt_on_drum.cpp
@@ -1,0 +1,20 @@
+#include <cmath>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+int main() {
+    const double drumRadius = 0.3; // metres
+    const int samples = 360;       // angular samples around drum
+    const double step = 2.0 * M_PI / samples;
+
+    std::vector<double> tension(samples);
+    for (int i = 0; i < samples; ++i) {
+        double theta = i * step;
+        // simple sinusoidal variation in belt tension
+        tension[i] = 1000.0 + 100.0 * std::sin(theta);
+    }
+
+    double avg = std::accumulate(tension.begin(), tension.end(), 0.0) / samples;
+    std::cout << "Average belt tension: " << avg << " N\n";
+}


### PR DESCRIPTION
## Summary
- Document core architecture with DAG and memory layout diagrams
- Add contributor & operations guide
- Provide minimal physics, math, and GPU offload examples

## Testing
- `cmake -S . -B build` *(fails: HTTP 403 when downloading googletest)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3012b864832b87a5bd96d7dffabd