### PR TITLE
Add deterministic numerics utilities and tests

### DIFF
--- a/docs/numerics.md
+++ b/docs/numerics.md
@@ -1,0 +1,28 @@
+# Numerics & Determinism
+
+This project treats numerical determinism as a first-class goal.
+
+## Mixed-Precision Reductions
+
+`robust::sum_fp32_to_fp64` explicitly promotes single-precision streams
+to double precision for reductions. For sensitive paths,
+`robust::kahan_sum_fp32` provides compensated summation.
+
+## Shadow Arithmetic
+
+Tests use double precision "shadow" values and
+`robust::ulp_distance` to track error growth and detect unstable
+kernels.
+
+## Denormals & FMA Control
+
+`rt::init_fp_env` sets FE_TONEAREST and enables flush-to-zero and
+denormals-are-zero per thread. `rt::set_use_fma` gates fused
+multiply-add so behaviour is deterministic across targets.
+
+## Fixed-Point Option
+
+For hard real-time subsystems a small fixed-point type `rt::Q16_16`
+implements deterministic arithmetic without relying on floating point
+hardware.
+

--- a/include/simcore/robust_fp.hpp
+++ b/include/simcore/robust_fp.hpp
@@ -12,6 +12,35 @@ inline double safe_rsqrt(double x, double eps = 1e-12) {
     return 1.0 / std::sqrt(x);
 }
 
+// Accumulate a range of float values into double precision. This makes
+// the mixed-precision policy explicit for code paths where FP32 data is
+// reduced using FP64 accumulation.
+template <class It>
+double sum_fp32_to_fp64(It begin, It end) {
+    double acc = 0.0;
+    for (It it = begin; it != end; ++it) {
+        acc += static_cast<double>(*it);
+    }
+    return acc;
+}
+
+// Kahan/Babushka summation for a range of float values with a double
+// accumulator. Useful for highly sensitive reductions where classical
+// FP32->FP64 promotion is still not accurate enough.
+template <class It>
+double kahan_sum_fp32(It begin, It end) {
+    double sum = 0.0;
+    double c = 0.0; // compensation
+    for (It it = begin; it != end; ++it) {
+        double val = static_cast<double>(*it);
+        double y = val - c;
+        double t = sum + y;
+        c = (t - sum) - y;
+        sum = t;
+    }
+    return sum;
+}
+
 // Classic Kahan summation for improved accuracy.
 template <class It>
 double kahan_sum(It begin, It end) {

--- a/rt/include/rt/fixed_point.hpp
+++ b/rt/include/rt/fixed_point.hpp
@@ -1,0 +1,56 @@
+#pragma once
+#include <cstdint>
+#include <cmath>
+
+namespace rt {
+
+// Simple fixed-point type with configurable fractional bits. This is
+// intended for hard real-time paths where floating point determinism is
+// not sufficient.
+
+template <int FractionBits>
+class FixedPoint {
+    using storage_t = std::int32_t;
+    storage_t value_;
+    static constexpr storage_t scale = storage_t{1} << FractionBits;
+
+public:
+    constexpr FixedPoint() : value_(0) {}
+    static constexpr int frac_bits = FractionBits;
+
+    static constexpr FixedPoint fromRaw(storage_t v) {
+        FixedPoint fp;
+        fp.value_ = v;
+        return fp;
+    }
+
+    static constexpr FixedPoint fromFloat(float f) {
+        return fromRaw(static_cast<storage_t>(std::llround(f * scale)));
+    }
+
+    float toFloat() const {
+        return static_cast<float>(value_) / static_cast<float>(scale);
+    }
+
+    constexpr FixedPoint operator+(FixedPoint rhs) const {
+        return fromRaw(value_ + rhs.value_);
+    }
+    constexpr FixedPoint operator-(FixedPoint rhs) const {
+        return fromRaw(value_ - rhs.value_);
+    }
+    constexpr FixedPoint operator*(FixedPoint rhs) const {
+        std::int64_t prod = static_cast<std::int64_t>(value_) * rhs.value_;
+        return fromRaw(static_cast<storage_t>(prod >> FractionBits));
+    }
+
+    constexpr bool operator==(FixedPoint rhs) const {
+        return value_ == rhs.value_;
+    }
+
+    storage_t raw() const { return value_; }
+};
+
+using Q16_16 = FixedPoint<16>;
+
+} // namespace rt
+

--- a/tests/test_numerics.cpp
+++ b/tests/test_numerics.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 #include <rt/numerics.hpp>
+#include <rt/fixed_point.hpp>
+#include <simcore/robust_fp.hpp>
 #include <cfenv>
+#include <limits>
 
 TEST(Numerics, InitFpEnvSetsTonearest) {
     std::fesetround(FE_DOWNWARD);
@@ -14,4 +17,30 @@ TEST(Numerics, FmaGateStable) {
     rt::set_use_fma(false);
     double y = rt::fma(1.0, 2.0, 3.0);
     EXPECT_EQ(x, y);
+}
+
+TEST(Numerics, InitFpEnvFlushesDenormals) {
+    rt::init_fp_env();
+    volatile float x = std::numeric_limits<float>::denorm_min();
+    // DAZ should treat the denorm input as zero
+    float y = x + 1.0f;
+    EXPECT_EQ(y, 1.0f);
+}
+
+TEST(Numerics, FmaGateUlpStable) {
+    rt::set_use_fma(true);
+    double a = rt::fma(1e308, 1e-308, 1.0);
+    rt::set_use_fma(false);
+    double b = rt::fma(1e308, 1e-308, 1.0);
+    EXPECT_EQ(robust::ulp_distance(a, b), 0u);
+}
+
+TEST(Numerics, FixedPointBasicOps) {
+    using rt::Q16_16;
+    Q16_16 a = Q16_16::fromFloat(1.5f);
+    Q16_16 b = Q16_16::fromFloat(2.25f);
+    Q16_16 sum = a + b;
+    EXPECT_NEAR(sum.toFloat(), 3.75f, 1e-5f);
+    Q16_16 prod = a * b;
+    EXPECT_NEAR(prod.toFloat(), 3.375f, 1e-5f);
 }

--- a/tests/test_robust_fp.cpp
+++ b/tests/test_robust_fp.cpp
@@ -38,7 +38,8 @@ TEST(RobustFP, FloatReductionMixedPrecision) {
 
     double mixed = robust::sum_fp32_to_fp64(v.begin(), v.end());
     EXPECT_GT(mixed, static_cast<double>(naive));
-    EXPECT_NEAR(mixed, 1000000.0 * 1e-7, 1e-9);
+    double expected = static_cast<double>(v.size()) * static_cast<double>(1e-7f);
+    EXPECT_NEAR(mixed, expected, 5e-10);
 }
 
 TEST(RobustFP, KahanFloatReduction) {
@@ -46,10 +47,14 @@ TEST(RobustFP, KahanFloatReduction) {
     v.push_back(1.0f);
     v.insert(v.end(), 1000000, 1e-8f);
 
+    float naive = 0.0f;
+    for (float x : v) naive += x;
     double mixed = robust::sum_fp32_to_fp64(v.begin(), v.end());
     double kahan = robust::kahan_sum_fp32(v.begin(), v.end());
-    EXPECT_GT(kahan, mixed);
-    EXPECT_NEAR(kahan, 1.0 + 1000000.0 * 1e-8, 1e-12);
+    EXPECT_GT(kahan, static_cast<double>(naive));
+    EXPECT_NEAR(kahan, mixed, 1e-12);
+    double expected = 1.0 + static_cast<double>(v.size()) * static_cast<double>(1e-8f);
+    EXPECT_NEAR(kahan, expected, 5e-11);
 }
 
 TEST(RobustFP, ShadowArithmeticDetectsInstability) {
@@ -57,8 +62,8 @@ TEST(RobustFP, ShadowArithmeticDetectsInstability) {
     float a = 1e8f;
     float b = -1e8f;
     float c = 1.0f;
-    float result = (a + b) + c; // loses the c contribution
-    double shadow = (static_cast<double>(a) + static_cast<double>(b)) + static_cast<double>(c);
+    float result = (a + c) + b; // loses the c contribution
+    double shadow = (static_cast<double>(a) + static_cast<double>(c)) + static_cast<double>(b);
     std::uint64_t ulp = robust::ulp_distance(static_cast<double>(result), shadow);
     EXPECT_GT(ulp, 0u); // shadow arithmetic detects the loss
 }

--- a/tests/test_robust_fp.cpp
+++ b/tests/test_robust_fp.cpp
@@ -53,7 +53,8 @@ TEST(RobustFP, KahanFloatReduction) {
     double kahan = robust::kahan_sum_fp32(v.begin(), v.end());
     EXPECT_GT(kahan, static_cast<double>(naive));
     EXPECT_NEAR(kahan, mixed, 1e-12);
-    double expected = 1.0 + static_cast<double>(v.size()) * static_cast<double>(1e-8f);
+    double expected = 1.0 +
+        static_cast<double>(v.size() - 1) * static_cast<double>(1e-8f);
     EXPECT_NEAR(kahan, expected, 5e-11);
 }
 

--- a/tests/test_robust_fp.cpp
+++ b/tests/test_robust_fp.cpp
@@ -2,6 +2,7 @@
 #include <simcore/robust_fp.hpp>
 #include <vector>
 #include <limits>
+#include <cstdint>
 
 TEST(RobustFP, SafeRsqrtFinite) {
     double r = robust::safe_rsqrt(0.0);
@@ -27,4 +28,37 @@ TEST(RobustFP, KahanImprovesSumULP) {
     const double expected = 1.0 + 1e-14;
     EXPECT_GT(kahan, naive);              // should accumulate more
     EXPECT_NEAR(kahan, expected, 1e-15);   // close to exact result
+}
+
+TEST(RobustFP, FloatReductionMixedPrecision) {
+    // Many small FP32 values lose precision when accumulated in float.
+    std::vector<float> v(1000000, 1e-7f);
+    float naive = 0.0f;
+    for (float x : v) naive += x;
+
+    double mixed = robust::sum_fp32_to_fp64(v.begin(), v.end());
+    EXPECT_GT(mixed, static_cast<double>(naive));
+    EXPECT_NEAR(mixed, 1000000.0 * 1e-7, 1e-9);
+}
+
+TEST(RobustFP, KahanFloatReduction) {
+    std::vector<float> v;
+    v.push_back(1.0f);
+    v.insert(v.end(), 1000000, 1e-8f);
+
+    double mixed = robust::sum_fp32_to_fp64(v.begin(), v.end());
+    double kahan = robust::kahan_sum_fp32(v.begin(), v.end());
+    EXPECT_GT(kahan, mixed);
+    EXPECT_NEAR(kahan, 1.0 + 1000000.0 * 1e-8, 1e-12);
+}
+
+TEST(RobustFP, ShadowArithmeticDetectsInstability) {
+    // Catastrophic cancellation in single precision.
+    float a = 1e8f;
+    float b = -1e8f;
+    float c = 1.0f;
+    float result = (a + b) + c; // loses the c contribution
+    double shadow = (static_cast<double>(a) + static_cast<double>(b)) + static_cast<double>(c);
+    std::uint64_t ulp = robust::ulp_distance(static_cast<double>(result), shadow);
+    EXPECT_GT(ulp, 0u); // shadow arithmetic detects the loss
 }


### PR DESCRIPTION
## Summary
- add explicit mixed-precision and Kahan FP32->FP64 reductions
- add fixed-point `Q16_16` for hard realtime paths
- document numerics determinism and add tests for FP env, shadow arithmetic, and fixed point

## Testing
- `cmake -DENABLE_TESTS=ON -DCMAKE_BUILD_TYPE=Debug ..` *(fails: cannot download googletest due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c126f67c832b9765feca5a0d5570