### PR TITLE
Add sparse-set utilities and SoA/AoS bridging

### DIFF
--- a/include/simcore/car_soa.hpp
+++ b/include/simcore/car_soa.hpp
@@ -2,17 +2,22 @@
 #include <vector>
 #include <cstddef>
 #include <cassert>
+#include "simcore/aligned_allocator.hpp"
 
 /* -----------------------------------------------------------------
    Struct-of-arrays storage for the dummy "car" example.
    Now maintains sparse/dense mappings so systems can query only the
-   components they need.
+   components they need. Dense arrays are cacheline aligned with tail
+   padding to avoid cross-line writes.
    ----------------------------------------------------------------- */
 struct CarSoA
 {
+    static constexpr std::size_t CacheLine = 64;
+    static constexpr std::size_t TailPad = CacheLine / sizeof(double);
+
     // dense component storage
-    std::vector<double> pos;   // metres
-    std::vector<double> vel;   // m/s
+    std::vector<double, AlignedAllocator<double, CacheLine>> pos;   // metres
+    std::vector<double, AlignedAllocator<double, CacheLine>> vel;   // m/s
     // entity mappings
     std::vector<std::size_t> sparse;  // entity -> dense index + 1 (0 = missing)
     std::vector<std::size_t> dense;   // dense index -> entity id
@@ -30,8 +35,8 @@ struct CarSoA
 
     void reserve(std::size_t n)
     {
-        pos.reserve(n);
-        vel.reserve(n);
+        pos.reserve(n + TailPad);
+        vel.reserve(n + TailPad);
         dense.reserve(n);
         sparse.reserve(n);
     }
@@ -48,6 +53,7 @@ struct CarSoA
         if (id >= sparse.size())
             sparse.resize(id + 1, 0);
         assert(sparse[id] == 0 && "entity already present");
+        ensure_capacity();
         std::size_t idx = pos.size();
         pos.push_back(p);
         vel.push_back(v);
@@ -97,4 +103,19 @@ struct CarSoA
         std::size_t idxp1 = (id < sparse.size()) ? sparse[id] : 0;
         return idxp1 ? &vel[idxp1 - 1] : &defaultVel;
     }
+
+    template <typename Func>
+    void for_each(Func f) {
+        for (std::size_t i = 0; i < pos.size(); ++i)
+            f(dense[i], pos[i], vel[i]);
+    }
+
+private:
+    void ensure_capacity() {
+        if (pos.capacity() - pos.size() <= TailPad)
+            pos.reserve(pos.size() * 2 + TailPad);
+        if (vel.capacity() - vel.size() <= TailPad)
+            vel.reserve(vel.size() * 2 + TailPad);
+    }
 };
+

--- a/include/simcore/soa_simd.hpp
+++ b/include/simcore/soa_simd.hpp
@@ -25,6 +25,18 @@ struct Vec3SoA<const T> {
     const T* z;
 };
 
+namespace detail {
+#if defined(ENABLE_SIMD) && defined(__AVX2__)
+// Precomputed masks for tail processing (1..3 elements)
+alignas(32) static constexpr std::int64_t mask_lut[4][4] = {
+    {0, 0, 0, 0},
+    {-1, 0, 0, 0},
+    {-1, -1, 0, 0},
+    {-1, -1, -1, 0}
+};
+#endif
+} // namespace detail
+
 // p += a * v  (element-wise) for 3 channels (x,y,z)
 inline void axpy3(double a,
                   Vec3SoA<const double> v,
@@ -36,7 +48,7 @@ inline void axpy3(double a,
     std::size_t i = 0;
 
     // Vectorized body in 4-wide chunks
-    for (; i + 3 < n; i += 4) {
+    for (; i + 4 <= n; i += 4) {
         // x
         __m256d px = _mm256_loadu_pd(p.x + i);
         __m256d vx = _mm256_loadu_pd(v.x + i);
@@ -56,11 +68,25 @@ inline void axpy3(double a,
         _mm256_storeu_pd(p.z + i, pz);
     }
 
-    // Scalar tail
-    for (; i < n; ++i) {
-        p.x[i] += a * v.x[i];
-        p.y[i] += a * v.y[i];
-        p.z[i] += a * v.z[i];
+    // Vectorized tail using masks (no scalar loop)
+    std::size_t rem = n - i;
+    if (rem) {
+        const __m256i mask = _mm256_load_si256(reinterpret_cast<const __m256i*>(detail::mask_lut[rem]));
+
+        __m256d px = _mm256_maskload_pd(p.x + i, mask);
+        __m256d vx = _mm256_maskload_pd(v.x + i, mask);
+        px = _mm256_fmadd_pd(aa, vx, px);
+        _mm256_maskstore_pd(p.x + i, mask, px);
+
+        __m256d py = _mm256_maskload_pd(p.y + i, mask);
+        __m256d vy = _mm256_maskload_pd(v.y + i, mask);
+        py = _mm256_fmadd_pd(aa, vy, py);
+        _mm256_maskstore_pd(p.y + i, mask, py);
+
+        __m256d pz = _mm256_maskload_pd(p.z + i, mask);
+        __m256d vz = _mm256_maskload_pd(v.z + i, mask);
+        pz = _mm256_fmadd_pd(aa, vz, pz);
+        _mm256_maskstore_pd(p.z + i, mask, pz);
     }
 #else
     // Portable scalar fallback (API is still available)
@@ -73,3 +99,4 @@ inline void axpy3(double a,
 }
 
 } // namespace soa
+

--- a/include/simcore/soa_view.hpp
+++ b/include/simcore/soa_view.hpp
@@ -1,0 +1,51 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+namespace soa {
+
+// Strided span representing a channel inside an AoS buffer.
+template <typename T>
+struct StridedSpan {
+    T* ptr;
+    std::size_t stride; // bytes
+    T& operator[](std::size_t i) const {
+        return *reinterpret_cast<T*>(reinterpret_cast<std::uintptr_t>(ptr) + i * stride);
+    }
+};
+
+// View over legacy AoS arrays exposing SoA-like access.
+template <typename T>
+struct Vec3AoSView {
+    StridedSpan<T> x;
+    StridedSpan<T> y;
+    StridedSpan<T> z;
+
+    template <typename Struct>
+    static Vec3AoSView from(Struct* data,
+                            T Struct::*px,
+                            T Struct::*py,
+                            T Struct::*pz) {
+        return {
+            { &(data->*px), sizeof(Struct) },
+            { &(data->*py), sizeof(Struct) },
+            { &(data->*pz), sizeof(Struct) }
+        };
+    }
+};
+
+// p += s * v for AoS views (scalar implementation)
+template <typename T>
+inline void axpy3(Vec3AoSView<T> v,
+                  Vec3AoSView<T> p,
+                  T s,
+                  std::size_t n) {
+    for (std::size_t i = 0; i < n; ++i) {
+        p.x[i] += s * v.x[i];
+        p.y[i] += s * v.y[i];
+        p.z[i] += s * v.z[i];
+    }
+}
+
+} // namespace soa
+

--- a/include/simcore/sparse_set.hpp
+++ b/include/simcore/sparse_set.hpp
@@ -75,18 +75,27 @@ private:
     T default_{};
 };
 
-// Grouped view over two sparse sets.
+// Grouped view over two sparse sets. Iterates over the smaller set and
+// invokes the callback with matching components in a deterministic order.
 template <typename Func, typename A, typename B>
 void group_view(A& a, B& b, Func f) {
+    A* smallA = &a;
+    B* smallB = &b;
+    bool swapped = false;
     if (a.size() > b.size()) {
-        group_view(b, a, [&](std::size_t id, auto& compB, auto& compA) { f(id, compA, compB); });
-        return;
+        smallA = &b;
+        smallB = &a;
+        swapped = true;
     }
-    const auto& ents = a.entities();
+    const auto& ents = smallA->entities();
     for (std::size_t i = 0; i < ents.size(); ++i) {
         std::size_t id = ents[i];
-        if (b.has(id))
-            f(id, a.data()[i], *b.get(id));
+        if (smallB->has(id)) {
+            if (swapped)
+                f(id, *smallB->get(id), smallA->data()[i]);
+            else
+                f(id, smallA->data()[i], *smallB->get(id));
+        }
     }
 }
 

--- a/include/simcore/sparse_set.hpp
+++ b/include/simcore/sparse_set.hpp
@@ -1,0 +1,101 @@
+#pragma once
+#include <vector>
+#include <cstddef>
+#include <cassert>
+#include <algorithm>
+#include "simcore/aligned_allocator.hpp"
+
+// Generic sparse-set container with cacheline aligned dense storage
+// and tail padding to avoid cacheline straddling.
+template <typename T>
+class SparseSet {
+public:
+    using value_type = T;
+    static constexpr std::size_t CacheLine = 64;
+    static constexpr std::size_t TailPad = CacheLine / sizeof(T);
+
+    SparseSet() { ensure_capacity(); }
+
+    bool has(std::size_t id) const {
+        return id < sparse_.size() && sparse_[id] != 0;
+    }
+
+    T* get(std::size_t id) {
+        std::size_t idxp1 = (id < sparse_.size()) ? sparse_[id] : 0;
+        return idxp1 ? &dense_[idxp1 - 1] : &default_;
+    }
+    const T* get(std::size_t id) const {
+        std::size_t idxp1 = (id < sparse_.size()) ? sparse_[id] : 0;
+        return idxp1 ? &dense_[idxp1 - 1] : &default_;
+    }
+
+    void insert(std::size_t id, const T& value) {
+        if (id >= sparse_.size())
+            sparse_.resize(id + 1, 0);
+        assert(!has(id) && "entity already present");
+        ensure_capacity();
+        std::size_t idx = dense_.size();
+        dense_.push_back(value);
+        entities_.push_back(id);
+        sparse_[id] = idx + 1; // store index + 1
+    }
+
+    void remove(std::size_t id) {
+        assert(has(id));
+        std::size_t idx = sparse_[id] - 1;
+        std::size_t last = dense_.size() - 1;
+        if (idx != last) {
+            dense_[idx] = dense_[last];
+            std::size_t moved = entities_[last];
+            entities_[idx] = moved;
+            sparse_[moved] = idx + 1;
+        }
+        dense_.pop_back();
+        entities_.pop_back();
+        sparse_[id] = 0;
+    }
+
+    std::size_t size() const { return dense_.size(); }
+    const std::vector<std::size_t>& entities() const { return entities_; }
+    const T* data() const { return dense_.data(); }
+    T* data() { return dense_.data(); }
+    std::size_t capacity() const { return dense_.capacity(); }
+    static constexpr std::size_t tail_padding() { return TailPad; }
+
+private:
+    void ensure_capacity() {
+        if (dense_.capacity() - dense_.size() <= TailPad) {
+            dense_.reserve(dense_.size() * 2 + TailPad);
+        }
+    }
+
+    std::vector<T, AlignedAllocator<T, CacheLine>> dense_{};
+    std::vector<std::size_t> sparse_{};
+    std::vector<std::size_t> entities_{};
+    T default_{};
+};
+
+// Grouped view over two sparse sets.
+template <typename Func, typename A, typename B>
+void group_view(A& a, B& b, Func f) {
+    if (a.size() > b.size()) {
+        group_view(b, a, [&](std::size_t id, auto& compB, auto& compA) { f(id, compA, compB); });
+        return;
+    }
+    const auto& ents = a.entities();
+    for (std::size_t i = 0; i < ents.size(); ++i) {
+        std::size_t id = ents[i];
+        if (b.has(id))
+            f(id, a.data()[i], *b.get(id));
+    }
+}
+
+// Grouped view over three sparse sets.
+template <typename Func, typename A, typename B, typename C>
+void group_view(A& a, B& b, C& c, Func f) {
+    group_view(a, b, [&](std::size_t id, auto& compA, auto& compB) {
+        if (c.has(id))
+            f(id, compA, compB, *c.get(id));
+    });
+}
+

--- a/include/simcore/sparse_set.hpp
+++ b/include/simcore/sparse_set.hpp
@@ -79,22 +79,21 @@ private:
 // invokes the callback with matching components in a deterministic order.
 template <typename Func, typename A, typename B>
 void group_view(A& a, B& b, Func f) {
-    A* smallA = &a;
-    B* smallB = &b;
-    bool swapped = false;
     if (a.size() > b.size()) {
-        smallA = &b;
-        smallB = &a;
-        swapped = true;
-    }
-    const auto& ents = smallA->entities();
-    for (std::size_t i = 0; i < ents.size(); ++i) {
-        std::size_t id = ents[i];
-        if (smallB->has(id)) {
-            if (swapped)
-                f(id, *smallB->get(id), smallA->data()[i]);
-            else
-                f(id, smallA->data()[i], *smallB->get(id));
+        const auto& ents = b.entities();
+        for (std::size_t i = 0; i < ents.size(); ++i) {
+            std::size_t id = ents[i];
+            if (a.has(id)) {
+                f(id, *a.get(id), b.data()[i]);
+            }
+        }
+    } else {
+        const auto& ents = a.entities();
+        for (std::size_t i = 0; i < ents.size(); ++i) {
+            std::size_t id = ents[i];
+            if (b.has(id)) {
+                f(id, a.data()[i], *b.get(id));
+            }
         }
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,8 @@ set(TEST_SOURCES
     test_profiler.cpp
     test_adaptive_param.cpp
     test_soa.cpp
+    test_sparse_set.cpp
+    test_soa_view.cpp
     test_jobqueue.cpp
     test_workerpool_priority.cpp
     test_phase_graph.cpp

--- a/tests/test_soa_view.cpp
+++ b/tests/test_soa_view.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+#include <simcore/soa_view.hpp>
+
+struct LegacyVec3 { double x, y, z; };
+
+TEST(SOAView, Access)
+{
+    LegacyVec3 arr[4] = {{1,2,3},{4,5,6},{7,8,9},{10,11,12}};
+    auto view = soa::Vec3AoSView<double>::from(arr, &LegacyVec3::x, &LegacyVec3::y, &LegacyVec3::z);
+    view.x[1] = 40.0;
+    EXPECT_EQ(arr[1].x, 40.0);
+    EXPECT_EQ(view.y[2], 8.0);
+}
+
+TEST(SOAView, Axpy)
+{
+    LegacyVec3 pos[3] = {{0,0,0},{0,0,0},{0,0,0}};
+    LegacyVec3 vel[3] = {{1,2,3},{4,5,6},{7,8,9}};
+    auto pview = soa::Vec3AoSView<double>::from(pos, &LegacyVec3::x, &LegacyVec3::y, &LegacyVec3::z);
+    auto vview = soa::Vec3AoSView<double>::from(vel, &LegacyVec3::x, &LegacyVec3::y, &LegacyVec3::z);
+    soa::axpy3(vview, pview, 2.0, 3);
+    EXPECT_DOUBLE_EQ(pos[2].z, 9.0 * 2.0);
+    EXPECT_DOUBLE_EQ(pos[1].y, 5.0 * 2.0);
+}
+

--- a/tests/test_sparse_set.cpp
+++ b/tests/test_sparse_set.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+#include <simcore/sparse_set.hpp>
+#include <vector>
+#include <cstdint>
+
+TEST(SparseSet, InsertRemoveAligned)
+{
+    SparseSet<double> pos;
+    pos.insert(2, 1.0);
+    pos.insert(5, 3.0);
+
+    EXPECT_TRUE(pos.has(2));
+    EXPECT_EQ(*pos.get(5), 3.0);
+
+    uintptr_t addr = reinterpret_cast<uintptr_t>(pos.data());
+    EXPECT_EQ(addr % 64, 0u);
+    EXPECT_GE(pos.capacity() - pos.size(), SparseSet<double>::tail_padding());
+}
+
+TEST(SparseSet, GroupView)
+{
+    SparseSet<double> pos;
+    SparseSet<int> tag;
+    pos.insert(1, 1.0);
+    pos.insert(3, 2.0);
+    tag.insert(3, 5);
+    tag.insert(4, 7);
+
+    std::vector<std::size_t> ids;
+    group_view(pos, tag, [&](std::size_t id, double& p, int& t){
+        ids.push_back(id);
+        p += 1.0;
+        t += 1;
+    });
+
+    ASSERT_EQ(ids.size(), 1u);
+    EXPECT_EQ(ids[0], 3u);
+    EXPECT_DOUBLE_EQ(*pos.get(3), 3.0);
+    EXPECT_EQ(*tag.get(3), 6);
+}
+


### PR DESCRIPTION
## Summary
- add cacheline-aligned `SparseSet` with grouped-view helpers
- eliminate scalar tails in `soa_simd` kernels using AVX2 mask loads/stores
- provide AoS-to-SoA strided views and tail-padded `CarSoA`

## Testing
- `cmake -S . -B build -DENABLE_TESTS=ON` *(fails: Each download failed for googletest, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4af31248832b9c092364a7efd482