### PR TITLE
Implement NUMA first-touch initialization for SoA/AoSoA arrays

### DIFF
--- a/include/simcore/soa/first_touch.hpp
+++ b/include/simcore/soa/first_touch.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <rt/numa.hpp>
+#include <simcore/soa/aosoa.hpp>
+#include <simcore/soa/soa_simd.hpp>
+
+namespace soa {
+
+template <typename T>
+void init_vec3_soa(Vec3SoA<T> soa, std::size_t n,
+                   const std::vector<int> &nodes, T value = T{}) {
+  static_assert(!std::is_const_v<T>, "Vec3SoA initializer requires mutable T");
+  if (!soa.x || !soa.y || !soa.z || n == 0)
+    return;
+
+  auto work = [soa, value](std::size_t begin, std::size_t end, int) {
+    for (std::size_t i = begin; i < end; ++i) {
+      soa.x[i] = value;
+      soa.y[i] = value;
+      soa.z[i] = value;
+    }
+  };
+  rt::numa::parallel_for_nodes(n, nodes, std::move(work));
+}
+
+template <typename T>
+void init_vec3_soa(Vec3SoA<T> soa, std::size_t n, T value = T{}) {
+  init_vec3_soa(soa, n, std::vector<int>{}, value);
+}
+
+template <typename T, std::size_t TILE>
+void init_vec3_aosoa(Vec3AoSoA<T, TILE> aosoa, std::size_t elements,
+                      const std::vector<int> &nodes, T value = T{}) {
+  static_assert(!std::is_const_v<T>,
+                "Vec3AoSoA initializer requires mutable T");
+  if (!aosoa.tiles || elements == 0)
+    return;
+
+  const std::size_t tileCount = (elements + TILE - 1) / TILE;
+  if (tileCount == 0)
+    return;
+  const std::size_t totalSlots = tileCount * TILE;
+
+  auto work = [aosoa, value](std::size_t begin, std::size_t end, int) {
+    for (std::size_t idx = begin; idx < end; ++idx) {
+      const std::size_t tile = idx / TILE;
+      const std::size_t lane = idx % TILE;
+      aosoa.tiles[tile].x[lane] = value;
+      aosoa.tiles[tile].y[lane] = value;
+      aosoa.tiles[tile].z[lane] = value;
+    }
+  };
+  rt::numa::parallel_for_nodes(totalSlots, nodes, std::move(work));
+}
+
+template <typename T, std::size_t TILE>
+void init_vec3_aosoa(Vec3AoSoA<T, TILE> aosoa, std::size_t elements,
+                      T value = T{}) {
+  init_vec3_aosoa(aosoa, elements, std::vector<int>{}, value);
+}
+
+} // namespace soa
+

--- a/rt/include/rt/numa.hpp
+++ b/rt/include/rt/numa.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
 #include <cstddef>
+#include <algorithm>
+#include <memory>
+#include <thread>
+#include <type_traits>
+#include <vector>
 
 #include <simcore/rt_memory.hpp>
 
@@ -27,6 +32,40 @@ inline void bind_thread_to_node(int node) noexcept {
 #else
   (void)node;
 #endif
+}
+
+template <typename Fn>
+void parallel_for_nodes(std::size_t total, const std::vector<int> &nodes,
+                        Fn &&fn) {
+  if (total == 0)
+    return;
+
+  if (nodes.empty()) {
+    fn(0, total, -1);
+    return;
+  }
+
+  const std::size_t threads = nodes.size();
+  const std::size_t chunk = (total + threads - 1) / threads;
+
+  auto fnPtr =
+      std::make_shared<std::decay_t<Fn>>(std::forward<Fn>(fn));
+  std::vector<std::thread> workers;
+  workers.reserve(threads);
+  for (std::size_t t = 0; t < threads; ++t) {
+    const std::size_t begin = t * chunk;
+    if (begin >= total)
+      break;
+    const std::size_t end = std::min(total, begin + chunk);
+    const int node = nodes[t % nodes.size()];
+    workers.emplace_back([begin, end, node, fnPtr]() {
+      if (node >= 0)
+        bind_thread_to_node(node);
+      (*fnPtr)(begin, end, node);
+    });
+  }
+  for (auto &th : workers)
+    th.join();
 }
 
 using ThreadArena = FrameArena;

--- a/tests/test_numa_integration.cpp
+++ b/tests/test_numa_integration.cpp
@@ -1,10 +1,14 @@
+#include <algorithm>
 #include <cstring>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <vector>
 
 #include <gtest/gtest.h>
 #include <simcore/SimCore.hpp>
+#include <simcore/rt_memory.hpp>
+#include <simcore/soa/first_touch.hpp>
 
 #ifdef SIM_USE_NUMA
 #include <numa.h>
@@ -22,6 +26,26 @@ struct ArenaCapture {
   std::vector<void *> addresses;
   std::vector<int> nodes;
 };
+
+void expect_pages_on_nodes(void *base, std::size_t bytes,
+                           std::size_t firstBytes, int nodeA, int nodeB) {
+  if (bytes == 0)
+    return;
+  const std::size_t page = rt::os_page_size();
+  const std::size_t totalPages = (bytes + page - 1) / page;
+  std::vector<void *> pages(totalPages);
+  for (std::size_t i = 0; i < totalPages; ++i)
+    pages[i] = static_cast<char *>(base) + i * page;
+  std::vector<int> status(totalPages);
+  numa_move_pages(0, static_cast<unsigned long>(totalPages), pages.data(),
+                  nullptr, status.data(), 0);
+  const std::size_t boundaryPages =
+      std::min((firstBytes + page - 1) / page, totalPages);
+  for (std::size_t i = 0; i < boundaryPages; ++i)
+    EXPECT_EQ(status[i], nodeA);
+  for (std::size_t i = boundaryPages; i < totalPages; ++i)
+    EXPECT_EQ(status[i], nodeB);
+}
 } // namespace
 
 TEST(NumaIntegration, WorkerArenasAreNodeLocal) {
@@ -72,6 +96,64 @@ TEST(NumaIntegration, WorkerArenasAreNodeLocal) {
     ASSERT_GE(capture.nodes[i], 0);
     EXPECT_EQ(status[i], capture.nodes[i]);
   }
+}
+
+TEST(NumaIntegration, FirstTouchSoADistributesPages) {
+  if (numa_available() < 0 || numa_num_configured_nodes() < 2) {
+    GTEST_SKIP() << "NUMA not available";
+  }
+
+  const std::vector<int> nodes{0, 1};
+  constexpr std::size_t elements = 1u << 19; // ~4 MiB per channel
+  auto x = std::make_unique<double[]>(elements);
+  auto y = std::make_unique<double[]>(elements);
+  auto z = std::make_unique<double[]>(elements);
+  soa::Vec3SoA<double> soa{x.get(), y.get(), z.get()};
+
+  soa::init_vec3_soa(soa, elements, nodes, 0.0);
+
+  const std::size_t totalBytes = elements * sizeof(double);
+  const std::size_t threads = nodes.size();
+  const std::size_t chunk = (elements + threads - 1) / threads;
+  const std::size_t firstElems = std::min(elements, chunk);
+  const std::size_t firstBytes = firstElems * sizeof(double);
+
+  expect_pages_on_nodes(x.get(), totalBytes, firstBytes, nodes[0], nodes[1]);
+  EXPECT_DOUBLE_EQ(x[0], 0.0);
+  EXPECT_DOUBLE_EQ(y[0], 0.0);
+  EXPECT_DOUBLE_EQ(z[0], 0.0);
+}
+
+TEST(NumaIntegration, FirstTouchAoSoADistributesPages) {
+  if (numa_available() < 0 || numa_num_configured_nodes() < 2) {
+    GTEST_SKIP() << "NUMA not available";
+  }
+
+  const std::vector<int> nodes{0, 1};
+  constexpr std::size_t Tile = 256;
+  constexpr std::size_t elements = Tile * 512; // 512 tiles worth of elements
+  const std::size_t tileCount = (elements + Tile - 1) / Tile;
+  using TileType = typename soa::Vec3AoSoA<double, Tile>::Tile;
+  auto tiles = std::make_unique<TileType[]>(tileCount);
+  soa::Vec3AoSoA<double, Tile> aosoa{tiles.get()};
+
+  soa::init_vec3_aosoa(aosoa, elements, nodes, 1.0);
+
+  const std::size_t totalBytes = tileCount * sizeof(TileType);
+  const std::size_t totalSlots = tileCount * Tile;
+  const std::size_t threads = nodes.size();
+  const std::size_t chunk = (totalSlots + threads - 1) / threads;
+  const std::size_t firstElems = std::min(totalSlots, chunk);
+  const std::size_t fullTiles = firstElems / Tile;
+  const std::size_t lane = firstElems % Tile;
+  std::size_t firstBytes = fullTiles * sizeof(TileType);
+  if (lane > 0)
+    firstBytes += (2 * Tile + lane) * sizeof(double);
+
+  expect_pages_on_nodes(tiles.get(), totalBytes, firstBytes, nodes[0], nodes[1]);
+  EXPECT_DOUBLE_EQ(aosoa.tiles[0].x[0], 1.0);
+  EXPECT_DOUBLE_EQ(aosoa.tiles[0].y[0], 1.0);
+  EXPECT_DOUBLE_EQ(aosoa.tiles[0].z[0], 1.0);
 }
 #else
 TEST(NumaIntegration, Skipped) {


### PR DESCRIPTION
## Summary
- add a reusable rt::numa::parallel_for_nodes helper to execute work bound to requested NUMA nodes
- provide soa::init_vec3_soa/aosoa utilities that first-touch large vector blocks in parallel during initialization
- extend the NUMA integration test to validate SoA and AoSoA allocations land on the expected nodes after first-touching

## Testing
- cmake --preset dev *(fails: proxy blocked the googletest download)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c2b36740832bbb5101162688420c