### PR TITLE
Add snapshot/rollback functionality with replay test

### DIFF
--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -28,6 +28,7 @@
 #include <rt/fiber_pool.hpp>
 #include <rt/numerics.hpp>
 #include <rt/prng.hpp>
+#include <rt/snapshot.hpp>
 
 #ifndef _WIN32
 #include <sched.h>
@@ -424,6 +425,100 @@ public:
   std::int64_t frame() const { return frame_; }
   double dtSeconds() const { return dt_.count(); }
   double lastDriftMs() const { return lastDriftMs_; }
+
+  std::vector<std::uint8_t> saveFrame() const {
+    rt::SnapshotWriter w;
+    w.write<std::uint64_t>(static_cast<std::uint64_t>(frame_));
+    w.write<std::uint64_t>(rngSeed_);
+    w.write<std::uint64_t>(static_cast<std::uint64_t>(subSteps_));
+    w.write<std::uint64_t>(static_cast<std::uint64_t>(preSteps_));
+    std::uint64_t phCount = phases_.size();
+    w.write<std::uint64_t>(phCount);
+    for (const auto &ph : phases_) {
+      w.writeVector(ph.chunkSamples);
+      w.write<std::uint64_t>(static_cast<std::uint64_t>(ph.elementCount));
+      std::uint8_t en = ph.enabled ? 1 : 0;
+      w.write(en);
+      w.write<std::uint64_t>(static_cast<std::uint64_t>(ph.chosenChunk));
+      w.write<std::uint64_t>(static_cast<std::uint64_t>(ph.totalChunks));
+      w.write<std::uint64_t>(static_cast<std::uint64_t>(ph.chunkSkew));
+      w.write(ph.chunkCusum);
+      std::uint8_t pinned = ph.chunkPinned ? 1 : 0;
+      w.write(pinned);
+    }
+    w.writeVector(costWindow_);
+    w.write<std::uint64_t>(static_cast<std::uint64_t>(costHead_));
+    w.write<std::uint64_t>(static_cast<std::uint64_t>(costCount_));
+    w.write(costSumMs_);
+    std::uint8_t prim = predictivePrimed_ ? 1 : 0;
+    w.write(prim);
+    w.write<std::uint64_t>(static_cast<std::uint64_t>(degradeRung_));
+    w.write<std::uint64_t>(static_cast<std::uint64_t>(bursts_));
+    w.write<std::uint64_t>(static_cast<std::uint64_t>(extraSteps_));
+    w.write(recoveredMs_);
+    w.write(precoveredMs_);
+    return w.data;
+  }
+
+  void loadFrame(const std::vector<std::uint8_t> &data) {
+    rt::SnapshotReader r(data);
+    std::uint64_t tmp = 0;
+    r.read(tmp);
+    frame_ = static_cast<std::int64_t>(tmp);
+    r.read(rngSeed_);
+    r.read(tmp);
+    subSteps_ = static_cast<int>(tmp);
+    r.read(tmp);
+    preSteps_ = static_cast<int>(tmp);
+    std::uint64_t phSaved = 0;
+    r.read(phSaved);
+    for (std::uint64_t i = 0; i < phSaved; ++i) {
+      std::vector<std::size_t> samples;
+      r.readVector(samples);
+      r.read(tmp);
+      std::size_t elem = static_cast<std::size_t>(tmp);
+      std::uint8_t en = 0;
+      r.read(en);
+      r.read(tmp);
+      std::size_t chosen = static_cast<std::size_t>(tmp);
+      r.read(tmp);
+      std::size_t totalChunks = static_cast<std::size_t>(tmp);
+      r.read(tmp);
+      std::size_t chunkSkew = static_cast<std::size_t>(tmp);
+      double cusum = 0.0;
+      r.read(cusum);
+      std::uint8_t pinned = 0;
+      r.read(pinned);
+      if (i < phases_.size()) {
+        auto &ph = phases_[i];
+        ph.chunkSamples = std::move(samples);
+        ph.elementCount = elem;
+        ph.enabled = (en != 0);
+        ph.chosenChunk = chosen;
+        ph.totalChunks = totalChunks;
+        ph.chunkSkew = chunkSkew;
+        ph.chunkCusum = cusum;
+        ph.chunkPinned = (pinned != 0);
+      }
+    }
+    r.readVector(costWindow_);
+    r.read(tmp);
+    costHead_ = static_cast<std::size_t>(tmp);
+    r.read(tmp);
+    costCount_ = static_cast<std::size_t>(tmp);
+    r.read(costSumMs_);
+    std::uint8_t prim = 0;
+    r.read(prim);
+    predictivePrimed_ = prim != 0;
+    r.read(tmp);
+    degradeRung_ = static_cast<int>(tmp);
+    r.read(tmp);
+    bursts_ = static_cast<int>(tmp);
+    r.read(tmp);
+    extraSteps_ = static_cast<int>(tmp);
+    r.read(recoveredMs_);
+    r.read(precoveredMs_);
+  }
 
   void run() {
     startReal_ = Clock::now();

--- a/rt/include/rt/snapshot.hpp
+++ b/rt/include/rt/snapshot.hpp
@@ -1,0 +1,94 @@
+#pragma once
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace rt {
+
+struct SnapshotWriter {
+    std::vector<std::uint8_t> data;
+
+    template <class T> void write(const T &v) {
+        static_assert(std::is_trivially_copyable_v<T>, "write requires POD");
+        const auto *p = reinterpret_cast<const std::uint8_t *>(&v);
+        data.insert(data.end(), p, p + sizeof(T));
+    }
+
+    template <class T> void writeVector(const std::vector<T> &vec) {
+        std::uint64_t n = vec.size();
+        write(n);
+        if (n) {
+            static_assert(std::is_trivially_copyable_v<T>, "writeVector requires POD");
+            const auto *p = reinterpret_cast<const std::uint8_t *>(vec.data());
+            data.insert(data.end(), p, p + n * sizeof(T));
+        }
+    }
+
+    template <class K, class V>
+    void writeMap(const std::unordered_map<K, V> &m) {
+        std::vector<std::pair<K, V>> items(m.begin(), m.end());
+        std::sort(items.begin(), items.end(), [](auto &a, auto &b) {
+            return a.first < b.first;
+        });
+        std::uint64_t n = items.size();
+        write(n);
+        for (auto &kv : items) {
+            write(kv.first);
+            write(kv.second);
+        }
+    }
+};
+
+struct SnapshotReader {
+    const std::vector<std::uint8_t> &data;
+    std::size_t offset{0};
+
+    explicit SnapshotReader(const std::vector<std::uint8_t> &d) : data(d) {}
+
+    template <class T> void read(T &out) {
+        static_assert(std::is_trivially_copyable_v<T>, "read requires POD");
+        std::memcpy(&out, data.data() + offset, sizeof(T));
+        offset += sizeof(T);
+    }
+
+    template <class T> void readVector(std::vector<T> &vec) {
+        std::uint64_t n = 0;
+        read(n);
+        vec.resize(static_cast<std::size_t>(n));
+        if (n) {
+            static_assert(std::is_trivially_copyable_v<T>, "readVector requires POD");
+            std::memcpy(vec.data(), data.data() + offset, n * sizeof(T));
+            offset += n * sizeof(T);
+        }
+    }
+
+    template <class K, class V> void readMap(std::unordered_map<K, V> &m) {
+        std::uint64_t n = 0;
+        read(n);
+        m.clear();
+        m.reserve(static_cast<std::size_t>(n));
+        for (std::uint64_t i = 0; i < n; ++i) {
+            K k;
+            V v;
+            read(k);
+            read(v);
+            m.emplace(std::move(k), std::move(v));
+        }
+    }
+};
+
+inline std::uint64_t hash64(const std::vector<std::uint8_t> &buf) {
+    std::uint64_t h = 1469598103934665603ull;
+    for (std::uint8_t b : buf) {
+        h ^= b;
+        h *= 1099511628211ull;
+    }
+    return h;
+}
+
+} // namespace rt
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TEST_SOURCES
     test_watchdog.cpp
     test_numerics.cpp
     test_prng_determinism.cpp
+    test_snapshot.cpp
 )
 
 if (ENABLE_RAPIDCHECK AND TARGET rapidcheck_gtest)

--- a/tests/test_snapshot.cpp
+++ b/tests/test_snapshot.cpp
@@ -1,0 +1,69 @@
+#include <gtest/gtest.h>
+#include <simcore/SimCore.hpp>
+#include <simcore/logger.hpp>
+#include <rt/snapshot.hpp>
+#include <unordered_map>
+#include <vector>
+
+TEST(SnapshotRollback, ReplayHashEquality) {
+    const int N = 40;
+    const int TOTAL = 60; // N + 20 frames
+
+    SimCore::Settings s;
+    s.hz = 60.0;
+    s.maxFrames = N;
+    s.threads = 1;
+    s.adaptive = false;
+    s.predictiveEnable = false;
+    s.budgetMonitor = false;
+    s.autoTuneChunks = false;
+    s.driftLogInterval = 0;
+
+    Logger log; log.setLevel(Logger::Level::Error);
+    SimCore sim(s);
+    sim.setLogger(&log);
+
+    std::vector<int> dense(32, 0);
+    std::unordered_map<int,int> sparse;
+    for (int i = 0; i < 16; ++i) sparse[i * 2] = i;
+
+    const std::size_t phase = sim.addPhase("P");
+    sim.addSerialSubsystem(phase, [&](std::int64_t f, SimCore::Seconds){
+        for (std::size_t i = 0; i < dense.size(); ++i)
+            dense[i] += int(sim.prng(f, i) & 0xff);
+        for (auto &kv : sparse)
+            kv.second += int(sim.prng(f, kv.first) & 0xff);
+    });
+
+    sim.run(); // run N frames
+
+    rt::SnapshotWriter ecsSnap;
+    ecsSnap.writeVector(dense);
+    ecsSnap.writeMap(sparse);
+    std::vector<std::uint8_t> simSnap = sim.saveFrame();
+
+    auto s2 = s;
+    s2.maxFrames = TOTAL;
+    sim.applySettings(s2);
+    sim.run(); // run remaining frames
+
+    rt::SnapshotWriter final1;
+    final1.writeVector(dense);
+    final1.writeMap(sparse);
+    auto hash1 = rt::hash64(final1.data);
+
+    dense.clear();
+    sparse.clear();
+    rt::SnapshotReader ecsRead(ecsSnap.data);
+    ecsRead.readVector(dense);
+    ecsRead.readMap(sparse);
+    sim.loadFrame(simSnap);
+    sim.run();
+
+    rt::SnapshotWriter final2;
+    final2.writeVector(dense);
+    final2.writeMap(sparse);
+    auto hash2 = rt::hash64(final2.data);
+
+    EXPECT_EQ(hash1, hash2);
+}


### PR DESCRIPTION
## Summary
- implement binary snapshot utilities for deterministic ECS state
- enable SimCore frame serialization and restoration
- add rollback/replay test verifying hash equality

## Testing
- `cmake -B build -DENABLE_TESTS=OFF`
- `cmake --build build`
- ⚠️ `cmake -B build -DENABLE_TESTS=ON` *(failed: 403 fetching googletest)*


------
https://chatgpt.com/codex/tasks/task_e_68bf0a7a2eec832bb26cff5b2ab9046c