### PR TITLE
Add C ABI and strong units

### DIFF
--- a/api/cabi.h
+++ b/api/cabi.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Stable C ABI for embedding the simulation core.
+ * Provides versioning and compile-time feature flag introspection.
+ */
+
+typedef struct {
+    uint32_t major;
+    uint32_t minor;
+} cabi_version_t;
+
+/* Feature flags exposed at compile time */
+enum cabi_feature {
+    CABI_FEATURE_LOG  = 1u << 0,
+    CABI_FEATURE_PROF = 1u << 1,
+};
+
+typedef uint32_t cabi_feature_flags;
+
+static inline cabi_version_t cabi_version(void) {
+    return (cabi_version_t){1u, 0u};
+}
+
+static inline cabi_feature_flags cabi_get_features(void) {
+    cabi_feature_flags f = 0u;
+#ifdef LOG_ENABLED
+    f |= CABI_FEATURE_LOG;
+#endif
+#ifdef PROF_ENABLED
+    f |= CABI_FEATURE_PROF;
+#endif
+    return f;
+}
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/core/include/core/units.hpp
+++ b/core/include/core/units.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-// Minimal strong type units used for time and distance.
-// In a full implementation, this would leverage mp-units, but here we
-// provide a lightweight quantity wrapper to illustrate the concept.
+// Lightweight strong type units for time and distance.
+// In a production system, consider using the mp-units library instead.
 
 #include <cstdint>
+#include <type_traits>
 
 namespace core {
 
@@ -12,9 +12,44 @@ namespace core {
 template <typename Unit, typename Rep = double>
 struct quantity {
     Rep value;
-    constexpr explicit quantity(Rep v) : value(v) {}
+    constexpr explicit quantity(Rep v = {}) : value(v) {}
     constexpr Rep count() const { return value; }
 };
+
+// Arithmetic operators - only same units are permitted
+
+template <typename Unit, typename Rep>
+constexpr quantity<Unit, Rep> operator+(quantity<Unit, Rep> lhs, quantity<Unit, Rep> rhs) {
+    return quantity<Unit, Rep>{lhs.count() + rhs.count()};
+}
+
+template <typename Unit, typename Rep>
+constexpr quantity<Unit, Rep> operator-(quantity<Unit, Rep> lhs, quantity<Unit, Rep> rhs) {
+    return quantity<Unit, Rep>{lhs.count() - rhs.count()};
+}
+
+template <typename Unit, typename Rep, typename Scalar,
+          typename = std::enable_if_t<std::is_arithmetic_v<Scalar>>>
+constexpr quantity<Unit, Rep> operator*(quantity<Unit, Rep> q, Scalar s) {
+    return quantity<Unit, Rep>{q.count() * static_cast<Rep>(s)};
+}
+
+template <typename Unit, typename Rep, typename Scalar,
+          typename = std::enable_if_t<std::is_arithmetic_v<Scalar>>>
+constexpr quantity<Unit, Rep> operator*(Scalar s, quantity<Unit, Rep> q) {
+    return q * s;
+}
+
+template <typename Unit, typename Rep, typename Scalar,
+          typename = std::enable_if_t<std::is_arithmetic_v<Scalar>>>
+constexpr quantity<Unit, Rep> operator/(quantity<Unit, Rep> q, Scalar s) {
+    return quantity<Unit, Rep>{q.count() / static_cast<Rep>(s)};
+}
+
+template <typename Unit, typename Rep>
+constexpr bool operator==(quantity<Unit, Rep> lhs, quantity<Unit, Rep> rhs) {
+    return lhs.count() == rhs.count();
+}
 
 // Unit tags
 struct seconds_tag {};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(TEST_SOURCES
     test_prng_determinism.cpp
     test_snapshot.cpp
     test_trace_export.cpp
+    test_units.cpp
 )
 
 if (ENABLE_RAPIDCHECK AND TARGET rapidcheck_gtest)

--- a/tests/test_units.cpp
+++ b/tests/test_units.cpp
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+#include <core/units.hpp>
+#include <type_traits>
+#include <utility>
+
+using namespace core;
+
+namespace {
+// Detection idiom to test if addition is valid at compile time
+template <typename T, typename U, typename = void>
+struct can_add : std::false_type {};
+
+template <typename T, typename U>
+struct can_add<T, U, std::void_t<decltype(std::declval<T>() + std::declval<U>())>> : std::true_type {};
+} // namespace
+
+static_assert(can_add<meters, meters>::value, "meters + meters should compile");
+static_assert(!can_add<meters, seconds>::value, "meters + seconds should be ill-formed");
+
+TEST(Units, Addition) {
+    meters a{1.0};
+    meters b{2.0};
+    auto c = a + b;
+    EXPECT_DOUBLE_EQ(c.count(), 3.0);
+}
+


### PR DESCRIPTION
## Summary
- expose stable C ABI with version and feature flags
- implement lightweight strong-typed units for seconds and meters
- add compile-time tests for unit dimensional safety

## Testing
- `cmake -S . -B build -DENABLE_TESTS=OFF`
- `cmake --build build`
- `g++ -std=c++20 tests/test_units.cpp -I/tmp -Icore/include -Iinclude -fsyntax-only`
- `g++ -std=c++20 /tmp/bad_units.cpp -Icore/include -Iinclude` *(fails: no match for operator+)*
- `abi-compliance-checker -lib rtcar -headers api` *(fails: command not found)*
- `cmake -S . -B build` *(fails: gtest download 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf449a3d40832b8aabc32dfcc68f7a