### PR TITLE
Publish worker pool queue metrics

### DIFF
--- a/include/simcore/job_queue.hpp
+++ b/include/simcore/job_queue.hpp
@@ -66,6 +66,12 @@ public:
     enqueueCache_ = pos + 1;
     cell->data = std::forward<U>(v);
     cell->sequence.store(pos + 1, std::memory_order_release);
+    auto depth = count_.fetch_add(1, std::memory_order_acq_rel) + 1;
+    auto prev = maxDepth_.load(std::memory_order_relaxed);
+    while (depth > prev &&
+           !maxDepth_.compare_exchange_weak(prev, depth,
+                                            std::memory_order_relaxed)) {
+    }
     return true;
   }
 
@@ -94,6 +100,7 @@ public:
     dequeueCache_ = pos + 1;
     out = std::move(cell->data);
     cell->sequence.store(pos + buffer_.size(), std::memory_order_release);
+    count_.fetch_sub(1, std::memory_order_acq_rel);
     return true;
   }
 
@@ -105,12 +112,14 @@ public:
   std::size_t max_capacity() const { return buffer_.size(); }
 
   std::size_t size() const {
-    auto enq = enqueuePos_.load(std::memory_order_acquire);
-    auto deq = dequeuePos_.load(std::memory_order_acquire);
-    return enq - deq;
+    return count_.load(std::memory_order_acquire);
   }
 
   bool empty() const { return size() == 0; }
+
+  std::size_t max_depth() const {
+    return maxDepth_.load(std::memory_order_relaxed);
+  }
 
 private:
   static constexpr std::size_t cacheLine() {
@@ -141,6 +150,8 @@ private:
   const std::size_t mask_;
   alignas(cacheLine()) std::atomic<std::size_t> enqueuePos_{0};
   alignas(cacheLine()) std::atomic<std::size_t> dequeuePos_{0};
+  std::atomic<std::size_t> count_{0};
+  std::atomic<std::size_t> maxDepth_{0};
 
   // Per-thread caches for enqueue/dequeue positions.
   static thread_local std::size_t enqueueCache_;

--- a/include/simcore/metrics.hpp
+++ b/include/simcore/metrics.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <simcore/worker_pool.hpp>
+
+namespace metrics {
+
+struct CounterSample {
+  std::string name;
+  std::uint64_t value;
+};
+
+struct WorkerPoolSample {
+  std::size_t queueMaxDepth = 0;
+  std::size_t totalSteals = 0;
+  std::vector<std::size_t> stealsPerThread;
+};
+
+inline WorkerPoolSample make_sample(WorkerPool::Stats stats) {
+  WorkerPoolSample sample;
+  sample.queueMaxDepth = stats.maxQueueDepth;
+  sample.totalSteals = stats.totalSteals;
+  sample.stealsPerThread = std::move(stats.stealsPerThread);
+  return sample;
+}
+
+inline WorkerPoolSample sample(const WorkerPool &pool) {
+  return make_sample(pool.stats());
+}
+
+inline std::vector<CounterSample>
+worker_pool_counters(const WorkerPoolSample &sample,
+                     std::string_view prefix = "worker_pool") {
+  std::vector<CounterSample> counters;
+  counters.reserve(2 + sample.stealsPerThread.size());
+  std::string prefixStr(prefix);
+  counters.push_back(
+      CounterSample{prefixStr + ".queue_max",
+                    static_cast<std::uint64_t>(sample.queueMaxDepth)});
+  counters.push_back(
+      CounterSample{prefixStr + ".steals_total",
+                    static_cast<std::uint64_t>(sample.totalSteals)});
+  for (std::size_t i = 0; i < sample.stealsPerThread.size(); ++i) {
+    std::ostringstream name;
+    name << prefixStr << ".steals[" << i << "]";
+    counters.push_back(CounterSample{
+        name.str(), static_cast<std::uint64_t>(sample.stealsPerThread[i])});
+  }
+  return counters;
+}
+
+inline std::string worker_pool_json(const WorkerPoolSample &sample) {
+  std::ostringstream os;
+  os << "{\"queue_max\":" << sample.queueMaxDepth << ",\"steals\":[";
+  for (std::size_t i = 0; i < sample.stealsPerThread.size(); ++i) {
+    if (i > 0)
+      os << ',';
+    os << sample.stealsPerThread[i];
+  }
+  os << "],\"steals_total\":" << sample.totalSteals << "}";
+  return os.str();
+}
+
+} // namespace metrics
+

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -23,7 +23,8 @@ public:
 
   struct Stats {
     std::size_t maxQueueDepth;
-    std::size_t steals;
+    std::size_t totalSteals;
+    std::vector<std::size_t> stealsPerThread;
   };
 
   WorkerPool(std::size_t numThreads, std::size_t queueSizePow2 = 1024,
@@ -34,10 +35,11 @@ public:
     active_.store(0, std::memory_order_relaxed);
     outstanding_.store(0, std::memory_order_relaxed);
     maxOutstanding_ = maxOutstanding;
+    stealsPerThread_.resize(numThreads);
     for (std::size_t i = 0; i < numThreads; ++i) {
-      threads_.emplace_back([this] {
+      threads_.emplace_back([this, i] {
         rt::init_fp_env();
-        workerLoop();
+        workerLoop(i);
       });
     }
   }
@@ -88,12 +90,6 @@ public:
     while (!queue_.try_push(std::move(job))) {
       std::this_thread::yield();
     }
-    auto depth = queue_.size();
-    auto prev = maxQueueDepth_.load(std::memory_order_relaxed);
-    while (depth > prev &&
-           !maxQueueDepth_.compare_exchange_weak(prev, depth,
-                                                std::memory_order_relaxed)) {
-    }
   }
 
   void enqueue(JobFn fn, Priority pr = Priority::Normal,
@@ -138,12 +134,6 @@ public:
             outstanding_.fetch_sub(1, std::memory_order_acq_rel);
             return false;
           }
-          auto depth = queue_.size();
-          auto prev = maxQueueDepth_.load(std::memory_order_relaxed);
-          while (depth > prev &&
-                 !maxQueueDepth_.compare_exchange_weak(
-                     prev, depth, std::memory_order_relaxed)) {
-          }
           return true;
         }
       }
@@ -174,12 +164,6 @@ public:
       if (!queue_.try_push(std::move(job))) {
         outstanding_.fetch_sub(1, std::memory_order_acq_rel);
         return false;
-      }
-      auto depth = queue_.size();
-      auto prev = maxQueueDepth_.load(std::memory_order_relaxed);
-      while (depth > prev &&
-             !maxQueueDepth_.compare_exchange_weak(prev, depth,
-                                                  std::memory_order_relaxed)) {
       }
       return true;
     }
@@ -213,12 +197,18 @@ public:
   }
 
   Stats stats() const {
-    return Stats{maxQueueDepth_.load(std::memory_order_relaxed),
-                 steals_.load(std::memory_order_relaxed)};
+    Stats s;
+    s.maxQueueDepth = queue_.max_depth();
+    s.totalSteals = totalSteals_.load(std::memory_order_relaxed);
+    s.stealsPerThread.reserve(stealsPerThread_.size());
+    for (const auto &counter : stealsPerThread_) {
+      s.stealsPerThread.push_back(counter.load(std::memory_order_relaxed));
+    }
+    return s;
   }
 
 private:
-  void workerLoop() {
+  void workerLoop(std::size_t index) {
     for (;;) {
       Job job;
       if (queue_.try_pop(job)) {
@@ -229,7 +219,10 @@ private:
         outstanding_.fetch_sub(1, std::memory_order_acq_rel);
         continue;
       }
-      steals_.fetch_add(1, std::memory_order_relaxed);
+      totalSteals_.fetch_add(1, std::memory_order_relaxed);
+      if (index < stealsPerThread_.size()) {
+        stealsPerThread_[index].fetch_add(1, std::memory_order_relaxed);
+      }
       if (stopping_.load(std::memory_order_acquire) &&
           outstanding_.load(std::memory_order_acquire) == 0) {
         break;
@@ -244,7 +237,7 @@ private:
   std::atomic<std::size_t> active_{0};
   std::atomic<std::size_t> outstanding_{0};
   std::size_t maxOutstanding_ = 0;
-  std::atomic<std::size_t> maxQueueDepth_{0};
-  std::atomic<std::size_t> steals_{0};
+  std::vector<std::atomic<std::size_t>> stealsPerThread_{};
+  std::atomic<std::size_t> totalSteals_{0};
 };
 

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -198,11 +198,14 @@ public:
   Stats stats() const {
     Stats s;
     s.maxQueueDepth = queue_.max_depth();
-    s.totalSteals = totalSteals_.load(std::memory_order_relaxed);
     s.stealsPerThread.reserve(stealsPerThread_.size());
+    std::size_t totalSteals = 0;
     for (const auto &counter : stealsPerThread_) {
-      s.stealsPerThread.push_back(counter.load(std::memory_order_relaxed));
+      auto steals = counter.load(std::memory_order_relaxed);
+      s.stealsPerThread.push_back(steals);
+      totalSteals += steals;
     }
+    s.totalSteals = totalSteals;
     return s;
   }
 
@@ -218,7 +221,6 @@ private:
         outstanding_.fetch_sub(1, std::memory_order_acq_rel);
         continue;
       }
-      totalSteals_.fetch_add(1, std::memory_order_relaxed);
       if (index < stealsPerThread_.size()) {
         stealsPerThread_[index].fetch_add(1, std::memory_order_relaxed);
       }
@@ -237,6 +239,5 @@ private:
   std::atomic<std::size_t> outstanding_{0};
   std::size_t maxOutstanding_ = 0;
   std::vector<std::atomic<std::size_t>> stealsPerThread_{};
-  std::atomic<std::size_t> totalSteals_{0};
 };
 

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -29,13 +29,12 @@ public:
 
   WorkerPool(std::size_t numThreads, std::size_t queueSizePow2 = 1024,
              bool verbose = false, std::size_t maxOutstanding = 0)
-      : queue_(queueSizePow2) {
+      : queue_(queueSizePow2), stealsPerThread_(numThreads) {
     (void)verbose;
     stopping_.store(false, std::memory_order_relaxed);
     active_.store(0, std::memory_order_relaxed);
     outstanding_.store(0, std::memory_order_relaxed);
     maxOutstanding_ = maxOutstanding;
-    stealsPerThread_.resize(numThreads);
     for (std::size_t i = 0; i < numThreads; ++i) {
       threads_.emplace_back([this, i] {
         rt::init_fp_env();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES
     test_sparse_set.cpp
     test_soa_view.cpp
     test_jobqueue.cpp
+    test_queue_metrics.cpp
     test_jobqueue_perf.cpp
     test_workerpool_priority.cpp
     test_phase_graph.cpp

--- a/tests/test_queue_metrics.cpp
+++ b/tests/test_queue_metrics.cpp
@@ -1,0 +1,72 @@
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <numeric>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+#include <simcore/metrics.hpp>
+#include <simcore/worker_pool.hpp>
+
+using namespace std::chrono_literals;
+
+TEST(QueueMetrics, PublishesDepthAndSteals) {
+  WorkerPool pool(3, 256);
+  std::atomic<int> executed{0};
+  constexpr int jobs = 96;
+
+  for (int i = 0; i < jobs; ++i) {
+    if (i < 8) {
+      pool.enqueue([&] {
+        executed.fetch_add(1, std::memory_order_relaxed);
+        std::this_thread::sleep_for(1ms);
+      });
+    } else {
+      pool.enqueue([&] {
+        executed.fetch_add(1, std::memory_order_relaxed);
+      });
+    }
+  }
+
+  pool.drain();
+  auto stats = pool.stats();
+  auto sample = metrics::make_sample(std::move(stats));
+  pool.stop();
+
+  EXPECT_EQ(executed.load(), jobs);
+  EXPECT_GT(sample.queueMaxDepth, 0u);
+  EXPECT_GT(sample.totalSteals, 0u);
+  EXPECT_EQ(sample.stealsPerThread.size(), 3u);
+
+  auto stealSum = std::accumulate(sample.stealsPerThread.begin(),
+                                  sample.stealsPerThread.end(), std::size_t{0});
+  EXPECT_EQ(stealSum, sample.totalSteals);
+
+  auto json = metrics::worker_pool_json(sample);
+  EXPECT_NE(json.find("\"queue_max\""), std::string::npos);
+  EXPECT_NE(json.find("\"steals\""), std::string::npos);
+  EXPECT_NE(json.find("\"steals_total\""), std::string::npos);
+  EXPECT_NE(json.find(std::to_string(sample.queueMaxDepth)), std::string::npos);
+
+  auto counters = metrics::worker_pool_counters(sample, "pool");
+  auto findCounter = [&](std::string_view name) {
+    return std::find_if(counters.begin(), counters.end(),
+                        [&](const metrics::CounterSample &c) {
+                          return c.name == name;
+                        });
+  };
+
+  auto itQueue = findCounter("pool.queue_max");
+  ASSERT_NE(itQueue, counters.end());
+  EXPECT_EQ(itQueue->value,
+            static_cast<std::uint64_t>(sample.queueMaxDepth));
+
+  auto itSteals = findCounter("pool.steals_total");
+  ASSERT_NE(itSteals, counters.end());
+  EXPECT_EQ(itSteals->value,
+            static_cast<std::uint64_t>(sample.totalSteals));
+}
+

--- a/tests/test_rt_pipeline.cpp
+++ b/tests/test_rt_pipeline.cpp
@@ -41,7 +41,7 @@ TEST(RTPipeline, QueueMetricsAndNoThreadsInSrc) {
 
   auto stats = pool.stats();
   EXPECT_GT(stats.maxQueueDepth, 0u);
-  EXPECT_GT(stats.steals, 0u);
+  EXPECT_GT(stats.totalSteals, 0u);
 
   bool found = false;
   std::filesystem::path srcDir{PROJECT_SOURCE_DIR};


### PR DESCRIPTION
## Summary
- track bounded MPMC queue occupancy with a running count and expose a max depth accessor
- accumulate per-thread steal counters in the worker pool and surface helper APIs to export metrics
- add queue metric test coverage and include the new test in the suite while updating the RT pipeline assertions

## Testing
- cmake --preset dev *(fails: proxy returned 403 while downloading googletest)*

------
https://chatgpt.com/codex/tasks/task_e_68c9deb2dbec832b9a611714a9aadfb2