### PR TITLE
Add bintrace snapshot exporter to Chrome trace JSON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,11 @@ target_link_libraries(simcore_rt PUBLIC simcore_core)
 add_executable(simcore_app src/main.cpp)
 target_link_libraries(simcore_app PRIVATE simcore)
 
+# Sample trace dump utility
+add_executable(trace_dump src/trace_dump.cpp)
+target_link_libraries(trace_dump PRIVATE simcore)
+target_include_directories(trace_dump PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 # Tests
 if (ENABLE_TESTS)
     enable_testing()

--- a/src/trace_dump.cpp
+++ b/src/trace_dump.cpp
@@ -1,0 +1,15 @@
+#include "simcore/bintrace.hpp"
+#include "tools/trace_export.hpp"
+#include <fstream>
+
+int main() {
+    bintrace::Trace tr;
+    tr.init(1, 1024, true);
+    tr.bindThread(0);
+    tr.log(bintrace::EV_PhaseBegin);
+    tr.log(bintrace::EV_PhaseEnd);
+    auto snap = tr.snapshot();
+    std::ofstream f("trace.json");
+    trace_export::write_chrome_trace(snap, f);
+    return 0;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ set(TEST_SOURCES
     test_numerics.cpp
     test_prng_determinism.cpp
     test_snapshot.cpp
+    test_trace_export.cpp
 )
 
 if (ENABLE_RAPIDCHECK AND TARGET rapidcheck_gtest)
@@ -52,7 +53,9 @@ endif()
 target_include_directories(simcore_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/tests
+    ${CMAKE_SOURCE_DIR}
 )
+target_compile_definitions(simcore_tests PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 
 add_test(NAME simcore_all COMMAND simcore_tests)
 

--- a/tests/golden/trace_sample.json
+++ b/tests/golden/trace_sample.json
@@ -1,0 +1,1 @@
+{"traceEvents":[{"cat":"PhaseBegin","tid":0,"ts":100},{"cat":"PhaseEnd","tid":0,"ts":150},{"cat":"ChunkStart","tid":1,"ts":200},{"cat":"ChunkDone","tid":1,"ts":300}]}

--- a/tests/test_trace_export.cpp
+++ b/tests/test_trace_export.cpp
@@ -1,0 +1,30 @@
+#include <gtest/gtest.h>
+#include "simcore/bintrace.hpp"
+#include "tools/trace_export.hpp"
+#include <sstream>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+TEST(TraceExport, GoldenJson)
+{
+    bintrace::Trace::Snapshot snap;
+    snap.events = {
+        bintrace::Event{100, bintrace::EV_PhaseBegin, 0, 0, 0, 0},
+        bintrace::Event{150, bintrace::EV_PhaseEnd, 0, 0, 0, 0},
+        bintrace::Event{200, bintrace::EV_ChunkStart, 0, 0, 1, 0},
+        bintrace::Event{300, bintrace::EV_ChunkDone, 0, 0, 1, 0}
+    };
+    snap.perThreadCount = {2,2};
+
+    std::ostringstream os;
+    trace_export::write_chrome_trace(snap, os);
+    std::string out = os.str();
+
+    std::ifstream f(std::string(PROJECT_SOURCE_DIR) + "/tests/golden/trace_sample.json");
+    std::string golden((std::istreambuf_iterator<char>(f)), {});
+    EXPECT_EQ(out, golden);
+
+    std::size_t bin_size = snap.events.size() * sizeof(bintrace::Event);
+    EXPECT_LT(out.size(), bin_size * 10);
+}

--- a/tools/trace_export.hpp
+++ b/tools/trace_export.hpp
@@ -1,0 +1,33 @@
+#pragma once
+#include <ostream>
+#include <cstdint>
+#include "simcore/bintrace.hpp"
+
+namespace trace_export {
+
+inline const char* codeToCat(std::uint32_t code) {
+    switch (code) {
+    case bintrace::EV_PhaseBegin:  return "PhaseBegin";
+    case bintrace::EV_PhaseEnd:    return "PhaseEnd";
+    case bintrace::EV_ChunkStart:  return "ChunkStart";
+    case bintrace::EV_ChunkDone:   return "ChunkDone";
+    case bintrace::EV_BudgetLadder:return "BudgetLadder";
+    default: return "Unknown";
+    }
+}
+
+inline void write_chrome_trace(const bintrace::Trace::Snapshot& snap, std::ostream& os) {
+    os << "{\"traceEvents\":[";
+    bool first = true;
+    for (const auto& e : snap.events) {
+        if (!first) os << ',';
+        first = false;
+        os << "{\"cat\":\"" << codeToCat(e.code) << "\",";
+        os << "\"tid\":" << e.thread << ',';
+        os << "\"ts\":" << e.tsc << "}";
+    }
+    os << "]}";
+}
+
+} // namespace trace_export
+


### PR DESCRIPTION
## Summary
- add header-only trace exporter converting `bintrace::Trace::Snapshot` to Chrome trace JSON
- provide simple `trace_dump` example writing `trace.json`
- cover exporter with golden JSON test and size overhead check

## Testing
- `cmake ..` *(fails: Each download failed (googletest 403))*
- `cmake .. -DENABLE_TESTS=OFF && cmake --build . -- -j`


------
https://chatgpt.com/codex/tasks/task_e_68bf30066624832ba628003cd375e744