### PR TITLE
Add kernel bypass IO options

### DIFF
--- a/docs/io_kernel_bypass.md
+++ b/docs/io_kernel_bypass.md
@@ -1,0 +1,25 @@
+# IO and kernel-bypass options
+
+The logging subsystem offers an asynchronous file sink tuned for stress and
+worst-case durability testing.
+
+## Disk logging
+
+`Logger::AsyncRingFileSink` supports:
+
+- Preallocating a target log file to avoid growth-related fragmentation.
+- Optional `O_DIRECT|O_DSYNC` open flags via the `directSync` constructor
+  parameter to bypass caches when benchmarking durable paths.
+- A bounded queue that drops excess log records and tracks the drop count
+  via `dropped()` so tests can assert on pressure.
+
+## Network / IPC
+
+The experimental `KernelBypassSocket` (`include/simcore/kernel_bypass.hpp`)
+wraps platform specific kernel-bypass facilities:
+
+- `io_uring` on Linux.
+- I/O completion ports on Windows.
+
+The `poll()` API allows DPDK-style busy polling for NIC-bound telemetry when
+streaming live traces.

--- a/include/simcore/kernel_bypass.hpp
+++ b/include/simcore/kernel_bypass.hpp
@@ -1,0 +1,78 @@
+#pragma once
+#include <string>
+#ifdef __linux__
+# include <sys/socket.h>
+# include <unistd.h>
+# if __has_include(<liburing.h>)
+#  include <liburing.h>
+#  define SIMCORE_HAS_IO_URING 1
+# endif
+#elif defined(_WIN32)
+# include <winsock2.h>
+# include <windows.h>
+#endif
+
+// Simple cross-platform socket wrapper enabling optional kernel bypass.
+// On Linux io_uring is used when available. On Windows I/O completion ports
+// are used.  When neither backend is available a blocking send() fallback is
+// provided.  The poll() method enables DPDK-style busy polling when desired.
+class KernelBypassSocket {
+public:
+    KernelBypassSocket();
+    ~KernelBypassSocket();
+    bool send(int fd, const std::string& data);
+    void poll();
+private:
+#ifdef SIMCORE_HAS_IO_URING
+    io_uring ring_{};
+#elif defined(_WIN32)
+    HANDLE iocp_{};
+#endif
+};
+
+inline KernelBypassSocket::KernelBypassSocket() {
+#ifdef SIMCORE_HAS_IO_URING
+    io_uring_queue_init(8, &ring_, 0);
+#elif defined(_WIN32)
+    iocp_ = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
+#endif
+}
+
+inline KernelBypassSocket::~KernelBypassSocket() {
+#ifdef SIMCORE_HAS_IO_URING
+    io_uring_queue_exit(&ring_);
+#elif defined(_WIN32)
+    if (iocp_) CloseHandle(iocp_);
+#endif
+}
+
+inline bool KernelBypassSocket::send(int fd, const std::string& data) {
+#ifdef SIMCORE_HAS_IO_URING
+    io_uring_sqe* sqe = io_uring_get_sqe(&ring_);
+    if (!sqe) return false;
+    io_uring_prep_send(sqe, fd, data.data(), data.size(), 0);
+    io_uring_submit(&ring_);
+    return true;
+#elif defined(_WIN32)
+    WSABUF buf{(ULONG)data.size(), const_cast<char*>(data.data())};
+    DWORD sent = 0; OVERLAPPED ov{};
+    return WSASend(fd, &buf, 1, &sent, 0, &ov, nullptr) == 0;
+#else
+    return ::send(fd, data.data(), data.size(), 0) == (ssize_t)data.size();
+#endif
+}
+
+inline void KernelBypassSocket::poll() {
+#ifdef SIMCORE_HAS_IO_URING
+    io_uring_cqe* cqe = nullptr;
+    while (io_uring_peek_cqe(&ring_, &cqe) == 0 && cqe) {
+        io_uring_cqe_seen(&ring_, cqe);
+    }
+#elif defined(_WIN32)
+    DWORD bytes; ULONG_PTR key; LPOVERLAPPED ov;
+    while (GetQueuedCompletionStatus(iocp_, &bytes, &key, &ov, 0)) {}
+#else
+    // no-op fallback
+#endif
+}
+

--- a/include/simcore/logger.hpp
+++ b/include/simcore/logger.hpp
@@ -73,16 +73,41 @@ public:
     public:
         explicit AsyncRingFileSink(const std::string& path,
                                    std::size_t cap = 1024,
-                                   std::chrono::milliseconds syncEvery = std::chrono::milliseconds(100))
+                                   std::chrono::milliseconds syncEvery = std::chrono::milliseconds(100),
+                                   bool directSync = false,
+                                   std::size_t preallocate = 0)
             : fd_(-1), cap_(cap), syncEvery_(syncEvery) {
 #ifdef _WIN32
             int tmp = -1;
-            if (_sopen_s(&tmp, path.c_str(), _O_CREAT | _O_APPEND | _O_WRONLY, _SH_DENYNO,
+            int oflag = _O_CREAT | _O_APPEND | _O_WRONLY;
+#ifdef _O_DSYNC
+            if (directSync) oflag |= _O_DSYNC;
+#endif
+            if (_sopen_s(&tmp, path.c_str(), oflag, _SH_DENYNO,
                           _S_IREAD | _S_IWRITE) == 0) {
                 fd_ = tmp;
+                if (fd_ >= 0 && preallocate > 0) {
+#ifdef _WIN32
+                    _chsize_s(fd_, static_cast<long long>(preallocate));
+#endif
+                }
             }
 #else
-            fd_ = ::open(path.c_str(), O_CREAT | O_APPEND | O_WRONLY, 0644);
+            int flags = O_CREAT | O_APPEND | O_WRONLY;
+            if (directSync) {
+                flags |= O_DSYNC;
+#ifdef O_DIRECT
+                flags |= O_DIRECT;
+#endif
+            }
+            fd_ = ::open(path.c_str(), flags, 0644);
+            if (fd_ >= 0 && preallocate > 0) {
+#if defined(__linux__)
+                ::posix_fallocate(fd_, 0, static_cast<off_t>(preallocate));
+#else
+                ::ftruncate(fd_, static_cast<off_t>(preallocate));
+#endif
+            }
 #endif
             if (fd_ >= 0) {
                 worker_ = std::thread([this]{ run(); });
@@ -108,10 +133,15 @@ public:
         void write(const Record& r) override {
             if (fd_ < 0) return;
             std::lock_guard<std::mutex> lk(m_);
-            if (queue_.size() >= cap_) queue_.pop_front();
+            if (queue_.size() >= cap_) {
+                ++dropped_;
+                return;
+            }
             queue_.push_back(r.msg);
             cv_.notify_one();
         }
+
+        std::size_t dropped() const { return dropped_.load(); }
 
     private:
         void flush() {
@@ -159,6 +189,7 @@ public:
         int fd_;
         std::deque<std::string> queue_;
         std::size_t cap_;
+        std::atomic<std::size_t> dropped_{0};
         std::chrono::milliseconds syncEvery_;
         std::chrono::steady_clock::time_point lastSync_{};
         std::mutex m_;

--- a/include/simcore/logger.hpp
+++ b/include/simcore/logger.hpp
@@ -82,6 +82,8 @@ public:
             int oflag = _O_CREAT | _O_APPEND | _O_WRONLY;
 #ifdef _O_DSYNC
             if (directSync) oflag |= _O_DSYNC;
+#else
+            (void)directSync;
 #endif
             if (_sopen_s(&tmp, path.c_str(), oflag, _SH_DENYNO,
                           _S_IREAD | _S_IWRITE) == 0) {

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -41,25 +41,16 @@ TEST(Logger, AsyncRingFileSinkDrops)
     auto path = fs::temp_directory_path() / "async_log_drop.log";
     std::error_code ec;
     fs::remove(path, ec);
-    auto sink = std::make_shared<Logger::AsyncRingFileSink>(path.string(), 1,
+    auto sink = std::make_shared<Logger::AsyncRingFileSink>(path.string(), 0,
                                                            std::chrono::milliseconds(100));
     {
         Logger log;
         log.addSink(sink);
-        const int threads = 8;
-        const int msgs = 200;
-        std::barrier sync(threads);
-        auto spammer = [&] {
-            sync.arrive_and_wait();
-            for (int i = 0; i < msgs; ++i) {
-                log.info("msg{}", i);
-            }
-        };
-        std::vector<std::thread> workers;
-        for (int t = 0; t < threads; ++t) workers.emplace_back(spammer);
-        for (auto &th : workers) th.join();
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        for (int i = 0; i < 10; ++i) {
+            log.info("msg{}", i);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
-    EXPECT_GT(sink->dropped(), 0u);
+    EXPECT_EQ(sink->dropped(), 10u);
     fs::remove(path);
 }

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -48,6 +48,6 @@ TEST(Logger, AsyncRingFileSinkDrops)
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
-    EXPECT_EQ(sink->dropped(), 9u);
+    EXPECT_GT(sink->dropped(), 0u);
     fs::remove(path);
 }

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -41,13 +41,14 @@ TEST(Logger, AsyncRingFileSinkDrops)
     auto path = fs::temp_directory_path() / "async_log_drop.log";
     std::error_code ec;
     fs::remove(path, ec);
-    auto sink = std::make_shared<Logger::AsyncRingFileSink>(path.string(), 1,
-                                                           std::chrono::milliseconds(100));
+    // Use a zero-capacity queue so every record is dropped deterministically.
+    auto sink = std::make_shared<Logger::AsyncRingFileSink>(
+        path.string(), 0, std::chrono::milliseconds(100));
+    constexpr int threads = 4;
+    constexpr int perThread = 1000;
     {
         Logger log;
         log.addSink(sink);
-        constexpr int threads = 4;
-        constexpr int perThread = 1000;
         std::barrier start(threads + 1);
         std::vector<std::thread> workers;
         for (int t = 0; t < threads; ++t) {
@@ -62,6 +63,7 @@ TEST(Logger, AsyncRingFileSinkDrops)
         for (auto &th : workers) th.join();
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    EXPECT_GT(sink->dropped(), 0u);
+    constexpr std::size_t expected = static_cast<std::size_t>(threads * perThread);
+    EXPECT_EQ(sink->dropped(), expected);
     fs::remove(path);
 }

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -32,3 +32,22 @@ TEST(Logger, AsyncRingFileSinkFlushes)
     EXPECT_EQ(count,10);
     fs::remove(path);
 }
+
+TEST(Logger, AsyncRingFileSinkDrops)
+{
+    namespace fs = std::filesystem;
+    auto path = fs::temp_directory_path() / "async_log_drop.log";
+    std::error_code ec;
+    fs::remove(path, ec);
+    auto sink = std::make_shared<Logger::AsyncRingFileSink>(path.string(), 1, std::chrono::milliseconds(10));
+    {
+        Logger log;
+        log.addSink(sink);
+        for(int i=0;i<10;++i){
+            log.info("msg{}", i);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    EXPECT_EQ(sink->dropped(), 9u);
+    fs::remove(path);
+}

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -41,16 +41,27 @@ TEST(Logger, AsyncRingFileSinkDrops)
     auto path = fs::temp_directory_path() / "async_log_drop.log";
     std::error_code ec;
     fs::remove(path, ec);
-    auto sink = std::make_shared<Logger::AsyncRingFileSink>(path.string(), 0,
+    auto sink = std::make_shared<Logger::AsyncRingFileSink>(path.string(), 1,
                                                            std::chrono::milliseconds(100));
     {
         Logger log;
         log.addSink(sink);
-        for (int i = 0; i < 10; ++i) {
-            log.info("msg{}", i);
+        constexpr int threads = 4;
+        constexpr int perThread = 1000;
+        std::barrier start(threads + 1);
+        std::vector<std::thread> workers;
+        for (int t = 0; t < threads; ++t) {
+            workers.emplace_back([&] {
+                start.arrive_and_wait();
+                for (int i = 0; i < perThread; ++i) {
+                    log.info("msg{}", i);
+                }
+            });
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        start.arrive_and_wait();
+        for (auto &th : workers) th.join();
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    EXPECT_EQ(sink->dropped(), 10u);
+    EXPECT_GT(sink->dropped(), 0u);
     fs::remove(path);
 }

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -43,7 +43,7 @@ TEST(Logger, AsyncRingFileSinkDrops)
     {
         Logger log;
         log.addSink(sink);
-        for(int i=0;i<10;++i){
+        for(int i=0;i<1000;++i){
             log.info("msg{}", i);
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(50));

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -65,5 +65,6 @@ TEST(Logger, AsyncRingFileSinkDrops)
     }
     constexpr std::size_t expected = static_cast<std::size_t>(threads * perThread);
     EXPECT_EQ(sink->dropped(), expected);
+    sink.reset();
     fs::remove(path);
 }

--- a/tests/test_async_logger.cpp
+++ b/tests/test_async_logger.cpp
@@ -3,6 +3,8 @@
 #include <fstream>
 #include <filesystem>
 #include <thread>
+#include <barrier>
+#include <vector>
 
 TEST(Logger, AsyncRingFileSinkFlushes)
 {
@@ -39,14 +41,24 @@ TEST(Logger, AsyncRingFileSinkDrops)
     auto path = fs::temp_directory_path() / "async_log_drop.log";
     std::error_code ec;
     fs::remove(path, ec);
-    auto sink = std::make_shared<Logger::AsyncRingFileSink>(path.string(), 1, std::chrono::milliseconds(10));
+    auto sink = std::make_shared<Logger::AsyncRingFileSink>(path.string(), 1,
+                                                           std::chrono::milliseconds(100));
     {
         Logger log;
         log.addSink(sink);
-        for(int i=0;i<1000;++i){
-            log.info("msg{}", i);
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        const int threads = 8;
+        const int msgs = 200;
+        std::barrier sync(threads);
+        auto spammer = [&] {
+            sync.arrive_and_wait();
+            for (int i = 0; i < msgs; ++i) {
+                log.info("msg{}", i);
+            }
+        };
+        std::vector<std::thread> workers;
+        for (int t = 0; t < threads; ++t) workers.emplace_back(spammer);
+        for (auto &th : workers) th.join();
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
     }
     EXPECT_GT(sink->dropped(), 0u);
     fs::remove(path);


### PR DESCRIPTION
## Summary
- support preallocated direct + dsync log files and drop metrics in AsyncRingFileSink
- provide experimental KernelBypassSocket for io_uring/IOCP style networking
- document new IO and kernel bypass options and add drop-count test

## Testing
- `cmake ..` *(fails: error downloading https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c055cdbcf0832b944be52d0a56b018