### PR TITLE
Add plugin ABI with hot-plug support and docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 
-project(car_sim_core LANGUAGES CXX)
+project(car_sim_core LANGUAGES C CXX)
 
 # Options (toggle logging / profiler / tests)
 option(ENABLE_LOG "Enable logging" ON)
@@ -154,7 +154,7 @@ add_library(simcore_core INTERFACE)
 target_include_directories(simcore_core INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/core/include)
 
 # Runtime module providing C API surface
-set(RT_SOURCES rt/src/runtime.cpp)
+set(RT_SOURCES rt/src/runtime.cpp rt/src/plugin_manager.cpp)
 
 if (UNIX)
     list(APPEND RT_SOURCES rt/src/crashdump_posix.cpp)
@@ -168,6 +168,9 @@ target_include_directories(simcore_rt PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/core/include
 )
 target_link_libraries(simcore_rt PUBLIC simcore_core)
+if (UNIX)
+    target_link_libraries(simcore_rt PUBLIC dl)
+endif()
 
 # Main executable
 add_executable(simcore_app src/main.cpp)

--- a/docs/devex_governance.md
+++ b/docs/devex_governance.md
@@ -1,0 +1,21 @@
+# Developer Experience and Governance
+
+This project provides a lightweight template for adding new systems via the
+`tools/new_system.py` generator. Consistent coding style and comprehensive
+testing are required for all contributions.
+
+Plugins must adhere to the C ABI defined in `rt/plugin_api.h` and carry strict
+`abi_major` and `abi_minor` version numbers. Breaking changes require bumping
+the major version.
+
+## Contribution Workflow
+
+1. Create a feature branch and implement the change.
+2. Run `cmake` and `ctest` before submitting a pull request.
+3. Ensure new code has unit tests and documentation.
+4. Follow semantic versioning for public interfaces, including plugins.
+
+## Governance
+
+Changes are reviewed by maintainers. A quorum of two maintainers must approve
+API or ABI changes.

--- a/docs/real_time_readiness_checklist.md
+++ b/docs/real_time_readiness_checklist.md
@@ -1,0 +1,9 @@
+# Real-Time Readiness Checklist
+
+Use this checklist to assess whether the system is ready for real-time use.
+
+- [ ] Deterministic execution paths validated by unit tests.
+- [ ] All dynamic allocations are bounded or eliminated.
+- [ ] Plugins can be hot-loaded and unloaded without restarting the runtime.
+- [ ] Watchdog timers and monitoring enabled.
+- [ ] Threat model reviewed and mitigations implemented.

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -1,0 +1,11 @@
+# Threat Model
+
+This document outlines potential threats to the runtime and mitigation
+strategies.
+
+- **Plugin misuse**: Untrusted plugins could attempt to exploit the process.
+  Only load plugins from trusted sources and verify ABI versions.
+- **Resource exhaustion**: Plugins may allocate excessive memory or CPU. Use
+  runtime limits and monitoring to detect and contain abuses.
+- **Denial of Service**: Malformed inputs may trigger unexpected states.
+  Validate inputs and employ watchdog timers.

--- a/rt/include/rt/plugin_api.h
+++ b/rt/include/rt/plugin_api.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define RT_PLUGIN_API_VERSION_MAJOR 1
+#define RT_PLUGIN_API_VERSION_MINOR 0
+
+typedef struct {
+    uint32_t abi_major;
+    uint32_t abi_minor;
+    const char* name;
+    const char* version;
+} rt_plugin_desc;
+
+typedef int (*rt_plugin_init_fn)(const rt_plugin_desc* desc);
+typedef void (*rt_plugin_shutdown_fn)(void);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/rt/include/rt/plugin_api.h
+++ b/rt/include/rt/plugin_api.h
@@ -9,14 +9,14 @@ extern "C" {
 #define RT_PLUGIN_API_VERSION_MAJOR 1
 #define RT_PLUGIN_API_VERSION_MINOR 0
 
-typedef struct {
+typedef struct rt_plugin_desc {
     uint32_t abi_major;
     uint32_t abi_minor;
     const char* name;
     const char* version;
-} rt_plugin_desc;
+} rt_plugin_desc_t;
 
-typedef int (*rt_plugin_init_fn)(const rt_plugin_desc* desc);
+typedef int (*rt_plugin_init_fn)(const rt_plugin_desc_t* desc);
 typedef void (*rt_plugin_shutdown_fn)(void);
 
 #ifdef __cplusplus

--- a/rt/include/rt/plugin_manager.hpp
+++ b/rt/include/rt/plugin_manager.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+
+#include <rt/plugin_api.h>
+
+namespace rt {
+
+struct PluginHandle {
+    void* handle{nullptr};
+    rt_plugin_desc desc{};
+    rt_plugin_shutdown_fn shutdown{nullptr};
+};
+
+class PluginManager {
+public:
+    static PluginHandle load(const std::string& path);
+    static void unload(PluginHandle& plugin);
+};
+
+} // namespace rt
+

--- a/rt/include/rt/plugin_manager.hpp
+++ b/rt/include/rt/plugin_manager.hpp
@@ -8,7 +8,7 @@ namespace rt {
 
 struct PluginHandle {
     void* handle{nullptr};
-    rt_plugin_desc desc{};
+    rt_plugin_desc_t desc{};
     rt_plugin_shutdown_fn shutdown{nullptr};
 };
 

--- a/rt/src/plugin_manager.cpp
+++ b/rt/src/plugin_manager.cpp
@@ -1,0 +1,54 @@
+#include <rt/plugin_manager.hpp>
+
+#include <dlfcn.h>
+#include <stdexcept>
+
+namespace rt {
+
+PluginHandle PluginManager::load(const std::string& path) {
+    void* handle = dlopen(path.c_str(), RTLD_NOW);
+    if (!handle) {
+        throw std::runtime_error(dlerror());
+    }
+
+    auto* desc = reinterpret_cast<rt_plugin_desc*>(dlsym(handle, "rt_plugin_desc"));
+    if (!desc) {
+        dlclose(handle);
+        throw std::runtime_error("missing rt_plugin_desc symbol");
+    }
+
+    if (desc->abi_major != RT_PLUGIN_API_VERSION_MAJOR ||
+        desc->abi_minor > RT_PLUGIN_API_VERSION_MINOR) {
+        dlclose(handle);
+        throw std::runtime_error("incompatible plugin ABI version");
+    }
+
+    auto init = reinterpret_cast<rt_plugin_init_fn>(dlsym(handle, "rt_plugin_init"));
+    auto shutdown = reinterpret_cast<rt_plugin_shutdown_fn>(dlsym(handle, "rt_plugin_shutdown"));
+    if (!init || !shutdown) {
+        dlclose(handle);
+        throw std::runtime_error("missing plugin entry points");
+    }
+
+    if (init(desc) != 0) {
+        dlclose(handle);
+        throw std::runtime_error("plugin initialization failed");
+    }
+
+    PluginHandle plugin{handle, *desc, shutdown};
+    return plugin;
+}
+
+void PluginManager::unload(PluginHandle& plugin) {
+    if (plugin.handle) {
+        if (plugin.shutdown) {
+            plugin.shutdown();
+        }
+        dlclose(plugin.handle);
+        plugin.handle = nullptr;
+        plugin.shutdown = nullptr;
+    }
+}
+
+} // namespace rt
+

--- a/rt/src/plugin_manager.cpp
+++ b/rt/src/plugin_manager.cpp
@@ -1,17 +1,55 @@
 #include <rt/plugin_manager.hpp>
 
-#include <dlfcn.h>
 #include <stdexcept>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
 
 namespace rt {
 
 PluginHandle PluginManager::load(const std::string& path) {
+#if defined(_WIN32)
+    HMODULE handle = LoadLibraryA(path.c_str());
+    if (!handle) {
+        throw std::runtime_error("LoadLibrary failed");
+    }
+
+    auto* desc = reinterpret_cast<rt_plugin_desc_t*>(GetProcAddress(handle, "rt_plugin_desc"));
+    if (!desc) {
+        FreeLibrary(handle);
+        throw std::runtime_error("missing rt_plugin_desc symbol");
+    }
+
+    if (desc->abi_major != RT_PLUGIN_API_VERSION_MAJOR ||
+        desc->abi_minor > RT_PLUGIN_API_VERSION_MINOR) {
+        FreeLibrary(handle);
+        throw std::runtime_error("incompatible plugin ABI version");
+    }
+
+    auto init = reinterpret_cast<rt_plugin_init_fn>(GetProcAddress(handle, "rt_plugin_init"));
+    auto shutdown = reinterpret_cast<rt_plugin_shutdown_fn>(GetProcAddress(handle, "rt_plugin_shutdown"));
+    if (!init || !shutdown) {
+        FreeLibrary(handle);
+        throw std::runtime_error("missing plugin entry points");
+    }
+
+    if (init(desc) != 0) {
+        FreeLibrary(handle);
+        throw std::runtime_error("plugin initialization failed");
+    }
+
+    PluginHandle plugin{handle, *desc, shutdown};
+    return plugin;
+#else
     void* handle = dlopen(path.c_str(), RTLD_NOW);
     if (!handle) {
         throw std::runtime_error(dlerror());
     }
 
-    auto* desc = reinterpret_cast<rt_plugin_desc*>(dlsym(handle, "rt_plugin_desc"));
+    auto* desc = reinterpret_cast<rt_plugin_desc_t*>(dlsym(handle, "rt_plugin_desc"));
     if (!desc) {
         dlclose(handle);
         throw std::runtime_error("missing rt_plugin_desc symbol");
@@ -37,9 +75,20 @@ PluginHandle PluginManager::load(const std::string& path) {
 
     PluginHandle plugin{handle, *desc, shutdown};
     return plugin;
+#endif
 }
 
 void PluginManager::unload(PluginHandle& plugin) {
+#if defined(_WIN32)
+    if (plugin.handle) {
+        if (plugin.shutdown) {
+            plugin.shutdown();
+        }
+        FreeLibrary(static_cast<HMODULE>(plugin.handle));
+        plugin.handle = nullptr;
+        plugin.shutdown = nullptr;
+    }
+#else
     if (plugin.handle) {
         if (plugin.shutdown) {
             plugin.shutdown();
@@ -48,6 +97,7 @@ void PluginManager::unload(PluginHandle& plugin) {
         plugin.handle = nullptr;
         plugin.shutdown = nullptr;
     }
+#endif
 }
 
 } // namespace rt

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,9 +78,10 @@ target_include_directories(test_incompatible_plugin PRIVATE ${CMAKE_SOURCE_DIR}/
 set_target_properties(test_incompatible_plugin PROPERTIES OUTPUT_NAME bad_plugin)
 
 add_dependencies(simcore_tests test_sample_plugin test_incompatible_plugin)
-target_compile_definitions(simcore_tests PRIVATE \
-    PLUGIN_PATH="$<TARGET_FILE:test_sample_plugin>" \
-    BAD_PLUGIN_PATH="$<TARGET_FILE:test_incompatible_plugin>")
+target_compile_definitions(simcore_tests PRIVATE
+    PLUGIN_PATH="$<TARGET_FILE:test_sample_plugin>"
+    BAD_PLUGIN_PATH="$<TARGET_FILE:test_incompatible_plugin>"
+)
 
 add_test(NAME simcore_all COMMAND simcore_tests)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ set(TEST_SOURCES
     test_huge_page.cpp
     test_thermal_limp.cpp
     test_config_hot_reload.cpp
+    test_plugin_manager.cpp
 )
 
 if (ENABLE_RAPIDCHECK AND TARGET rapidcheck_gtest)
@@ -67,6 +68,19 @@ target_include_directories(simcore_tests PRIVATE
     ${CMAKE_SOURCE_DIR}
 )
 target_compile_definitions(simcore_tests PRIVATE PROJECT_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+
+add_library(test_sample_plugin SHARED sample_plugin.c)
+target_include_directories(test_sample_plugin PRIVATE ${CMAKE_SOURCE_DIR}/rt/include)
+set_target_properties(test_sample_plugin PROPERTIES OUTPUT_NAME sample_plugin)
+
+add_library(test_incompatible_plugin SHARED sample_plugin_bad.c)
+target_include_directories(test_incompatible_plugin PRIVATE ${CMAKE_SOURCE_DIR}/rt/include)
+set_target_properties(test_incompatible_plugin PROPERTIES OUTPUT_NAME bad_plugin)
+
+add_dependencies(simcore_tests test_sample_plugin test_incompatible_plugin)
+target_compile_definitions(simcore_tests PRIVATE \
+    PLUGIN_PATH="$<TARGET_FILE:test_sample_plugin>" \
+    BAD_PLUGIN_PATH="$<TARGET_FILE:test_incompatible_plugin>")
 
 add_test(NAME simcore_all COMMAND simcore_tests)
 

--- a/tests/sample_plugin.c
+++ b/tests/sample_plugin.c
@@ -1,0 +1,24 @@
+#include <rt/plugin_api.h>
+
+static int initialized = 0;
+
+rt_plugin_desc rt_plugin_desc = {
+    RT_PLUGIN_API_VERSION_MAJOR,
+    RT_PLUGIN_API_VERSION_MINOR,
+    "test_sample_plugin",
+    "1.0"
+};
+
+int rt_plugin_init(const rt_plugin_desc* desc) {
+    (void)desc;
+    initialized = 1;
+    return 0;
+}
+
+void rt_plugin_shutdown(void) {
+    initialized = 0;
+}
+
+int rt_plugin_is_initialized(void) {
+    return initialized;
+}

--- a/tests/sample_plugin.c
+++ b/tests/sample_plugin.c
@@ -1,24 +1,30 @@
 #include <rt/plugin_api.h>
 
+#ifdef _WIN32
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
 static int initialized = 0;
 
-rt_plugin_desc rt_plugin_desc = {
+EXPORT rt_plugin_desc_t rt_plugin_desc = {
     RT_PLUGIN_API_VERSION_MAJOR,
     RT_PLUGIN_API_VERSION_MINOR,
     "test_sample_plugin",
     "1.0"
 };
 
-int rt_plugin_init(const rt_plugin_desc* desc) {
+EXPORT int rt_plugin_init(const rt_plugin_desc_t* desc) {
     (void)desc;
     initialized = 1;
     return 0;
 }
 
-void rt_plugin_shutdown(void) {
+EXPORT void rt_plugin_shutdown(void) {
     initialized = 0;
 }
 
-int rt_plugin_is_initialized(void) {
+EXPORT int rt_plugin_is_initialized(void) {
     return initialized;
 }

--- a/tests/sample_plugin_bad.c
+++ b/tests/sample_plugin_bad.c
@@ -1,15 +1,21 @@
 #include <rt/plugin_api.h>
 
-rt_plugin_desc rt_plugin_desc = {
+#ifdef _WIN32
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT
+#endif
+
+EXPORT rt_plugin_desc_t rt_plugin_desc = {
     RT_PLUGIN_API_VERSION_MAJOR + 1,
     0,
     "bad_plugin",
-    "1.0"
+    "1.0",
 };
 
-int rt_plugin_init(const rt_plugin_desc* desc) {
+EXPORT int rt_plugin_init(const rt_plugin_desc_t* desc) {
     (void)desc;
     return 0;
 }
 
-void rt_plugin_shutdown(void) {}
+EXPORT void rt_plugin_shutdown(void) {}

--- a/tests/sample_plugin_bad.c
+++ b/tests/sample_plugin_bad.c
@@ -1,0 +1,15 @@
+#include <rt/plugin_api.h>
+
+rt_plugin_desc rt_plugin_desc = {
+    RT_PLUGIN_API_VERSION_MAJOR + 1,
+    0,
+    "bad_plugin",
+    "1.0"
+};
+
+int rt_plugin_init(const rt_plugin_desc* desc) {
+    (void)desc;
+    return 0;
+}
+
+void rt_plugin_shutdown(void) {}

--- a/tests/test_plugin_manager.cpp
+++ b/tests/test_plugin_manager.cpp
@@ -2,12 +2,18 @@
 
 #include <rt/plugin_manager.hpp>
 
+#if defined(_WIN32)
+#include <windows.h>
+#define GETSYM(h, sym) GetProcAddress((HMODULE)(h), (sym))
+#else
 #include <dlfcn.h>
+#define GETSYM(h, sym) dlsym((h), (sym))
+#endif
 
 TEST(PluginManager, LoadAndUnload) {
     auto plugin = rt::PluginManager::load(PLUGIN_PATH);
     EXPECT_STREQ(plugin.desc.name, "test_sample_plugin");
-    auto is_init = reinterpret_cast<int (*)()>(dlsym(plugin.handle, "rt_plugin_is_initialized"));
+    auto is_init = reinterpret_cast<int (*)()>(GETSYM(plugin.handle, "rt_plugin_is_initialized"));
     ASSERT_TRUE(is_init);
     EXPECT_EQ(is_init(), 1);
     rt::PluginManager::unload(plugin);

--- a/tests/test_plugin_manager.cpp
+++ b/tests/test_plugin_manager.cpp
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+
+#include <rt/plugin_manager.hpp>
+
+#include <dlfcn.h>
+
+TEST(PluginManager, LoadAndUnload) {
+    auto plugin = rt::PluginManager::load(PLUGIN_PATH);
+    EXPECT_STREQ(plugin.desc.name, "test_sample_plugin");
+    auto is_init = reinterpret_cast<int (*)()>(dlsym(plugin.handle, "rt_plugin_is_initialized"));
+    ASSERT_TRUE(is_init);
+    EXPECT_EQ(is_init(), 1);
+    rt::PluginManager::unload(plugin);
+    EXPECT_EQ(plugin.handle, nullptr);
+}
+
+TEST(PluginManager, VersionMismatch) {
+    EXPECT_THROW(rt::PluginManager::load(BAD_PLUGIN_PATH), std::runtime_error);
+}

--- a/tools/new_system.py
+++ b/tools/new_system.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Generate a new system skeleton with tests and benchmarks."""
+
+import argparse
+import pathlib
+import textwrap
+
+TEMPLATE_MAIN = """#include <iostream>
+
+int main() {
+    std::cout << "Hello from {name}!\n";
+    return 0;
+}
+"""
+
+TEMPLATE_TEST = """#include <gtest/gtest.h>
+
+TEST({name}, Basic) {
+    // TODO: add meaningful tests
+    EXPECT_EQ(1, 1);
+}
+"""
+
+TEMPLATE_BENCH = """// TODO: add benchmarks for {name}
+"""
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate new system skeleton")
+    parser.add_argument("name", help="System name")
+    args = parser.parse_args()
+
+    root = pathlib.Path(args.name)
+    (root / "src").mkdir(parents=True, exist_ok=True)
+    (root / "tests").mkdir(parents=True, exist_ok=True)
+    (root / "bench").mkdir(parents=True, exist_ok=True)
+
+    (root / "src" / f"{args.name}.cpp").write_text(TEMPLATE_MAIN.format(name=args.name))
+    (root / "tests" / f"test_{args.name}.cpp").write_text(TEMPLATE_TEST.format(name=args.name))
+    (root / "bench" / f"{args.name}_bench.cpp").write_text(TEMPLATE_BENCH.format(name=args.name))
+
+    print(f"Generated skeleton for {args.name} in {root.resolve()}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- define C plugin ABI with strict versioning
- add plugin manager enabling hot plugin load/unload
- provide skeleton generator and governance/threat documentation

## Testing
- `cmake -S . -B build` *(fails: cannot download googletest)*
- `cmake -S . -B build -DENABLE_TESTS=OFF`
- `cmake --build build`


------
https://chatgpt.com/codex/tasks/task_e_68c0b783d0f4832baa9db3535c76fcfe