### PR TITLE
Standardize timing on HighResClock

### DIFF
--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -24,6 +24,7 @@
 #include "frame_arena.hpp"
 #include "logger.hpp"
 #include "profiler.hpp"
+#include "highres_clock.hpp"
 #include "worker_pool.hpp"
 #include <rt/fiber_pool.hpp>
 #include <rt/numerics.hpp>
@@ -106,7 +107,7 @@ struct DetRangeReductionRef {
 class SimCore {
 public:
   using Seconds = std::chrono::duration<double>;
-  using Clock = std::chrono::steady_clock;
+  using Clock = HighResClock;
   using TaskHint = ::TaskHint;
 
   int bursts() const { return bursts_; }
@@ -266,6 +267,7 @@ public:
 #else
     machineId_ = "windows";
 #endif
+    HighResClock::init();
     applySettings(s);
     initThreads();
   }
@@ -908,24 +910,22 @@ private:
     // Frame-level profiler scope
     PROF_SCOPE(profiler_, "Frame");
 
-    auto computeStart = Clock::now();
+    uint64_t computeStart = Clock::now();
     executeFrame();
-    auto computeEnd = Clock::now();
+    uint64_t computeEnd = Clock::now();
 
-    const double computeMs =
-        std::chrono::duration<double, std::milli>(computeEnd - computeStart)
-            .count();
+    const double computeMs = Clock::to_ms(computeEnd - computeStart);
     updateBudget(computeMs);
 
     // feed-forward: build headroom (do BEFORE sleeping)
     if (settings_.predictiveEnable) {
       // headroom to the *next* frame target (not just-finished frame)
-      auto nowBeforePre = Clock::now();
-      const auto nextFrameTarget =
-          nextTarget_ + std::chrono::duration_cast<Clock::duration>(dt_);
-      const auto aheadDur = nextFrameTarget - nowBeforePre;
+      uint64_t nowBeforePre = Clock::now();
+      const uint64_t nextFrameTarget = nextTarget_ + dtNs_;
+      const int64_t aheadDur = static_cast<int64_t>(nextFrameTarget) -
+                               static_cast<int64_t>(nowBeforePre);
       const double aheadFr =
-          std::chrono::duration<double>(aheadDur).count() / dt_.count();
+          (static_cast<double>(aheadDur) / 1e9) / dt_.count();
 
       // decide desired number (based on slope, warmup, etc.)
       const double slope = computeSlopeMsPerFrame();
@@ -946,40 +946,42 @@ private:
           break;
 
         // Execute one extra frame right now
-        auto cs = Clock::now();
+        uint64_t cs = Clock::now();
         executeFrame();
-        auto ce = Clock::now();
+        uint64_t ce = Clock::now();
 
         // keep budget accounting for each pre-step
-        double cm = std::chrono::duration<double, std::milli>(ce - cs).count();
+        double cm = Clock::to_ms(ce - cs);
         updateBudget(cm);
 
         // each pre-step moves the schedule forward by dt
-        nextTarget_ += std::chrono::duration_cast<Clock::duration>(dt_);
+        nextTarget_ += dtNs_;
         ++preSteps_;
       }
     }
 
-    nextTarget_ += std::chrono::duration_cast<Clock::duration>(dt_);
+    nextTarget_ += dtNs_;
 
-    auto now = Clock::now();
+    uint64_t now = Clock::now();
     if (now < nextTarget_) {
-      auto remain = std::chrono::duration_cast<std::chrono::microseconds>(
-          nextTarget_ - now);
-      if (remain.count() > settings_.spinMicros)
+      uint64_t remain = nextTarget_ - now;
+      if (remain > static_cast<uint64_t>(settings_.spinMicros) * 1000ULL)
         std::this_thread::sleep_for(
-            remain - std::chrono::microseconds(settings_.spinMicros));
-      else { /* busy */
+            std::chrono::nanoseconds(remain -
+                                     static_cast<uint64_t>(settings_.spinMicros) *
+                                         1000ULL));
+      else {
       }
     }
 
     // reactive fallback
     if (settings_.adaptive) {
       logDrift();
-      auto behind = Clock::now() - nextTarget_;
-      if (behind.count() > 0) {
+      int64_t behind = static_cast<int64_t>(Clock::now()) -
+                       static_cast<int64_t>(nextTarget_);
+      if (behind > 0) {
         int extra =
-            int(std::chrono::duration<double>(behind).count() / dt_.count());
+            int((static_cast<double>(behind) / 1e9) / dt_.count());
         if (extra > settings_.maxCatchUp)
           extra = settings_.maxCatchUp;
 
@@ -993,11 +995,10 @@ private:
           if (settings_.maxFrames >= 0 && frame_ >= settings_.maxFrames)
             break;
 
-          auto cs = Clock::now();
+          uint64_t cs = Clock::now();
           executeFrame();
-          auto ce = Clock::now();
-          double cm =
-              std::chrono::duration<double, std::milli>(ce - cs).count();
+          uint64_t ce = Clock::now();
+          double cm = Clock::to_ms(ce - cs);
           updateBudget(cm);
         }
       }
@@ -1282,9 +1283,9 @@ private:
       return;
     if (frame_ % settings_.driftLogInterval)
       return;
-    auto now = Clock::now();
+    uint64_t now = Clock::now();
     double simT = static_cast<double>(frame_) * dt_.count();
-    double realT = std::chrono::duration<double>(now - startReal_).count();
+    double realT = static_cast<double>(now - startReal_) / 1e9;
     lastDriftMs_ = (simT - realT) * 1000.0;
     if (logger_)
       LOG_INFO(logger_, "[DRIFT] frame={} drift={:.2f}ms", frame_,
@@ -1296,7 +1297,7 @@ private:
         (settings_.hz > 1000.0) ? int(std::ceil(settings_.hz / 1000.0)) : 1;
     dt_ = Seconds{1.0 / settings_.hz};
     outerDt_ = dt_ * subSteps_;
-    outerDtChrono_ = std::chrono::duration_cast<Clock::duration>(outerDt_);
+    dtNs_ = static_cast<std::uint64_t>(dt_.count() * 1'000'000'000.0);
     startReal_ = Clock::now();
   }
 
@@ -1413,9 +1414,9 @@ private:
   int subSteps_ = 1;
   Seconds dt_{1.0 / 500.0};
   Seconds outerDt_{dt_};
-  Clock::duration outerDtChrono_{};
-  Clock::time_point nextTarget_{};
-  Clock::time_point startReal_{};
+  std::uint64_t dtNs_{0};
+  std::uint64_t nextTarget_{0};
+  std::uint64_t startReal_{0};
   Seconds accumulator_{0};
 
   std::vector<std::thread> threads_;

--- a/include/simcore/bintrace.hpp
+++ b/include/simcore/bintrace.hpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <new>
 #include <fstream>
+#include "highres_clock.hpp"
 
 namespace bintrace {
 
@@ -29,28 +30,9 @@ enum : std::uint32_t {
     EV_BudgetLadder = 0x05,
 };
 
-#if defined(__x86_64__) || defined(_M_X64)
-#  if defined(_MSC_VER)
-#    include <intrin.h>
 static inline std::uint64_t rdtsc() noexcept {
-    return __rdtsc();
+    return HighResClock::now();
 }
-#  else
-static inline std::uint64_t rdtsc() noexcept {
-    unsigned hi, lo;
-    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
-    return (static_cast<std::uint64_t>(hi) << 32) | lo;
-}
-#  endif
-#else
-#  include <chrono>
-static inline std::uint64_t rdtsc() noexcept {
-    using Clock = std::chrono::steady_clock;
-    return static_cast<std::uint64_t>(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(
-            Clock::now().time_since_epoch()).count());
-}
-#endif
 
 class Trace {
 public:

--- a/include/simcore/highres_clock.hpp
+++ b/include/simcore/highres_clock.hpp
@@ -37,7 +37,7 @@ public:
     }
 
     // Nanoseconds since an arbitrary epoch (monotonic).
-    static uint64_t now_ns() {
+    static uint64_t now() {
         auto ref_now = std::chrono::steady_clock::now();
         uint64_t ns_ref = to_ns(ref_now);
 
@@ -56,6 +56,11 @@ public:
             return ensure_monotonic(ns);
         }
         return ensure_monotonic(ns_ref);
+    }
+
+    // Helper: convert nanoseconds to milliseconds.
+    static double to_ms(uint64_t ns) {
+        return static_cast<double>(ns) / 1'000'000.0;
     }
 
     static bool using_tsc() { return tsc_ok_.load(); }

--- a/include/simcore/profiler.hpp
+++ b/include/simcore/profiler.hpp
@@ -1,13 +1,13 @@
 #pragma once
 #include <string>
 #include <vector>
-#include <chrono>
 #include <unordered_map>
 #include <mutex>
 #include <atomic>
 #include <algorithm>
 #include <iostream>
 #include <iomanip>
+#include "highres_clock.hpp"
 
 #ifdef PROF_ENABLED
 
@@ -30,17 +30,17 @@ public:
     public:
         ScopeGuard(Profiler* p, std::string n)
             : prof_(p), name_(std::move(n)),
-              t0_(std::chrono::steady_clock::now()) {}
+              t0_(HighResClock::now()) {}
         ~ScopeGuard() {
             if (!prof_) return;
-            auto t1 = std::chrono::steady_clock::now();
-            long double ns = std::chrono::duration<long double, std::nano>(t1 - t0_).count();
+            auto t1 = HighResClock::now();
+            long double ns = static_cast<long double>(t1 - t0_);
             prof_->record(name_, ns);
         }
     private:
         Profiler* prof_;
         std::string name_;
-        std::chrono::steady_clock::time_point t0_;
+        uint64_t t0_;
     };
 
     void record(const std::string& n, long double ns) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TEST_SOURCES
     test_phase_telemetry.cpp
     test_aligned_allocator.cpp
     test_highres_clock.cpp
+    test_highres_clock_integration.cpp
     test_rate_governor.cpp
     test_hazard_ptr.cpp
     test_lockfree_queue.cpp

--- a/tests/test_highres_clock.cpp
+++ b/tests/test_highres_clock.cpp
@@ -4,10 +4,10 @@
 
 TEST(HighResClock, MonotonicMockedTSC) {
     HighResClock::init([](){ static uint64_t c=0; return c+=100; });
-    uint64_t a = HighResClock::now_ns();
-    uint64_t b = HighResClock::now_ns();
+    uint64_t a = HighResClock::now();
+    uint64_t b = HighResClock::now();
     EXPECT_LT(a, b);
-    uint64_t c = HighResClock::now_ns();
+    uint64_t c = HighResClock::now();
     EXPECT_LT(b, c);
 }
 
@@ -17,11 +17,11 @@ TEST(HighResClock, DriftDisablesTSC) {
     auto reader = [](){ if (slow) c += 10; else c += 1000; return c; };
     HighResClock::init(reader);
     ASSERT_TRUE(HighResClock::using_tsc());
-    (void)HighResClock::now_ns();
+    (void)HighResClock::now();
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    (void)HighResClock::now_ns();
+    (void)HighResClock::now();
     slow = true;
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    for (int i=0;i<5000;i++) HighResClock::now_ns();
+    for (int i=0;i<5000;i++) HighResClock::now();
     EXPECT_FALSE(HighResClock::using_tsc());
 }

--- a/tests/test_highres_clock_integration.cpp
+++ b/tests/test_highres_clock_integration.cpp
@@ -1,0 +1,12 @@
+#include <gtest/gtest.h>
+#include "simcore/highres_clock.hpp"
+
+TEST(HighResClockIntegration, MonotonicSequence) {
+    HighResClock::init();
+    uint64_t last = HighResClock::now();
+    for (int i = 0; i < 10000; ++i) {
+        uint64_t cur = HighResClock::now();
+        EXPECT_GT(cur, last);
+        last = cur;
+    }
+}


### PR DESCRIPTION
## Summary
- use HighResClock::now() across SimCore, profiler, and trace
- add to_ms helper for converting nanoseconds
- add integration test validating monotonic HighResClock sequence

## Testing
- `cmake -S . -B build` *(failed: downloading googletest, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b2c3e6d8832bb74a952811491a5d