### PR TITLE
feat: add rate governor ladder

### DIFF
--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -1288,7 +1288,8 @@ private:
     startReal_ = Clock::now();
   }
 
-  void activateDegradeRung(int rung) {
+public:
+  void applyDegradeRung(int rung) {
     degradeRung_ = rung;
     switch (rung) {
     case 1:
@@ -1308,6 +1309,7 @@ private:
                   static_cast<std::uint64_t>(frame_));
   }
 
+private:
   void updateBudget(double computeMs) {
     if (!settings_.budgetMonitor || settings_.budgetWindow <= 0)
       return;
@@ -1359,11 +1361,11 @@ private:
     const double t3 =
         std::max(settings_.budgetWarnRatio, settings_.budgetCritRatio - 0.02);
     if (degradeRung_ < 1 && ratioRef >= t1)
-      activateDegradeRung(1);
+      applyDegradeRung(1);
     if (degradeRung_ < 2 && ratioRef >= t2)
-      activateDegradeRung(2);
+      applyDegradeRung(2);
     if (degradeRung_ < 3 && ratioRef >= t3)
-      activateDegradeRung(3);
+      applyDegradeRung(3);
 
     if (settings_.autoAdaptHz) {
       if (adaptCooldown_ > 0)

--- a/include/simcore/rate_governor.hpp
+++ b/include/simcore/rate_governor.hpp
@@ -1,27 +1,49 @@
 #pragma once
 #include <algorithm>
+#include <functional>
 
 // Simple PI based rate governor. Controls a scale factor so that
 // compute_ms stays within frame_ms. Includes hysteresis and clamping.
 class RateGovernor {
 public:
+    using RungCallback = std::function<void(int)>;
+
     RateGovernor(double frame_ms, double kp=0.1, double ki=0.01,
-                 double floor=0.5, double ceiling=1.0, double hysteresis=0.05)
+                 double floor=0.5, double ceiling=1.0, double hysteresis=0.05,
+                 RungCallback rungCb = {})
         : frame_ms_(frame_ms), kp_(kp), ki_(ki),
-          floor_(floor), ceiling_(ceiling), hyst_(hysteresis) {}
+          floor_(floor), ceiling_(ceiling), hyst_(hysteresis),
+          rungCb_(std::move(rungCb)) {}
 
     // Update with the last frame's compute time. Returns new scale factor.
     double update(double compute_ms) {
         double ratio = compute_ms / (frame_ms_ * scale_);
         double error = ratio - 1.0;
-        if (std::abs(error) < hyst_) return scale_;
-        integral_ += error;
-        double delta = kp_ * error + ki_ * integral_;
-        scale_ = std::clamp(scale_ - delta, floor_, ceiling_);
+        if (std::abs(error) >= hyst_) {
+            integral_ += error;
+            double delta = kp_ * error + ki_ * integral_;
+            scale_ = std::clamp(scale_ - delta, floor_, ceiling_);
+        }
+
+        const double ratioRef = compute_ms / frame_ms_;
+        if (rung_ < 1 && ratioRef >= t1_) {
+            rung_ = 1;
+            if (rungCb_) rungCb_(1);
+        }
+        if (rung_ < 2 && ratioRef >= t2_) {
+            rung_ = 2;
+            if (rungCb_) rungCb_(2);
+        }
+        if (rung_ < 3 && ratioRef >= t3_) {
+            rung_ = 3;
+            if (rungCb_) rungCb_(3);
+        }
+
         return scale_;
     }
 
     double scale() const { return scale_; }
+    int rung() const { return rung_; }
 
 private:
     double frame_ms_;
@@ -32,5 +54,10 @@ private:
     double hyst_;
     double integral_ = 0.0;
     double scale_ = 1.0;
+    int rung_ = 0;
+    const double t1_ = 1.1;
+    const double t2_ = 1.3;
+    const double t3_ = 1.5;
+    RungCallback rungCb_;
 };
 

--- a/tests/test_rate_governor.cpp
+++ b/tests/test_rate_governor.cpp
@@ -1,8 +1,11 @@
 #include <gtest/gtest.h>
 #include "simcore/rate_governor.hpp"
+#include <vector>
 
-TEST(RateGovernor, AdversarialBurstRecovers) {
-    RateGovernor rg(16.0); // 16ms frame
+TEST(RateGovernor, AdversarialBurstTriggersLadderAndRecovers) {
+    std::vector<int> events;
+    RateGovernor rg(16.0, 0.1, 0.01, 0.5, 1.0, 0.05,
+                    [&](int rung){ events.push_back(rung); });
     // warmup stable frames
     for(int i=0;i<5;i++) {
         double s = rg.update(10.0);
@@ -11,6 +14,11 @@ TEST(RateGovernor, AdversarialBurstRecovers) {
     // adversarial burst
     double s = rg.update(40.0);
     EXPECT_LT(s, 1.0);
+    EXPECT_EQ(rg.rung(), 3);
+    ASSERT_EQ(events.size(), 3u);
+    EXPECT_EQ(events[0], 1);
+    EXPECT_EQ(events[1], 2);
+    EXPECT_EQ(events[2], 3);
     // subsequent frames should recover
     for(int i=0;i<40;i++) {
         s = rg.update(10.0);


### PR DESCRIPTION
## Summary
- extend RateGovernor with rung callback and degradation ladder
- expose SimCore ladder policy for external control and bintrace logging
- test adversarial bursts triggering rungs and confirming recovery

## Testing
- `cmake -S . -B build -G Ninja` *(failed: Each download failed! status_code: 22 The requested URL returned error: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf372dfd28832b9e754d0bea26e0b1