### PR TITLE
Ensure worker arenas are NUMA local

### DIFF
--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -660,6 +660,9 @@ private:
                              cpuList
 #endif
       ] {
+#ifndef SIM_USE_NUMA
+        (void)node;
+#endif
 #ifdef SIM_USE_NUMA
         if (node >= 0)
           rt::numa::bind_thread_to_node(node);

--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -30,6 +30,7 @@
 #include "highres_clock.hpp"
 #include "worker_pool.hpp"
 #include <rt/fiber_pool.hpp>
+#include <rt/numa.hpp>
 #include <rt/numerics.hpp>
 #include <rt/prng.hpp>
 #include <rt/snapshot.hpp>
@@ -652,12 +653,17 @@ private:
 
     threads_.reserve(workerCount_);
     for (std::size_t i = 0; i < workerCount_; ++i) {
-      threads_.emplace_back([this, i
+      int node = (i < threadNodes.size()) ? threadNodes[i] : -1;
+      threads_.emplace_back([this, i, node
 #ifdef __linux__
                              ,
                              cpuList
 #endif
       ] {
+#ifdef SIM_USE_NUMA
+        if (node >= 0)
+          rt::numa::bind_thread_to_node(node);
+#endif
 #ifdef __linux__
         if (settings_.pinThreads && !cpuList.empty())
           set_affinity(std::size_t(cpuList[i % cpuList.size()]));

--- a/include/simcore/frame_arena.hpp
+++ b/include/simcore/frame_arena.hpp
@@ -1,5 +1,7 @@
 #pragma once
 #include "rt_memory.hpp"
+#include <rt/numa.hpp>
 
-using FrameArena     = rt::FrameArena;
+using FrameArena = rt::FrameArena;
 using FrameArenaPool = rt::FrameArenaPool;
+using ThreadArena = rt::numa::ThreadArena;

--- a/include/simcore/rt_memory.hpp
+++ b/include/simcore/rt_memory.hpp
@@ -50,17 +50,10 @@ static inline std::size_t os_page_size() noexcept {
 // Optional: page pre-touch, mlock, hugepage advice at init.
 class FrameArena {
 public:
+  FrameArena() = default;
   explicit FrameArena(std::size_t capacityBytes = (1u << 20),
-                      std::size_t alignment = 64, int numaNode = -1)
-      : alignment_(normalize_align(alignment))
-#if defined(__linux__) && defined(SIM_USE_NUMA)
-        , numaNode_(numaNode)
-#endif
-  {
-#if !(defined(__linux__) && defined(SIM_USE_NUMA))
-    (void)numaNode;
-#endif
-    reserve_(capacityBytes);
+                      std::size_t alignment = 64, int numaNode = -1) {
+    configure(capacityBytes, alignment, numaNode);
   }
 
   FrameArena(const FrameArena &) = delete;
@@ -107,6 +100,29 @@ public:
   }
 
   ~FrameArena() { release_(); }
+
+  void configure(std::size_t capacityBytes, std::size_t alignment = 64,
+                 int numaNode = -1) {
+    alignment = normalize_align(alignment);
+    if (buffer_ && capacity_ == capacityBytes && alignment_ == alignment
+#if defined(__linux__) && defined(SIM_USE_NUMA)
+        && numaNode_ == numaNode
+#endif
+    ) {
+      head_ = 0;
+#if !(defined(__linux__) && defined(SIM_USE_NUMA))
+      (void)numaNode;
+#endif
+      return;
+    }
+    alignment_ = alignment;
+#if defined(__linux__) && defined(SIM_USE_NUMA)
+    numaNode_ = numaNode;
+#else
+    (void)numaNode;
+#endif
+    reserve_(capacityBytes);
+  }
 
   void reset() noexcept { head_ = 0; }
   std::size_t capacity() const noexcept { return capacity_; }
@@ -242,12 +258,9 @@ public:
                  std::size_t perThreadCapacityBytes = (1u << 20),
                  std::size_t baseAlignment = 64,
                  const std::vector<int> &nodes = {})
-      : arenas_(), nodes_(nodes), nextIndex_(0) {
-    arenas_.reserve(threads);
-    for (std::size_t i = 0; i < threads; ++i) {
-      int node = (i < nodes_.size()) ? nodes_[i] : -1;
-      arenas_.emplace_back(perThreadCapacityBytes, baseAlignment, node);
-    }
+      : arenas_(threads), nodes_(nodes), perThreadCapacityBytes_(perThreadCapacityBytes),
+        baseAlignment_(baseAlignment), nextIndex_(0) {
+    nodes_.resize(threads, -1);
 
     static_assert(std::is_move_constructible<FrameArena>::value,
                   "FrameArena must be move-constructible");
@@ -262,6 +275,10 @@ public:
   void bindCurrentThread(std::size_t i) noexcept {
     assert(i < arenas_.size());
     tlsIndex_ = i;
+    if (perThreadCapacityBytes_) {
+      int node = nodeForIndex(i);
+      arenas_[i].configure(perThreadCapacityBytes_, baseAlignment_, node);
+    }
   }
 
   // Non-deterministic first-touch assignment (optional).
@@ -281,12 +298,18 @@ public:
   const FrameArena &arena(std::size_t i) const noexcept { return arenas_[i]; }
   FrameArena &arena(std::size_t i) noexcept { return arenas_[i]; }
   int node(std::size_t i) const noexcept {
-    return (i < nodes_.size()) ? nodes_[i] : -1;
+    return nodeForIndex(i);
   }
 
 private:
+  int nodeForIndex(std::size_t i) const noexcept {
+    return (i < nodes_.size()) ? nodes_[i] : -1;
+  }
+
   std::vector<FrameArena> arenas_;
   std::vector<int> nodes_;
+  std::size_t perThreadCapacityBytes_ = 0;
+  std::size_t baseAlignment_ = 64;
   std::atomic<std::size_t> nextIndex_;
   static thread_local std::size_t tlsIndex_;
 };

--- a/include/simcore/rt_memory.hpp
+++ b/include/simcore/rt_memory.hpp
@@ -51,7 +51,7 @@ static inline std::size_t os_page_size() noexcept {
 class FrameArena {
 public:
   FrameArena() = default;
-  explicit FrameArena(std::size_t capacityBytes = (1u << 20),
+  explicit FrameArena(std::size_t capacityBytes,
                       std::size_t alignment = 64, int numaNode = -1) {
     configure(capacityBytes, alignment, numaNode);
   }

--- a/rt/include/rt/numa.hpp
+++ b/rt/include/rt/numa.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+
+#include <simcore/rt_memory.hpp>
+
+#if defined(__linux__) && defined(SIM_USE_NUMA)
+#include <numa.h>
+#endif
+
+namespace rt::numa {
+
+inline bool available() noexcept {
+#if defined(__linux__) && defined(SIM_USE_NUMA)
+  return numa_available() != -1;
+#else
+  return false;
+#endif
+}
+
+inline void bind_thread_to_node(int node) noexcept {
+#if defined(__linux__) && defined(SIM_USE_NUMA)
+  if (node >= 0 && available()) {
+    numa_run_on_node(node);
+    numa_set_preferred(node);
+  }
+#else
+  (void)node;
+#endif
+}
+
+using ThreadArena = FrameArena;
+
+inline ThreadArena make_thread_arena(std::size_t size, int node) {
+  return ThreadArena(size, 64, node);
+}
+
+} // namespace rt::numa
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,7 +113,8 @@ endif()
 
 # --- affinity test -------------------------------------------------
 if (UNIX AND NOT APPLE)   # linux
-    list(APPEND TEST_SOURCES tests/test_affinity.cpp tests/test_numa_pool.cpp)
+    list(APPEND TEST_SOURCES tests/test_affinity.cpp tests/test_numa_pool.cpp
+                                 tests/test_numa_integration.cpp)
     find_library(LIBNUMA numa)
     find_path(NUMA_INCLUDE_DIR numa.h)
     if (LIBNUMA AND NUMA_INCLUDE_DIR)

--- a/tests/test_numa_integration.cpp
+++ b/tests/test_numa_integration.cpp
@@ -1,0 +1,81 @@
+#include <cstring>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <simcore/SimCore.hpp>
+
+#ifdef SIM_USE_NUMA
+#include <numa.h>
+#include <sched.h>
+
+namespace {
+struct ArenaCapture {
+  void push(void *addr, int node) {
+    std::lock_guard<std::mutex> lock(mutex);
+    addresses.push_back(addr);
+    nodes.push_back(node);
+  }
+
+  std::mutex mutex;
+  std::vector<void *> addresses;
+  std::vector<int> nodes;
+};
+} // namespace
+
+TEST(NumaIntegration, WorkerArenasAreNodeLocal) {
+  if (numa_available() < 0 || numa_num_configured_nodes() < 2) {
+    GTEST_SKIP() << "NUMA not available";
+  }
+  if (std::thread::hardware_concurrency() < 2) {
+    GTEST_SKIP() << "Insufficient hardware concurrency";
+  }
+
+  SimCore::Settings cfg;
+  cfg.threads = 2;
+  cfg.pinThreads = true;
+  cfg.compactNUMA = true;
+  cfg.maxFrames = 1;
+  cfg.autoTuneChunks = false;
+  cfg.chunkSize = 1;
+  cfg.arenaPerThreadBytes = 1u << 12;
+
+  SimCore sim(cfg);
+  std::size_t phase = sim.addPhase("numa", cfg.threads * 8);
+
+  ArenaCapture capture;
+  sim.addParallelRangeTask(
+      phase, [&sim, &capture](std::size_t, std::size_t, std::int64_t,
+                              SimCore::Seconds) {
+        static thread_local bool recorded = false;
+        if (recorded)
+          return;
+        recorded = true;
+        void *ptr = sim.frameArena().allocate(4096);
+        std::memset(ptr, 1, 4096);
+        int cpu = sched_getcpu();
+        int node = (cpu >= 0) ? numa_node_of_cpu(cpu) : -1;
+        capture.push(ptr, node);
+      });
+
+  sim.run();
+
+  ASSERT_FALSE(capture.addresses.empty());
+  ASSERT_GE(capture.addresses.size(), cfg.threads);
+  std::vector<void *> pages = capture.addresses;
+  std::vector<int> status(pages.size());
+  numa_move_pages(0, static_cast<unsigned long>(pages.size()), pages.data(),
+                  nullptr, status.data(), 0);
+
+  for (std::size_t i = 0; i < pages.size(); ++i) {
+    ASSERT_GE(capture.nodes[i], 0);
+    EXPECT_EQ(status[i], capture.nodes[i]);
+  }
+}
+#else
+TEST(NumaIntegration, Skipped) {
+  GTEST_SKIP() << "SIM_USE_NUMA not enabled";
+}
+#endif
+


### PR DESCRIPTION
## Summary
- add a NUMA helper header that exposes per-thread arenas and bind helpers
- lazily configure frame arenas on the owning worker thread and bind SimCore workers to their NUMA node before allocation
- add a NUMA integration test that verifies worker scratch pages live on the executing node and wire it into the test build

## Testing
- cmake -S . -B build *(fails: proxy blocks googletest download)*

------
https://chatgpt.com/codex/tasks/task_e_68c99f3376a4832bb244238cd4b71a65