### PR TITLE
Add basic config hot reload support

### DIFF
--- a/core/include/core/config_hot_reload.hpp
+++ b/core/include/core/config_hot_reload.hpp
@@ -20,69 +20,68 @@ namespace core {
 // configuration instance so readers always observe a fully constructed object.
 class ConfigHotReloader {
 public:
-    explicit ConfigHotReloader(std::string path)
-        : path_(std::move(path)), config_(std::make_shared<Config>()),
-          last_write_() {}
+  explicit ConfigHotReloader(std::string path)
+      : path_(std::move(path)), config_(std::make_shared<Config>()),
+        last_write_() {}
 
-    // Load initial configuration from disk. Returns true on success.
-    bool load() {
-        Config cfg;
-        if (!read_from_disk(cfg, config_.load()->major)) {
-            return false;
-        }
-        config_.store(std::make_shared<Config>(cfg), std::memory_order_release);
-        last_write_ = std::filesystem::last_write_time(path_);
-        return true;
+  // Load initial configuration from disk. Returns true on success.
+  bool load() {
+    Config cfg;
+    if (!read_from_disk(cfg, std::atomic_load(&config_)->major)) {
+      return false;
     }
+    std::atomic_store(&config_, std::make_shared<Config>(cfg));
+    last_write_ = std::filesystem::last_write_time(path_);
+    return true;
+  }
 
-    // Attempt to hot reload the configuration. If the underlying file has not
-    // changed since the last successful load, this is a no-op and returns
-    // false. When the file changed, the new configuration is validated and
-    // swapped in atomically. Returns true when a new configuration was loaded.
-    bool hot_reload() {
-        std::error_code ec;
-        auto current = std::filesystem::last_write_time(path_, ec);
-        if (ec || current == last_write_) {
-            return false; // either can't stat or nothing changed
-        }
-        Config cfg;
-        if (!read_from_disk(cfg, config_.load()->major)) {
-            return false;
-        }
-        last_write_ = current;
-        config_.store(std::make_shared<Config>(cfg), std::memory_order_release);
-        return true;
+  // Attempt to hot reload the configuration. If the underlying file has not
+  // changed since the last successful load, this is a no-op and returns
+  // false. When the file changed, the new configuration is validated and
+  // swapped in atomically. Returns true when a new configuration was loaded.
+  bool hot_reload() {
+    std::error_code ec;
+    auto current = std::filesystem::last_write_time(path_, ec);
+    if (ec || current == last_write_) {
+      return false; // either can't stat or nothing changed
     }
+    Config cfg;
+    if (!read_from_disk(cfg, std::atomic_load(&config_)->major)) {
+      return false;
+    }
+    last_write_ = current;
+    std::atomic_store(&config_, std::make_shared<Config>(cfg));
+    return true;
+  }
 
-    // Obtain the current configuration snapshot.
-    std::shared_ptr<const Config> get() const noexcept {
-        return config_.load(std::memory_order_acquire);
-    }
+  // Obtain the current configuration snapshot.
+  std::shared_ptr<const Config> get() const noexcept {
+    return std::atomic_load(&config_);
+  }
 
 private:
-    bool read_from_disk(Config& out, std::uint32_t expected_major) {
-        std::ifstream in(path_, std::ios::binary);
-        if (!in.is_open()) {
-            return false;
-        }
-        std::uint32_t maj{};
-        std::uint32_t min{};
-        if (!(in >> maj >> min)) {
-            return false;
-        }
-        // Simple validation: major version must match previously loaded config.
-        if (maj != expected_major) {
-            return false;
-        }
-        out.major = maj;
-        out.minor = min;
-        return true;
+  bool read_from_disk(Config &out, std::uint32_t expected_major) {
+    std::ifstream in(path_, std::ios::binary);
+    if (!in.is_open()) {
+      return false;
     }
+    std::uint32_t maj{};
+    std::uint32_t min{};
+    if (!(in >> maj >> min)) {
+      return false;
+    }
+    // Simple validation: major version must match previously loaded config.
+    if (maj != expected_major) {
+      return false;
+    }
+    out.major = maj;
+    out.minor = min;
+    return true;
+  }
 
-    std::string path_;
-    std::atomic<std::shared_ptr<Config>> config_;
-    std::filesystem::file_time_type last_write_;
+  std::string path_;
+  std::shared_ptr<Config> config_;
+  std::filesystem::file_time_type last_write_;
 };
 
 } // namespace core
-

--- a/core/include/core/config_hot_reload.hpp
+++ b/core/include/core/config_hot_reload.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#if defined(_MSC_VER)
+#define _SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING
+#endif
+
 #include <atomic>
 #include <cstdint>
 #include <filesystem>

--- a/core/include/core/config_hot_reload.hpp
+++ b/core/include/core/config_hot_reload.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <system_error>
+
+#include "core/config.hpp"
+
+namespace core {
+
+// Simple hot-reloading wrapper around the Config structure.
+//
+// The configuration is stored on disk using a trivial two number format:
+//   <major> <minor>
+// Each reload validates the major version and atomically swaps in the new
+// configuration instance so readers always observe a fully constructed object.
+class ConfigHotReloader {
+public:
+    explicit ConfigHotReloader(std::string path)
+        : path_(std::move(path)), config_(std::make_shared<Config>()),
+          last_write_() {}
+
+    // Load initial configuration from disk. Returns true on success.
+    bool load() {
+        Config cfg;
+        if (!read_from_disk(cfg, config_.load()->major)) {
+            return false;
+        }
+        config_.store(std::make_shared<Config>(cfg), std::memory_order_release);
+        last_write_ = std::filesystem::last_write_time(path_);
+        return true;
+    }
+
+    // Attempt to hot reload the configuration. If the underlying file has not
+    // changed since the last successful load, this is a no-op and returns
+    // false. When the file changed, the new configuration is validated and
+    // swapped in atomically. Returns true when a new configuration was loaded.
+    bool hot_reload() {
+        std::error_code ec;
+        auto current = std::filesystem::last_write_time(path_, ec);
+        if (ec || current == last_write_) {
+            return false; // either can't stat or nothing changed
+        }
+        Config cfg;
+        if (!read_from_disk(cfg, config_.load()->major)) {
+            return false;
+        }
+        last_write_ = current;
+        config_.store(std::make_shared<Config>(cfg), std::memory_order_release);
+        return true;
+    }
+
+    // Obtain the current configuration snapshot.
+    std::shared_ptr<const Config> get() const noexcept {
+        return config_.load(std::memory_order_acquire);
+    }
+
+private:
+    bool read_from_disk(Config& out, std::uint32_t expected_major) {
+        std::ifstream in(path_, std::ios::binary);
+        if (!in.is_open()) {
+            return false;
+        }
+        std::uint32_t maj{};
+        std::uint32_t min{};
+        if (!(in >> maj >> min)) {
+            return false;
+        }
+        // Simple validation: major version must match previously loaded config.
+        if (maj != expected_major) {
+            return false;
+        }
+        out.major = maj;
+        out.minor = min;
+        return true;
+    }
+
+    std::string path_;
+    std::atomic<std::shared_ptr<Config>> config_;
+    std::filesystem::file_time_type last_write_;
+};
+
+} // namespace core
+

--- a/core/include/core/config_hot_reload.hpp
+++ b/core/include/core/config_hot_reload.hpp
@@ -1,20 +1,43 @@
 #pragma once
 
-#if defined(_MSC_VER)
-#define _SILENCE_CXX20_OLD_SHARED_PTR_ATOMIC_SUPPORT_DEPRECATION_WARNING
-#endif
-
 #include <atomic>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <memory>
+#include <utility>
 #include <string>
 #include <system_error>
 
 #include "core/config.hpp"
 
 namespace core {
+
+namespace detail {
+inline std::shared_ptr<Config> atomic_load_cfg(const std::shared_ptr<Config> *ptr) {
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+  auto value = std::atomic_load(ptr);
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+  return value;
+}
+
+inline void atomic_store_cfg(std::shared_ptr<Config> *ptr,
+                             std::shared_ptr<Config> value) {
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+  std::atomic_store(ptr, std::move(value));
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+}
+} // namespace detail
 
 // Simple hot-reloading wrapper around the Config structure.
 //
@@ -31,10 +54,10 @@ public:
   // Load initial configuration from disk. Returns true on success.
   bool load() {
     Config cfg;
-    if (!read_from_disk(cfg, std::atomic_load(&config_)->major)) {
+    if (!read_from_disk(cfg, detail::atomic_load_cfg(&config_)->major)) {
       return false;
     }
-    std::atomic_store(&config_, std::make_shared<Config>(cfg));
+    detail::atomic_store_cfg(&config_, std::make_shared<Config>(cfg));
     last_write_ = std::filesystem::last_write_time(path_);
     return true;
   }
@@ -50,17 +73,17 @@ public:
       return false; // either can't stat or nothing changed
     }
     Config cfg;
-    if (!read_from_disk(cfg, std::atomic_load(&config_)->major)) {
+    if (!read_from_disk(cfg, detail::atomic_load_cfg(&config_)->major)) {
       return false;
     }
     last_write_ = current;
-    std::atomic_store(&config_, std::make_shared<Config>(cfg));
+    detail::atomic_store_cfg(&config_, std::make_shared<Config>(cfg));
     return true;
   }
 
   // Obtain the current configuration snapshot.
   std::shared_ptr<const Config> get() const noexcept {
-    return std::atomic_load(&config_);
+    return detail::atomic_load_cfg(&config_);
   }
 
 private:

--- a/docs/config_hot_reload.md
+++ b/docs/config_hot_reload.md
@@ -1,0 +1,13 @@
+# Config Hot Reload
+
+This module provides a tiny hot-reload mechanism for the `core::Config` structure.
+Configuration is stored on disk in a simple textual format:
+
+```
+<major> <minor>
+```
+
+`ConfigHotReloader` watches the file's modification time and atomically swaps in
+new configuration objects when it changes.  Basic validation ensures the major
+version matches the previously loaded configuration.  The hot-reload wrapper is
+header-only and has no external dependencies.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ set(TEST_SOURCES
     test_units.cpp
     test_huge_page.cpp
     test_thermal_limp.cpp
+    test_config_hot_reload.cpp
 )
 
 if (ENABLE_RAPIDCHECK AND TARGET rapidcheck_gtest)

--- a/tests/test_config_hot_reload.cpp
+++ b/tests/test_config_hot_reload.cpp
@@ -1,28 +1,33 @@
-#include <gtest/gtest.h>
-#include <fstream>
+#include <chrono>
 #include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <thread>
 
 #include "core/config_hot_reload.hpp"
 
 TEST(ConfigHotReload, ReloadsUpdatedFile) {
-    const std::string path = "test_config.txt";
-    {
-        std::ofstream out(path);
-        out << "1 0";
-    }
+  const std::string path = "test_config.txt";
+  {
+    std::ofstream out(path);
+    out << "1 0";
+  }
 
-    core::ConfigHotReloader loader(path);
-    ASSERT_TRUE(loader.load());
-    EXPECT_EQ(loader.get()->minor, 0u);
+  core::ConfigHotReloader loader(path);
+  ASSERT_TRUE(loader.load());
+  EXPECT_EQ(loader.get()->minor, 0u);
 
-    // Update configuration on disk
-    {
-        std::ofstream out(path);
-        out << "1 1";
-    }
+  // Ensure filesystem timestamp resolution doesn't cause spurious failures
+  std::this_thread::sleep_for(std::chrono::seconds(1));
 
-    ASSERT_TRUE(loader.hot_reload());
-    EXPECT_EQ(loader.get()->minor, 1u);
+  // Update configuration on disk
+  {
+    std::ofstream out(path);
+    out << "1 1";
+  }
 
-    std::filesystem::remove(path);
+  ASSERT_TRUE(loader.hot_reload());
+  EXPECT_EQ(loader.get()->minor, 1u);
+
+  std::filesystem::remove(path);
 }

--- a/tests/test_config_hot_reload.cpp
+++ b/tests/test_config_hot_reload.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+#include <fstream>
+#include <filesystem>
+
+#include "core/config_hot_reload.hpp"
+
+TEST(ConfigHotReload, ReloadsUpdatedFile) {
+    const std::string path = "test_config.txt";
+    {
+        std::ofstream out(path);
+        out << "1 0";
+    }
+
+    core::ConfigHotReloader loader(path);
+    ASSERT_TRUE(loader.load());
+    EXPECT_EQ(loader.get()->minor, 0u);
+
+    // Update configuration on disk
+    {
+        std::ofstream out(path);
+        out << "1 1";
+    }
+
+    ASSERT_TRUE(loader.hot_reload());
+    EXPECT_EQ(loader.get()->minor, 1u);
+
+    std::filesystem::remove(path);
+}

--- a/tests/test_config_hot_reload.cpp
+++ b/tests/test_config_hot_reload.cpp
@@ -26,6 +26,9 @@ TEST(ConfigHotReload, ReloadsUpdatedFile) {
     out << "1 1";
   }
 
+  // Allow filesystem timestamp to advance after write
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
   ASSERT_TRUE(loader.hot_reload());
   EXPECT_EQ(loader.get()->minor, 1u);
 


### PR DESCRIPTION
## Summary
- add header-only ConfigHotReloader for atomic config updates
- document minimal config hot reload mechanism
- add unit test skeleton for reloading configuration files

## Testing
- `cmake ..` *(fails: Each download failed for googletest v1.14.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c078481080832b84a05413281eaf5d