### PR TITLE
Initialize FP env for worker threads

### DIFF
--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -75,6 +75,7 @@ public:
       }
       if (threads_.size() > 1) {
         std::thread([this, job = std::move(job)]() mutable {
+          rt::init_fp_env();
           active_.fetch_add(1, std::memory_order_acq_rel);
           if (job.fn)
             job.fn();
@@ -124,6 +125,7 @@ public:
               return true;
             }
             std::thread([this, job = std::move(job)]() mutable {
+              rt::init_fp_env();
               active_.fetch_add(1, std::memory_order_acq_rel);
               if (job.fn)
                 job.fn();
@@ -160,6 +162,7 @@ public:
           return true;
         }
         std::thread([this, job = std::move(job)]() mutable {
+          rt::init_fp_env();
           active_.fetch_add(1, std::memory_order_acq_rel);
           if (job.fn)
             job.fn();

--- a/rt/include/rt/numerics.hpp
+++ b/rt/include/rt/numerics.hpp
@@ -8,6 +8,23 @@
 
 namespace rt {
 
+namespace detail {
+
+// Build level gate controlling whether FMA may be used.  The default honours
+// the compiler target (presence of __FMA__/__AVX2__) but can be overridden via
+// RT_NUMERICS_FORCE_FMA / RT_NUMERICS_FORCE_NO_FMA build definitions.
+#if defined(RT_NUMERICS_FORCE_NO_FMA)
+inline constexpr bool kBuildAllowsFma = false;
+#elif defined(RT_NUMERICS_FORCE_FMA)
+inline constexpr bool kBuildAllowsFma = true;
+#elif defined(__FMA__) || defined(__AVX2__)
+inline constexpr bool kBuildAllowsFma = true;
+#else
+inline constexpr bool kBuildAllowsFma = false;
+#endif
+
+} // namespace detail
+
 // Configure floating point environment for determinism.
 // Sets rounding mode to FE_TONEAREST and enables flush-to-zero
 // and denormals-are-zero on x86 targets. Intended to be called
@@ -23,19 +40,33 @@ inline void init_fp_env() {
 }
 
 inline bool &use_fma_flag() {
-    static bool flag = true;
+    static bool flag = detail::kBuildAllowsFma;
     return flag;
 }
 
-inline void set_use_fma(bool on) { use_fma_flag() = on; }
-inline bool use_fma() { return use_fma_flag(); }
+inline void set_use_fma(bool on) {
+    if constexpr (detail::kBuildAllowsFma) {
+        use_fma_flag() = on;
+    } else {
+        (void)on;
+    }
+}
+
+inline bool use_fma() {
+    if constexpr (detail::kBuildAllowsFma) {
+        return use_fma_flag();
+    }
+    return false;
+}
 
 // Wrapper for fused multiply-add with a runtime gate. When the
 // gate is disabled the operation is performed as a separate
 // multiply and add which mirrors platforms lacking hardware FMA.
 inline double fma(double a, double b, double c) {
-    if (use_fma_flag())
-        return std::fma(a, b, c);
+    if constexpr (detail::kBuildAllowsFma) {
+        if (use_fma_flag())
+            return std::fma(a, b, c);
+    }
     return a * b + c;
 }
 


### PR DESCRIPTION
## Summary
- gate fused multiply-add usage behind build-time overrides while keeping the runtime toggle active only when permitted
- make opportunistic worker threads initialize the floating-point environment before executing jobs so FTZ/DAZ and rounding are consistent

## Testing
- `cmake --preset dev` *(fails: blocked fetching googletest over the network)*
- `cmake --preset dev -DENABLE_TESTS=OFF -DSIM_WERROR=OFF`
- `cmake --build --preset dev`


------
https://chatgpt.com/codex/tasks/task_e_68c9737946c4832ba373b5dbc44190f7