### PR TITLE
feat: add hugepage and thermal limp support

### DIFF
--- a/docs/memory_tlb_thermal.md
+++ b/docs/memory_tlb_thermal.md
@@ -1,0 +1,14 @@
+# Memory/TLB/Thermal Discipline
+
+## TLB Strategy
+
+- Use 2 MB huge pages for hot arrays to minimise TLB pressure.
+- Apply page coloring or `madvise` hints for streaming buffers.
+- Tune software prefetch distances per simulation phase and disable them when they become harmful.
+
+## Thermal Management
+
+- Monitor on-die telemetry through RAPL/HWP interfaces.
+- Add a "thermal limp" rung to the degrade ladder by reducing substeps before hardware throttling would cause larger stalls.
+
+These guidelines complement the existing real-time hardening steps and help maintain predictable performance under load.

--- a/docs/real_time_hardening.md
+++ b/docs/real_time_hardening.md
@@ -45,3 +45,5 @@ deep C-states.  This behaviour can be toggled at runtime by re-running the
 scripts: invoking them applies the low-latency configuration, while restoring a
 balanced power profile can be done with native tools such as `cpupower` on Linux
 or `powercfg` on Windows.
+
+See also [Memory/TLB/Thermal Discipline](memory_tlb_thermal.md) for in-application strategies.

--- a/hal/hal.hpp
+++ b/hal/hal.hpp
@@ -8,17 +8,26 @@
 #include <memory>
 #include <thread>
 #include <cstdlib>
+#if defined(__linux__)
+#include <sys/mman.h>
+#include <unistd.h>
+#include <malloc.h>
+#endif
 
 namespace simcore::hal {
 
-// Memory allocation flags (pinned/hugepage currently no-op)
+// Memory allocation flags
 enum class MemFlags : uint32_t {
     none     = 0,
     pinned   = 1u << 0,
     hugepage = 1u << 1,
 };
 
-inline void* alloc(std::size_t bytes, MemFlags /*flags*/ = MemFlags::none) {
+inline bool has_flag(MemFlags f, MemFlags bit) {
+    return (static_cast<uint32_t>(f) & static_cast<uint32_t>(bit)) != 0;
+}
+
+inline void* alloc(std::size_t bytes, MemFlags flags = MemFlags::none) {
     constexpr std::size_t align = 64;
     std::size_t size = (bytes + align - 1) / align * align;
     void* ptr = nullptr;
@@ -27,15 +36,38 @@ inline void* alloc(std::size_t bytes, MemFlags /*flags*/ = MemFlags::none) {
     if (!ptr) throw std::bad_alloc();
 #else
     if (posix_memalign(&ptr, align, size) != 0) throw std::bad_alloc();
+#if defined(__linux__)
+    if (has_flag(flags, MemFlags::hugepage)) {
+        (void)::madvise(ptr, size, MADV_HUGEPAGE);
+    }
+    if (has_flag(flags, MemFlags::pinned)) {
+        (void)::mlock(ptr, size);
+    }
+#endif
 #endif
     return ptr;
 }
 
-inline void free(void* ptr) {
+inline void free(void* ptr, MemFlags flags = MemFlags::none) {
+#if defined(__linux__)
+    if (has_flag(flags, MemFlags::pinned) && ptr) {
+        std::size_t sz = ::malloc_usable_size(ptr);
+        (void)::munlock(ptr, sz);
+    }
+#endif
 #if defined(_MSC_VER)
     _aligned_free(ptr);
 #else
     std::free(ptr);
+#endif
+}
+
+inline void prefetch(const void* ptr, int locality = 3) {
+#if defined(__GNUC__) || defined(__clang__)
+    __builtin_prefetch(ptr, 0, locality);
+#else
+    (void)ptr;
+    (void)locality;
 #endif
 }
 

--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -191,6 +191,10 @@ public:
     double minHz = 60.0;
     int adaptCooldownFrames = 600;
 
+    // Thermal monitoring
+    bool thermalMonitor = false;
+    double thermalLimitC = 90.0;
+
     // Graceful degradation
     bool visualizers = true;
     bool broadphaseCoarse = false;
@@ -1302,6 +1306,9 @@ public:
     case 3:
       settings_.broadphaseCoarse = true;
       break;
+    case 4:
+      subSteps_ = 1;
+      break;
     default:
       break;
     }
@@ -1310,6 +1317,19 @@ public:
   }
 
 private:
+#if defined(__linux__)
+  static double readPackageTempC() {
+    const char *paths[] = {"/sys/class/thermal/thermal_zone0/temp",
+                           "/sys/class/hwmon/hwmon0/temp1_input"};
+    for (const char *p : paths) {
+      std::ifstream in(p);
+      double milli;
+      if (in && (in >> milli))
+        return milli / 1000.0;
+    }
+    return 0.0;
+  }
+#endif
   void updateBudget(double computeMs) {
     if (!settings_.budgetMonitor || settings_.budgetWindow <= 0)
       return;
@@ -1366,6 +1386,14 @@ private:
       applyDegradeRung(2);
     if (degradeRung_ < 3 && ratioRef >= t3)
       applyDegradeRung(3);
+
+#if defined(__linux__)
+    if (settings_.thermalMonitor) {
+      lastTempC_ = readPackageTempC();
+      if (degradeRung_ < 4 && lastTempC_ >= settings_.thermalLimitC)
+        applyDegradeRung(4);
+    }
+#endif
 
     if (settings_.autoAdaptHz) {
       if (adaptCooldown_ > 0)
@@ -1426,6 +1454,7 @@ private:
 
   std::uint64_t deterministicHash_ = 0;
   double lastDriftMs_ = 0.0;
+  double lastTempC_ = 0.0;
   int bursts_ = 0;
   int extraSteps_ = 0;
   double recoveredMs_ = 0.0;

--- a/include/simcore/rt_memory.hpp
+++ b/include/simcore/rt_memory.hpp
@@ -16,10 +16,10 @@
 #include <unistd.h>   // sysconf
 #endif
 
-// Optional toggles (define before including if you want them ON):
-// #define RT_ARENA_PRETOUCH          1
-// #define RT_ARENA_MLOCK             1
-// #define RT_ARENA_MADVISE_HUGEPAGE  1
+#include "hal.hpp"
+
+// Optional toggle (define before including if you want it ON):
+// #define RT_ARENA_PRETOUCH 1
 
 namespace rt {
 
@@ -51,11 +51,14 @@ static inline std::size_t os_page_size() noexcept {
 class FrameArena {
 public:
   explicit FrameArena(std::size_t capacityBytes = (1u << 20),
-                      std::size_t alignment = 64, int numaNode = -1)
+                      std::size_t alignment = 64, int numaNode = -1,
+                      simcore::hal::MemFlags flags =
+                          simcore::hal::MemFlags::none)
       : alignment_(normalize_align(alignment))
 #if defined(__linux__) && defined(SIM_USE_NUMA)
         , numaNode_(numaNode)
 #endif
+        , flags_(flags)
   {
 #if !(defined(__linux__) && defined(SIM_USE_NUMA))
     (void)numaNode;
@@ -76,6 +79,7 @@ public:
 #if defined(__linux__)
         , pageSize_(o.pageSize_)
 #endif
+        , flags_(o.flags_)
   {
     o.buffer_ = nullptr;
     o.capacity_ = 0;
@@ -83,6 +87,7 @@ public:
 #if defined(__linux__) && defined(SIM_USE_NUMA)
     o.numaNode_ = -1;
 #endif
+    o.flags_ = simcore::hal::MemFlags::none;
   }
 
   FrameArena &operator=(FrameArena &&o) noexcept {
@@ -102,6 +107,8 @@ public:
 #if defined(__linux__)
       pageSize_ = o.pageSize_;
 #endif
+      flags_ = o.flags_;
+      o.flags_ = simcore::hal::MemFlags::none;
     }
     return *this;
   }
@@ -171,16 +178,10 @@ private:
       }
 #if defined(__linux__)
       pageSize_ = os_page_size();
-#endif
-#if RT_ARENA_MADVISE_HUGEPAGE
-#if defined(__linux__)
-      (void)::madvise(buffer_, capacity_, MADV_HUGEPAGE);
-#endif
-#endif
-#if RT_ARENA_MLOCK
-#if defined(__linux__)
-      (void)::mlock(buffer_, capacity_);
-#endif
+      if (simcore::hal::has_flag(flags_, simcore::hal::MemFlags::hugepage))
+        (void)::madvise(buffer_, capacity_, MADV_HUGEPAGE);
+      if (simcore::hal::has_flag(flags_, simcore::hal::MemFlags::pinned))
+        (void)::mlock(buffer_, capacity_);
 #endif
 #if RT_ARENA_PRETOUCH
       pre_touch_();
@@ -191,10 +192,9 @@ private:
 
   void release_() noexcept {
     if (buffer_) {
-#if RT_ARENA_MLOCK
 #if defined(__linux__)
-      (void)::munlock(buffer_, capacity_);
-#endif
+      if (simcore::hal::has_flag(flags_, simcore::hal::MemFlags::pinned))
+        (void)::munlock(buffer_, capacity_);
 #endif
 #if defined(__linux__) && defined(SIM_USE_NUMA)
       if (numaNode_ >= 0 && numa_available() != -1) {
@@ -227,6 +227,7 @@ private:
   std::size_t capacity_ = 0;
   std::size_t head_ = 0;
   std::size_t alignment_ = 64;
+  simcore::hal::MemFlags flags_ = simcore::hal::MemFlags::none;
 #if defined(__linux__) && defined(SIM_USE_NUMA)
   int numaNode_ = -1;
 #endif
@@ -241,12 +242,13 @@ public:
   FrameArenaPool(std::size_t threads,
                  std::size_t perThreadCapacityBytes = (1u << 20),
                  std::size_t baseAlignment = 64,
-                 const std::vector<int> &nodes = {})
+                 const std::vector<int> &nodes = {},
+                 simcore::hal::MemFlags flags = simcore::hal::MemFlags::none)
       : arenas_(), nodes_(nodes), nextIndex_(0) {
     arenas_.reserve(threads);
     for (std::size_t i = 0; i < threads; ++i) {
       int node = (i < nodes_.size()) ? nodes_[i] : -1;
-      arenas_.emplace_back(perThreadCapacityBytes, baseAlignment, node);
+      arenas_.emplace_back(perThreadCapacityBytes, baseAlignment, node, flags);
     }
 
     static_assert(std::is_move_constructible<FrameArena>::value,


### PR DESCRIPTION
## Summary
- add MemFlags-based pinned/hugepage allocation and prefetch helper
- allow FrameArena to request OS huge pages and mlock at runtime
- monitor CPU temperature and degrade to a thermal limp rung

## Testing
- `cmake -S . -B build` *(fails: downloading gtest returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf584fa8a0832b83e3943c9f3cca45