### PR TITLE
Integrate rate governor with SimCore frame loop

### DIFF
--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -1412,10 +1412,12 @@ private:
       if (t >= settings_.thermalLimpCelsius && degradeRung_ < 4)
         applyDegradeRung(4);
     }
-    if (!settings_.budgetMonitor || settings_.budgetWindow <= 0)
-      return;
 
-    if (!costWindow_.empty()) {
+    const double periodMs = 1000.0 / settings_.hz;
+    const bool monitorActive =
+        settings_.budgetMonitor && settings_.budgetWindow > 0;
+
+    if (monitorActive && !costWindow_.empty()) {
       if (costCount_ < costWindow_.size()) {
         costWindow_[costHead_] = computeMs;
         costSumMs_ += computeMs;
@@ -1429,15 +1431,22 @@ private:
       }
     }
 
-    const double periodMs = 1000.0 / settings_.hz;
     const double ratio = computeMs / periodMs;
-    const double avgComputeMs =
-        (costCount_ ? (costSumMs_ / double(costCount_)) : computeMs);
-    const double avgRatio = avgComputeMs / periodMs;
+    double avgComputeMs = computeMs;
+    double avgRatio = periodMs > 0.0 ? ratio : 0.0;
+
+    if (monitorActive) {
+      avgComputeMs =
+          (costCount_ ? (costSumMs_ / double(costCount_)) : computeMs);
+      avgRatio = avgComputeMs / periodMs;
+    }
 
     if (budgetCb_)
       budgetCb_(BudgetSample{computeMs, periodMs, ratio, avgComputeMs, avgRatio,
                              frame_});
+
+    if (!monitorActive)
+      return;
 
     if (logger_) {
       if (ratio >= settings_.budgetCritRatio ||

--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -3,6 +3,7 @@
 // minParallelChunks).
 #pragma once
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <cassert>
 #include <chrono>
@@ -24,6 +25,7 @@
 #include "frame_arena.hpp"
 #include "logger.hpp"
 #include "profiler.hpp"
+#include "rate_governor.hpp"
 #include "highres_clock.hpp"
 #include "worker_pool.hpp"
 #include <rt/fiber_pool.hpp>
@@ -124,6 +126,17 @@ public:
   int subSteps() const { return subSteps_; }
   int watchdogTrips() const { return watchdogTrips_.load(std::memory_order_acquire); }
   bool limpModeActive() const { return settings_.limpMode || watchdogLimp_.load(); }
+  int governorRung() const { return governor_.rung(); }
+  double governorScale() const { return governorScale_; }
+  std::uint64_t rungActivations(int rung) const {
+    if (rung < 1 || rung > 4)
+      return 0;
+    return degradeActivations_[static_cast<std::size_t>(rung - 1)];
+  }
+  std::uint64_t governorRungCount(int rung) const {
+    return governor_.rungCount(rung);
+  }
+  double frameBudgetMs() const { return frame_budget_ms_; }
 
   // Counter-based deterministic PRNG. Counter is derived from frame and
   // element index so results are independent of execution order.
@@ -194,6 +207,15 @@ public:
     double adaptDownFactor = 0.95;
     double minHz = 60.0;
     int adaptCooldownFrames = 600;
+
+    // Rate governor
+    bool rateGovernorEnable = true;
+    double rateGovernorTargetUtil = 0.9;
+    double rateGovernorHysteresis = 0.05;
+    double rateGovernorKp = 0.1;
+    double rateGovernorKi = 0.01;
+    double rateGovernorMinScale = 0.5;
+    double rateGovernorMaxScale = 1.0;
 
     // Thermal monitoring
     bool thermalMonitor = false;
@@ -311,6 +333,17 @@ public:
       settings_.predictiveWindow = settings_.budgetWindow;
 
     recalcTiming();
+
+    frame_budget_ms_ = dt_.count() * 1000.0;
+    target_util_ = settings_.rateGovernorTargetUtil;
+    hysteresis_ = settings_.rateGovernorHysteresis;
+    governor_ = RateGovernor(settings_.rateGovernorKp, settings_.rateGovernorKi,
+                             settings_.rateGovernorMinScale,
+                             settings_.rateGovernorMaxScale);
+    governor_.setCallback([this](int rung) { applyDegradeRung(rung); });
+    governorScale_ = 1.0;
+    degradeRung_ = 0;
+    degradeActivations_.fill(0);
 
     if (settings_.limpMode) {
       settings_.budgetMonitor = false;
@@ -927,6 +960,9 @@ private:
 
     const double computeMs = Clock::to_ms(computeEnd - computeStart);
     updateBudget(computeMs);
+    if (settings_.rateGovernorEnable)
+      governorScale_ =
+          governor_.update(computeMs, frame_budget_ms_, target_util_, hysteresis_);
 
     // feed-forward: build headroom (do BEFORE sleeping)
     if (settings_.predictiveEnable) {
@@ -1316,25 +1352,60 @@ private:
     dt_ = Seconds{1.0 / settings_.hz};
     outerDt_ = dt_ * subSteps_;
     dtNs_ = static_cast<std::uint64_t>(dt_.count() * 1'000'000'000.0);
+    frame_budget_ms_ = dt_.count() * 1000.0;
     startReal_ = Clock::now();
   }
 
 public:
   void applyDegradeRung(int rung) {
-    degradeRung_ = rung;
-    if (rung >= 1)
+    if (rung <= degradeRung_)
+      return;
+    rung = std::clamp(rung, 0, 4);
+    for (int step = degradeRung_ + 1; step <= rung; ++step) {
+      degradeRung_ = step;
+      recordDegradeActivation_(step);
+      switch (step) {
+      case 1:
+        drop_visuals_();
+        break;
+      case 2:
+        reduce_substeps_();
+        break;
+      case 3:
+        coarsen_phase_();
+        break;
+      case 4:
+        drop_visuals_();
+        coarsen_phase_();
+        subSteps_ = 1;
+        break;
+      default:
+        break;
+      }
+    }
+  }
+
+private:
+  void drop_visuals_() {
+    if (settings_.visualizers)
       settings_.visualizers = false;
-    if (rung >= 2 && subSteps_ > 1)
+  }
+
+  void reduce_substeps_() {
+    if (subSteps_ > 1)
       --subSteps_;
-    if (rung >= 3)
-      settings_.broadphaseCoarse = true;
-    if (rung >= 4)
-      subSteps_ = 1;
+  }
+
+  void coarsen_phase_() { settings_.broadphaseCoarse = true; }
+
+  void recordDegradeActivation_(int rung) {
+    if (rung < 1 || rung > 4)
+      return;
+    degradeActivations_[static_cast<std::size_t>(rung - 1)]++;
     bintrace_.log(bintrace::EV_BudgetLadder, static_cast<std::uint32_t>(rung),
                   static_cast<std::uint64_t>(frame_));
   }
 
-private:
   void updateBudget(double computeMs) {
     if (settings_.thermalMonitor && settings_.readPackageTemp) {
       double t = settings_.readPackageTemp();
@@ -1452,6 +1523,12 @@ private:
   double costSumMs_ = 0.0;
   int adaptCooldown_ = 0;
   int degradeRung_ = 0;
+  std::array<std::uint64_t, 4> degradeActivations_{};
+  RateGovernor governor_{};
+  double frame_budget_ms_ = 0.0;
+  double target_util_ = 0.9;
+  double hysteresis_ = 0.05;
+  double governorScale_ = 1.0;
   std::function<void(const BudgetSample &)> budgetCb_;
 
   std::uint64_t deterministicHash_ = 0;

--- a/include/simcore/rate_governor.hpp
+++ b/include/simcore/rate_governor.hpp
@@ -1,42 +1,59 @@
 #pragma once
 #include <algorithm>
+#include <array>
+#include <cstdint>
 #include <functional>
+#include <limits>
 
 // Simple PI based rate governor. Controls a scale factor so that
-// compute_ms stays within frame_ms. Includes hysteresis and clamping.
+// compute_ms stays within the frame budget. Includes hysteresis and clamping
+// and provides rung callbacks for staged degradations.
 class RateGovernor {
 public:
     using RungCallback = std::function<void(int)>;
 
-    RateGovernor(double frame_ms, double kp=0.1, double ki=0.01,
-                 double floor=0.5, double ceiling=1.0, double hysteresis=0.05,
-                 RungCallback rungCb = {})
-        : frame_ms_(frame_ms), kp_(kp), ki_(ki),
-          floor_(floor), ceiling_(ceiling), hyst_(hysteresis),
-          rungCb_(std::move(rungCb)) {}
+    RateGovernor(double kp = 0.1, double ki = 0.01, double floor = 0.5,
+                 double ceiling = 1.0)
+        : kp_(kp), ki_(ki), floor_(floor), ceiling_(ceiling) {}
 
-    // Update with the last frame's compute time. Returns new scale factor.
-    double update(double compute_ms) {
-        double ratio = compute_ms / (frame_ms_ * scale_);
-        double error = ratio - 1.0;
-        if (std::abs(error) >= hyst_) {
+    void setCallback(RungCallback cb) { rungCb_ = std::move(cb); }
+
+    // Update with the last frame's compute time and budget information.
+    // Returns the new scale factor recommendation.
+    double update(double compute_ms, double frame_ms, double target_util,
+                  double hysteresis) {
+        if (frame_ms <= std::numeric_limits<double>::epsilon())
+            return scale_;
+
+        const double budget = std::max(frame_ms, std::numeric_limits<double>::epsilon());
+        const double ratio = compute_ms / budget;
+
+        const double target = std::clamp(target_util, 0.0, 1.0);
+        const double hyst = std::max(hysteresis, 1e-6);
+        const double error = ratio - target;
+
+        if (std::abs(error) >= hyst) {
             integral_ += error;
-            double delta = kp_ * error + ki_ * integral_;
+            integral_ = std::clamp(integral_, -100.0, 100.0);
+            const double delta = kp_ * error + ki_ * integral_;
             scale_ = std::clamp(scale_ - delta, floor_, ceiling_);
         }
 
-        const double ratioRef = compute_ms / frame_ms_;
-        if (rung_ < 1 && ratioRef >= t1_) {
-            rung_ = 1;
-            if (rungCb_) rungCb_(1);
-        }
-        if (rung_ < 2 && ratioRef >= t2_) {
-            rung_ = 2;
-            if (rungCb_) rungCb_(2);
-        }
-        if (rung_ < 3 && ratioRef >= t3_) {
-            rung_ = 3;
-            if (rungCb_) rungCb_(3);
+        int targetRung = 0;
+        if (ratio >= target + 3.0 * hyst)
+            targetRung = 3;
+        else if (ratio >= target + 2.0 * hyst)
+            targetRung = 2;
+        else if (ratio >= target + hyst)
+            targetRung = 1;
+
+        if (targetRung > rung_) {
+            for (int rung = rung_ + 1; rung <= targetRung; ++rung) {
+                rungCounts_[static_cast<std::size_t>(rung - 1)]++;
+                if (rungCb_)
+                    rungCb_(rung);
+            }
+            rung_ = targetRung;
         }
 
         return scale_;
@@ -44,20 +61,21 @@ public:
 
     double scale() const { return scale_; }
     int rung() const { return rung_; }
+    std::uint64_t rungCount(int rung) const {
+        if (rung < 1 || rung > 3)
+            return 0;
+        return rungCounts_[static_cast<std::size_t>(rung - 1)];
+    }
 
 private:
-    double frame_ms_;
     double kp_;
     double ki_;
     double floor_;
     double ceiling_;
-    double hyst_;
     double integral_ = 0.0;
     double scale_ = 1.0;
     int rung_ = 0;
-    const double t1_ = 1.1;
-    const double t2_ = 1.3;
-    const double t3_ = 1.5;
+    std::array<std::uint64_t, 3> rungCounts_{};
     RungCallback rungCb_;
 };
 

--- a/tests/test_rate_governor.cpp
+++ b/tests/test_rate_governor.cpp
@@ -4,24 +4,27 @@
 
 TEST(RateGovernor, AdversarialBurstTriggersLadderAndRecovers) {
     std::vector<int> events;
-    RateGovernor rg(16.0, 0.1, 0.01, 0.5, 1.0, 0.05,
-                    [&](int rung){ events.push_back(rung); });
+    RateGovernor rg(0.1, 0.01, 0.5, 1.0);
+    rg.setCallback([&](int rung) { events.push_back(rung); });
     // warmup stable frames
     for(int i=0;i<5;i++) {
-        double s = rg.update(10.0);
+        double s = rg.update(10.0, 16.0, 0.9, 0.05);
         EXPECT_NEAR(s, 1.0, 0.1);
     }
     // adversarial burst
-    double s = rg.update(40.0);
+    double s = rg.update(40.0, 16.0, 0.9, 0.05);
     EXPECT_LT(s, 1.0);
     EXPECT_EQ(rg.rung(), 3);
     ASSERT_EQ(events.size(), 3u);
     EXPECT_EQ(events[0], 1);
     EXPECT_EQ(events[1], 2);
     EXPECT_EQ(events[2], 3);
+    EXPECT_EQ(rg.rungCount(1), 1u);
+    EXPECT_EQ(rg.rungCount(2), 1u);
+    EXPECT_EQ(rg.rungCount(3), 1u);
     // subsequent frames should recover
     for(int i=0;i<40;i++) {
-        s = rg.update(10.0);
+        s = rg.update(10.0, 16.0, 0.9, 0.05);
     }
     EXPECT_GT(s, 0.95);
 }

--- a/tests/test_rt_pipeline.cpp
+++ b/tests/test_rt_pipeline.cpp
@@ -1,3 +1,6 @@
+#include <algorithm>
+#include <atomic>
+#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <string>
@@ -8,6 +11,14 @@
 #include <gtest/gtest.h>
 #include <simcore/SimCore.hpp>
 #include <simcore/worker_pool.hpp>
+
+static void busy_for(double ms) {
+  using Clock = std::chrono::steady_clock;
+  auto start = Clock::now();
+  auto target = std::chrono::duration<double, std::milli>(ms);
+  while (Clock::now() - start < target)
+    std::atomic_signal_fence(std::memory_order_acq_rel);
+}
 
 TEST(RTPipeline, QueueMetricsAndNoThreadsInSrc) {
   WorkerPool pool(1);
@@ -71,5 +82,51 @@ TEST(RTPipeline, WatchdogTripRecordedAndContinues) {
 
   EXPECT_GT(sim.watchdogTrips(), 0);
   EXPECT_GE(sim.frame(), 2);
+}
+
+TEST(RTPipeline, RateGovernorClampsFrameBudget) {
+  WorkerPool pool(1);
+  SimCore::Settings s;
+  s.hz = 120.0;
+  s.maxFrames = 120;
+  s.threads = 0;
+  s.budgetMonitor = false;
+  s.bintraceEnable = true;
+  s.bintraceEventsPerThread = 1u << 10;
+  s.rateGovernorTargetUtil = 0.9;
+  s.rateGovernorHysteresis = 0.05;
+  SimCore sim(s);
+  sim.setWorkerPool(&pool);
+
+  std::vector<double> samples;
+  sim.setBudgetCallback([
+    &samples
+  ](const SimCore::BudgetSample &sample) { samples.push_back(sample.computeMs); });
+
+  auto p = sim.addPhase("governed");
+  sim.addSerialSubsystem(p, [&sim](std::int64_t, SimCore::Seconds) {
+    if (sim.visualizersEnabled())
+      busy_for(12.0);
+    else
+      busy_for(6.0);
+  });
+
+  sim.run();
+  pool.stop();
+
+  EXPECT_GE(sim.rungActivations(1), 1u);
+  EXPECT_GE(sim.governorRungCount(1), 1u);
+
+  ASSERT_FALSE(samples.empty());
+  auto sorted = samples;
+  std::sort(sorted.begin(), sorted.end());
+  std::size_t index = static_cast<std::size_t>(
+      std::ceil(0.99 * static_cast<double>(sorted.size())));
+  if (index == 0)
+    index = 1;
+  index = std::min(index, sorted.size()) - 1;
+  double p99 = sorted[index];
+  double budget = 1000.0 / s.hz;
+  EXPECT_LE(p99, budget * 1.05);
 }
 


### PR DESCRIPTION
## Summary
- integrate the rate governor with SimCore settings, tracking frame budgets, scale and rung counts, and wiring staged degradations into the frame loop
- add targeted helpers for disabling visuals, reducing substeps and coarsening phases so governor rungs flip runtime fidelity knobs while logging to bintrace
- update the rate governor unit test and add a pipeline integration test that exercises the governor under a tight budget and checks p99 frame timing

## Testing
- cmake --preset dev *(fails: proxy blocked download of googletest)*
- cmake -S . -B build/notests -DENABLE_TESTS=OFF -DSIM_WERROR=OFF
- cmake --build build/notests

------
https://chatgpt.com/codex/tasks/task_e_68c95b6cfe48832bb6b7109560e99e8c