### PR TITLE
feat: add graceful degrade ladder

### DIFF
--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -112,6 +112,9 @@ public:
   double precoveredMs() const { return precoveredMs_; }
   FrameArena &frameArena() { return frameArenas_->tls(); }
   bintrace::Trace &bintrace() { return bintrace_; }
+  bool visualizersEnabled() const { return settings_.visualizers; }
+  bool broadphaseCoarse() const { return settings_.broadphaseCoarse; }
+  int subSteps() const { return subSteps_; }
 
   struct Settings {
     // Affinity / NUMA
@@ -169,6 +172,10 @@ public:
     double adaptDownFactor = 0.95;
     double minHz = 60.0;
     int adaptCooldownFrames = 600;
+
+    // Graceful degradation
+    bool visualizers = true;
+    bool broadphaseCoarse = false;
 
     // Binary event trace
     bool bintraceEnable = false;
@@ -1114,6 +1121,27 @@ private:
     startReal_ = Clock::now();
   }
 
+  void activateDegradeRung(int rung) {
+    degradeRung_ = rung;
+    switch (rung) {
+    case 1:
+      settings_.visualizers = false;
+      break;
+    case 2:
+      if (subSteps_ > 1)
+        --subSteps_;
+      break;
+    case 3:
+      settings_.broadphaseCoarse = true;
+      break;
+    default:
+      break;
+    }
+    bintrace_.log(bintrace::EV_BudgetLadder,
+                  static_cast<std::uint32_t>(rung),
+                  static_cast<std::uint64_t>(frame_));
+  }
+
   void updateBudget(double computeMs) {
     if (!settings_.budgetMonitor || settings_.budgetWindow <= 0)
       return;
@@ -1157,6 +1185,18 @@ private:
                  frame_, computeMs, ratio, avgComputeMs, avgRatio);
       }
     }
+
+    const double ratioRef = std::max(ratio, avgRatio);
+    const double t1 = settings_.budgetWarnRatio;
+    const double t2 = (settings_.budgetWarnRatio + settings_.budgetCritRatio) * 0.5;
+    const double t3 =
+        std::max(settings_.budgetWarnRatio, settings_.budgetCritRatio - 0.02);
+    if (degradeRung_ < 1 && ratioRef >= t1)
+      activateDegradeRung(1);
+    if (degradeRung_ < 2 && ratioRef >= t2)
+      activateDegradeRung(2);
+    if (degradeRung_ < 3 && ratioRef >= t3)
+      activateDegradeRung(3);
 
     if (settings_.autoAdaptHz) {
       if (adaptCooldown_ > 0)
@@ -1211,6 +1251,7 @@ private:
   std::size_t costCount_ = 0;
   double costSumMs_ = 0.0;
   int adaptCooldown_ = 0;
+  int degradeRung_ = 0;
   std::function<void(const BudgetSample &)> budgetCb_;
 
   std::uint64_t deterministicHash_ = 0;

--- a/include/simcore/bintrace.hpp
+++ b/include/simcore/bintrace.hpp
@@ -26,6 +26,7 @@ enum : std::uint32_t {
     EV_PhaseEnd    = 0x02,
     EV_ChunkStart  = 0x03,
     EV_ChunkDone   = 0x04,
+    EV_BudgetLadder = 0x05,
 };
 
 #if defined(__x86_64__) || defined(_M_X64)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_SOURCES
     test_rt_arena.cpp
     test_rt_overflow_death.cpp
     test_bintrace.cpp
+    test_budget_degrade.cpp
     test_predictive_adaptive.cpp
     test_small_array_balance.cpp
     test_phase_telemetry.cpp

--- a/tests/test_budget_degrade.cpp
+++ b/tests/test_budget_degrade.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+#include <simcore/SimCore.hpp>
+#include <atomic>
+
+static void busy_spin(int micros) {
+    using Clock = std::chrono::steady_clock;
+    auto start = Clock::now();
+    while (std::chrono::duration_cast<std::chrono::microseconds>(Clock::now() - start).count() < micros) {
+        std::atomic_signal_fence(std::memory_order_acq_rel);
+    }
+}
+
+TEST(BudgetMonitor, GracefulDegradeTriggers) {
+    SimCore::Settings s;
+    s.hz = 3000.0;                 // subSteps > 1
+    s.maxFrames = 4;
+    s.threads = 1;
+    s.budgetMonitor = true;
+    s.bintraceEnable = true;
+    s.bintraceEventsPerThread = 1u << 10;
+
+    SimCore sim(s);
+    auto phase = sim.addPhase("Slow");
+    sim.setPhaseElementCount(phase, 1);
+    sim.addSerialSubsystem(phase, [&](std::int64_t, SimCore::Seconds){
+        busy_spin(450); // force over budget
+    });
+
+    sim.run();
+
+    EXPECT_FALSE(sim.visualizersEnabled());
+    EXPECT_LT(sim.subSteps(), 3);
+    EXPECT_TRUE(sim.broadphaseCoarse());
+
+    auto snap = sim.bintrace().snapshot();
+    int rung1 = 0, rung2 = 0, rung3 = 0;
+    for (const auto& ev : snap.events) {
+        if (ev.code == bintrace::EV_BudgetLadder) {
+            if (ev.a == 1) ++rung1;
+            if (ev.a == 2) ++rung2;
+            if (ev.a == 3) ++rung3;
+        }
+    }
+    EXPECT_EQ(rung1, 1);
+    EXPECT_EQ(rung2, 1);
+    EXPECT_EQ(rung3, 1);
+}
+


### PR DESCRIPTION
## Summary
- add EV_BudgetLadder event for binary trace logging
- implement budget monitor degrade ladder to drop visualizers, reduce substeps, and coarsen broadphase before frame misses
- test ladder activation and trace logging

## Testing
- `cmake -S . -B build` *(fails: downloading googletest v1.14.0.zip returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68beefe391e0832b90f7a4a52319aede