### PR TITLE
chore: add build tooling presets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ option(ENABLE_LOG "Enable logging" ON)
 option(ENABLE_PROF "Enable profiler" ON)
 option(ENABLE_TESTS "Build tests" ON)
 option(ENABLE_RAPIDCHECK "Enable RapidCheck property tests" OFF)
+option(SIM_ENABLE_IWYU "Run include-what-you-use during builds" OFF)
+option(SIM_WARN_ODR "Enable -Wodr to detect ODR violations" OFF)
 
 # Sanitizer toggles (semicolons to enable multiple: address;thread;leak;memory;hwaddress;safe-stack;cfi)
 set(SIM_SANITIZERS "" CACHE STRING "Sanitizers to enable for all targets")
@@ -32,6 +34,21 @@ if (SIM_SANITIZERS AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
     add_compile_options(-flto)
     add_link_options(-flto)
   endif()
+endif()
+
+# IWYU
+if (SIM_ENABLE_IWYU)
+  find_program(IWYU_PATH NAMES include-what-you-use iwyu)
+  if (IWYU_PATH)
+    set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE ${IWYU_PATH})
+  else()
+    message(WARNING "include-what-you-use requested but not found")
+  endif()
+endif()
+
+# ODR warnings
+if (SIM_WARN_ODR AND CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+  add_compile_options(-Wodr)
 endif()
 
 # LTO
@@ -188,6 +205,15 @@ add_subdirectory(samples)
 if (ENABLE_TESTS)
     enable_testing()
     add_subdirectory(tests)
+endif()
+
+# Optional Bloaty size analysis
+find_program(BLOATY_EXE NAMES bloaty)
+if (BLOATY_EXE)
+  add_custom_target(bloaty
+    COMMAND ${BLOATY_EXE} $<TARGET_FILE:simcore_app> -d compileunits,symbols -n 0.1
+    DEPENDS simcore_app
+    COMMENT "Run Bloaty on simcore_app")
 endif()
 
 add_custom_target(tests

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,60 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "dev",
+      "displayName": "Dev",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/dev",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_TESTS": "ON"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release with ThinLTO",
+      "inherits": "dev",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "SIM_ENABLE_LTO": "ON",
+        "SIM_LTO_THIN": "ON"
+      }
+    },
+    {
+      "name": "pgo-generate",
+      "displayName": "PGO Generate",
+      "inherits": "release",
+      "binaryDir": "${sourceDir}/build/pgo-gen",
+      "cacheVariables": {
+        "SIM_PGO": "gen",
+        "SIM_PGO_PROFILE": "${sourceDir}/profiles/gen"
+      }
+    },
+    {
+      "name": "pgo-use",
+      "displayName": "PGO Use",
+      "inherits": "release",
+      "binaryDir": "${sourceDir}/build/pgo-use",
+      "cacheVariables": {
+        "SIM_PGO": "use",
+        "SIM_PGO_PROFILE": "${sourceDir}/profiles/gen"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "dev", "configurePreset": "dev" },
+    { "name": "release", "configurePreset": "release" },
+    { "name": "pgo-generate", "configurePreset": "pgo-generate" },
+    { "name": "pgo-use", "configurePreset": "pgo-use" }
+  ],
+  "testPresets": [
+    { "name": "dev", "configurePreset": "dev" }
+  ]
+}

--- a/cmake/toolchains/clang.cmake
+++ b/cmake/toolchains/clang.cmake
@@ -1,0 +1,3 @@
+set(CMAKE_C_COMPILER clang)
+set(CMAKE_CXX_COMPILER clang++)
+set(CMAKE_CXX_STANDARD 20)

--- a/docs/build_tooling.md
+++ b/docs/build_tooling.md
@@ -1,0 +1,43 @@
+# Build and Tooling Guide
+
+This project supports a number of build helpers to aid in size and
+performance tuning.
+
+## CMake presets and toolchains
+
+Use the provided `CMakePresets.json` for common configurations:
+
+```
+cmake --preset dev      # Debug build with tests
+cmake --preset release  # Release build with ThinLTO
+cmake --preset pgo-generate  # Instrumentation phase
+cmake --preset pgo-use       # Optimisation phase using collected profile
+```
+
+A simple Clang toolchain is available in `cmake/toolchains/clang.cmake`.
+
+## PGO and ThinLTO
+
+PGO can be executed in two phases. The presets above store profiles under
+`profiles/` allowing separate generation and use steps.
+
+## Size analysis with Bloaty
+
+If [Bloaty](https://github.com/google/bloaty) is installed a `bloaty`
+custom target is generated. Invoke it after building to inspect code bloat:
+
+```
+cmake --build build/release
+cmake --build build/release --target bloaty
+```
+
+## Header hygiene
+
+Enable include-what-you-use and ODR warnings by toggling the options:
+
+```
+-DSIM_ENABLE_IWYU=ON -DSIM_WARN_ODR=ON
+```
+
+These checks help keep headers minimal and catch One Definition Rule
+violations early.

--- a/vcpkg-lock.json
+++ b/vcpkg-lock.json
@@ -1,0 +1,4 @@
+{
+  "version": 1,
+  "packages": {}
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,6 @@
+{
+  "name": "cpp-rt-car",
+  "version-string": "0.1.0",
+  "builtin-baseline": "3f7e1436a0b11806abbddce274164a491091223e",
+  "dependencies": []
+}


### PR DESCRIPTION
## Summary
- add CMake presets and clang toolchain file
- expose IWYU and ODR warning toggles in CMake
- wire optional Bloaty size analysis target
- document build and tooling workflow
- pin empty vcpkg lockfile

## Testing
- `cmake -S . -B build` *(fails: Each download failed! status_code: 22)*
- `cmake -S . -B build -DENABLE_TESTS=OFF`
- `cmake --build build`
- `ctest --test-dir build` *(no tests found)*
- `cmake --build build --target bloaty` *(fails: No rule to make target 'bloaty')*

------
https://chatgpt.com/codex/tasks/task_e_68c18a353ac0832b971e47354967e379