### PR TITLE
Enable fiber-based GPU fence wait with overlap test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,8 @@ add_library(simcore_rt STATIC ${RT_SOURCES})
 target_include_directories(simcore_rt PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/rt/include
     ${CMAKE_CURRENT_SOURCE_DIR}/core/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_CURRENT_SOURCE_DIR}/hal
 )
 target_link_libraries(simcore_rt PUBLIC simcore_core)
 if (UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,12 @@ add_library(simcore_core INTERFACE)
 target_include_directories(simcore_core INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/core/include)
 
 # Runtime module providing C API surface
-set(RT_SOURCES rt/src/runtime.cpp rt/src/plugin_manager.cpp rt/src/scheduler.cpp)
+set(RT_SOURCES
+    rt/src/runtime.cpp
+    rt/src/plugin_manager.cpp
+    rt/src/scheduler.cpp
+    rt/src/fiber_pool.cpp
+)
 
 if (UNIX)
     list(APPEND RT_SOURCES rt/src/crashdump_posix.cpp)

--- a/gpu/frame_graph.hpp
+++ b/gpu/frame_graph.hpp
@@ -115,13 +115,8 @@ public:
                 if (!pool_ptr)
                     pool_ptr = &ensure_pool();
                 auto* pool = pool_ptr;
-                auto wait_task = [this, fence, gpu_ns, pool, &gpu_total]() -> rt::Task {
-                    co_await rt::FiberPool::FenceAwaiter{*fence, *pool};
-                    gpu_total.fetch_add(gpu_ns->load(std::memory_order_acquire),
-                                        std::memory_order_acq_rel);
-                    co_return;
-                };
-                pool->spawn(wait_task());
+                pool->spawn(wait_for_fence_task(std::move(fence), std::move(gpu_ns), *pool,
+                                               gpu_total));
             }
         }
         if (pool_ptr)
@@ -148,6 +143,15 @@ private:
                 r.buf.size = 0;
             }
         }
+    }
+
+    static rt::Task wait_for_fence_task(std::shared_ptr<Fence> fence,
+                                        std::shared_ptr<std::atomic<hal::Duration::rep>> gpu_ns,
+                                        rt::FiberPool& pool,
+                                        std::atomic<hal::Duration::rep>& gpu_total) {
+        co_await rt::FiberPool::FenceAwaiter{*fence, pool};
+        gpu_total.fetch_add(gpu_ns->load(std::memory_order_acquire), std::memory_order_acq_rel);
+        co_return;
     }
 
     std::vector<Pass> passes_;

--- a/gpu/frame_graph.hpp
+++ b/gpu/frame_graph.hpp
@@ -51,13 +51,15 @@ struct OverlapBudget {
 
 namespace detail {
 
-inline rt::Task wait_for_fence_task(Fence fence,
-                                    std::atomic<hal::Duration::rep>* gpu_ns,
-                                    rt::FiberPool& pool,
-                                    std::atomic<hal::Duration::rep>& gpu_total) {
-    std::unique_ptr<std::atomic<hal::Duration::rep>> gpu_ns_holder{gpu_ns};
+inline rt::Task wait_for_fence_task(
+    Fence fence,
+    std::shared_ptr<std::atomic<hal::Duration::rep>> gpu_ns,
+    rt::FiberPool& pool,
+    std::atomic<hal::Duration::rep>& gpu_total) {
     co_await rt::FiberPool::FenceAwaiter{fence, pool};
-    gpu_total.fetch_add(gpu_ns_holder->load(std::memory_order_acquire), std::memory_order_acq_rel);
+    if (gpu_ns) {
+        gpu_total.fetch_add(gpu_ns->load(std::memory_order_acquire), std::memory_order_acq_rel);
+    }
     co_return;
 }
 
@@ -100,10 +102,10 @@ public:
 
         for (std::size_t i = 0; i < passes_.size(); ++i) {
             auto& p = passes_[i];
-            std::atomic<hal::Duration::rep>* gpu_ns = nullptr;
+            std::shared_ptr<std::atomic<hal::Duration::rep>> gpu_ns;
             Fence fence;
             if (p.gpu) {
-                gpu_ns = new std::atomic<hal::Duration::rep>(0);
+                gpu_ns = std::make_shared<std::atomic<hal::Duration::rep>>(0);
                 fence = submit([&, pass_idx = i, gpu_ns]() {
                     auto start = hal::now();
                     cpu_timeline_.wait(pass_idx + 1);
@@ -129,7 +131,7 @@ public:
                 if (!pool_ptr)
                     pool_ptr = &ensure_pool();
                 auto* pool = pool_ptr;
-                pool->spawn(detail::wait_for_fence_task(std::move(fence), gpu_ns,
+                pool->spawn(detail::wait_for_fence_task(std::move(fence), std::move(gpu_ns),
                                                        *pool, gpu_total));
             }
         }

--- a/gpu/frame_graph.hpp
+++ b/gpu/frame_graph.hpp
@@ -52,11 +52,12 @@ struct OverlapBudget {
 namespace detail {
 
 inline rt::Task wait_for_fence_task(Fence fence,
-                                    std::shared_ptr<std::atomic<hal::Duration::rep>> gpu_ns,
+                                    std::unique_ptr<std::atomic<hal::Duration::rep>> gpu_ns,
                                     rt::FiberPool& pool,
                                     std::atomic<hal::Duration::rep>& gpu_total) {
+    auto* gpu_ns_ptr = gpu_ns.get();
     co_await rt::FiberPool::FenceAwaiter{fence, pool};
-    gpu_total.fetch_add(gpu_ns->load(std::memory_order_acquire), std::memory_order_acq_rel);
+    gpu_total.fetch_add(gpu_ns_ptr->load(std::memory_order_acquire), std::memory_order_acq_rel);
     co_return;
 }
 
@@ -99,16 +100,17 @@ public:
 
         for (std::size_t i = 0; i < passes_.size(); ++i) {
             auto& p = passes_[i];
-            std::shared_ptr<std::atomic<hal::Duration::rep>> gpu_ns;
+            std::unique_ptr<std::atomic<hal::Duration::rep>> gpu_ns;
             Fence fence;
             if (p.gpu) {
-                gpu_ns = std::make_shared<std::atomic<hal::Duration::rep>>(0);
-                fence = submit([&, pass_idx = i, gpu_ns]() {
+                gpu_ns = std::make_unique<std::atomic<hal::Duration::rep>>(0);
+                auto* gpu_ns_ptr = gpu_ns.get();
+                fence = submit([&, pass_idx = i, gpu_ns_ptr]() {
                     auto start = hal::now();
                     cpu_timeline_.wait(pass_idx + 1);
                     p.gpu();
                     auto end = hal::now();
-                    gpu_ns->store(hal::elapsed(start, end).count(), std::memory_order_release);
+                    gpu_ns_ptr->store(hal::elapsed(start, end).count(), std::memory_order_release);
                     gpu_timeline_.signal();
                 });
             }

--- a/gpu/frame_graph.hpp
+++ b/gpu/frame_graph.hpp
@@ -51,15 +51,8 @@ struct OverlapBudget {
 
 namespace detail {
 
-inline rt::Task wait_for_fence_task(
-    Fence fence,
-    std::shared_ptr<std::atomic<hal::Duration::rep>> gpu_ns,
-    rt::FiberPool& pool,
-    std::atomic<hal::Duration::rep>& gpu_total) {
+inline rt::Task wait_for_fence_task(Fence fence, rt::FiberPool& pool) {
     co_await rt::FiberPool::FenceAwaiter{fence, pool};
-    if (gpu_ns) {
-        gpu_total.fetch_add(gpu_ns->load(std::memory_order_acquire), std::memory_order_acq_rel);
-    }
     co_return;
 }
 
@@ -102,16 +95,14 @@ public:
 
         for (std::size_t i = 0; i < passes_.size(); ++i) {
             auto& p = passes_[i];
-            std::shared_ptr<std::atomic<hal::Duration::rep>> gpu_ns;
             Fence fence;
             if (p.gpu) {
-                gpu_ns = std::make_shared<std::atomic<hal::Duration::rep>>(0);
-                fence = submit([&, pass_idx = i, gpu_ns]() {
+                fence = submit([&, pass_idx = i]() {
                     auto start = hal::now();
                     cpu_timeline_.wait(pass_idx + 1);
                     p.gpu();
                     auto end = hal::now();
-                    gpu_ns->store(hal::elapsed(start, end).count(), std::memory_order_release);
+                    gpu_total.fetch_add(hal::elapsed(start, end).count(), std::memory_order_acq_rel);
                     gpu_timeline_.signal();
                 });
             }
@@ -131,8 +122,7 @@ public:
                 if (!pool_ptr)
                     pool_ptr = &ensure_pool();
                 auto* pool = pool_ptr;
-                pool->spawn(detail::wait_for_fence_task(std::move(fence), std::move(gpu_ns),
-                                                       *pool, gpu_total));
+                pool->spawn(detail::wait_for_fence_task(std::move(fence), *pool));
             }
         }
         if (pool_ptr)

--- a/gpu/frame_graph.hpp
+++ b/gpu/frame_graph.hpp
@@ -49,6 +49,19 @@ struct OverlapBudget {
     hal::Duration gpu{0};
 };
 
+namespace detail {
+
+inline rt::Task wait_for_fence_task(Fence fence,
+                                    std::shared_ptr<std::atomic<hal::Duration::rep>> gpu_ns,
+                                    rt::FiberPool& pool,
+                                    std::atomic<hal::Duration::rep>& gpu_total) {
+    co_await rt::FiberPool::FenceAwaiter{fence, pool};
+    gpu_total.fetch_add(gpu_ns->load(std::memory_order_acquire), std::memory_order_acq_rel);
+    co_return;
+}
+
+} // namespace detail
+
 class FrameGraph {
 public:
     using PassFn = std::function<void()>;
@@ -87,17 +100,17 @@ public:
         for (std::size_t i = 0; i < passes_.size(); ++i) {
             auto& p = passes_[i];
             std::shared_ptr<std::atomic<hal::Duration::rep>> gpu_ns;
-            std::shared_ptr<Fence> fence;
+            Fence fence;
             if (p.gpu) {
                 gpu_ns = std::make_shared<std::atomic<hal::Duration::rep>>(0);
-                fence = std::make_shared<Fence>(submit([&, pass_idx = i, gpu_ns]() {
+                fence = submit([&, pass_idx = i, gpu_ns]() {
                     auto start = hal::now();
                     cpu_timeline_.wait(pass_idx + 1);
                     p.gpu();
                     auto end = hal::now();
                     gpu_ns->store(hal::elapsed(start, end).count(), std::memory_order_release);
                     gpu_timeline_.signal();
-                }));
+                });
             }
             bool cpu_signaled = false;
             if (p.cpu) {
@@ -115,8 +128,8 @@ public:
                 if (!pool_ptr)
                     pool_ptr = &ensure_pool();
                 auto* pool = pool_ptr;
-                pool->spawn(wait_for_fence_task(std::move(fence), std::move(gpu_ns), *pool,
-                                               gpu_total));
+                pool->spawn(detail::wait_for_fence_task(std::move(fence), std::move(gpu_ns),
+                                                       *pool, gpu_total));
             }
         }
         if (pool_ptr)
@@ -143,15 +156,6 @@ private:
                 r.buf.size = 0;
             }
         }
-    }
-
-    static rt::Task wait_for_fence_task(std::shared_ptr<Fence> fence,
-                                        std::shared_ptr<std::atomic<hal::Duration::rep>> gpu_ns,
-                                        rt::FiberPool& pool,
-                                        std::atomic<hal::Duration::rep>& gpu_total) {
-        co_await rt::FiberPool::FenceAwaiter{*fence, pool};
-        gpu_total.fetch_add(gpu_ns->load(std::memory_order_acquire), std::memory_order_acq_rel);
-        co_return;
     }
 
     std::vector<Pass> passes_;

--- a/gpu/frame_graph.hpp
+++ b/gpu/frame_graph.hpp
@@ -49,15 +49,6 @@ struct OverlapBudget {
     hal::Duration gpu{0};
 };
 
-namespace detail {
-
-inline rt::Task wait_for_fence_task(Fence fence, rt::FiberPool& pool) {
-    co_await rt::FiberPool::FenceAwaiter{fence, pool};
-    co_return;
-}
-
-} // namespace detail
-
 class FrameGraph {
 public:
     using PassFn = std::function<void()>;
@@ -122,7 +113,7 @@ public:
                 if (!pool_ptr)
                     pool_ptr = &ensure_pool();
                 auto* pool = pool_ptr;
-                pool->spawn(detail::wait_for_fence_task(std::move(fence), *pool));
+                pool->wait_for_fence(std::move(fence));
             }
         }
         if (pool_ptr)

--- a/gpu/frame_graph.hpp
+++ b/gpu/frame_graph.hpp
@@ -52,12 +52,12 @@ struct OverlapBudget {
 namespace detail {
 
 inline rt::Task wait_for_fence_task(Fence fence,
-                                    std::unique_ptr<std::atomic<hal::Duration::rep>> gpu_ns,
+                                    std::atomic<hal::Duration::rep>* gpu_ns,
                                     rt::FiberPool& pool,
                                     std::atomic<hal::Duration::rep>& gpu_total) {
-    auto* gpu_ns_ptr = gpu_ns.get();
+    std::unique_ptr<std::atomic<hal::Duration::rep>> gpu_ns_holder{gpu_ns};
     co_await rt::FiberPool::FenceAwaiter{fence, pool};
-    gpu_total.fetch_add(gpu_ns_ptr->load(std::memory_order_acquire), std::memory_order_acq_rel);
+    gpu_total.fetch_add(gpu_ns_holder->load(std::memory_order_acquire), std::memory_order_acq_rel);
     co_return;
 }
 
@@ -100,17 +100,16 @@ public:
 
         for (std::size_t i = 0; i < passes_.size(); ++i) {
             auto& p = passes_[i];
-            std::unique_ptr<std::atomic<hal::Duration::rep>> gpu_ns;
+            std::atomic<hal::Duration::rep>* gpu_ns = nullptr;
             Fence fence;
             if (p.gpu) {
-                gpu_ns = std::make_unique<std::atomic<hal::Duration::rep>>(0);
-                auto* gpu_ns_ptr = gpu_ns.get();
-                fence = submit([&, pass_idx = i, gpu_ns_ptr]() {
+                gpu_ns = new std::atomic<hal::Duration::rep>(0);
+                fence = submit([&, pass_idx = i, gpu_ns]() {
                     auto start = hal::now();
                     cpu_timeline_.wait(pass_idx + 1);
                     p.gpu();
                     auto end = hal::now();
-                    gpu_ns_ptr->store(hal::elapsed(start, end).count(), std::memory_order_release);
+                    gpu_ns->store(hal::elapsed(start, end).count(), std::memory_order_release);
                     gpu_timeline_.signal();
                 });
             }
@@ -130,7 +129,7 @@ public:
                 if (!pool_ptr)
                     pool_ptr = &ensure_pool();
                 auto* pool = pool_ptr;
-                pool->spawn(detail::wait_for_fence_task(std::move(fence), std::move(gpu_ns),
+                pool->spawn(detail::wait_for_fence_task(std::move(fence), gpu_ns,
                                                        *pool, gpu_total));
             }
         }

--- a/gpu/frame_graph.hpp
+++ b/gpu/frame_graph.hpp
@@ -5,11 +5,13 @@
 #include <cstdint>
 #include <functional>
 #include <initializer_list>
+#include <memory>
 #include <thread>
 #include <vector>
 
 #include "hal/hal.hpp"
 #include "hal/gpu_stub.hpp"
+#include <rt/fiber_pool.hpp>
 
 namespace simcore::hal::gpu {
 
@@ -52,6 +54,11 @@ public:
     using PassFn = std::function<void()>;
     struct Pass { PassFn cpu; PassFn gpu; };
 
+    FrameGraph() = default;
+    explicit FrameGraph(rt::FiberPool* pool) : externalPool_(pool) {}
+
+    void set_fiber_pool(rt::FiberPool* pool) { externalPool_ = pool; }
+
     ~FrameGraph() {
         for (auto& r : resources_) {
             if (r.buf.data) hal::free(r.buf.data);
@@ -74,34 +81,54 @@ public:
     OverlapBudget execute() {
         OverlapBudget budget{};
         auto total_start = hal::now();
+        std::atomic<hal::Duration::rep> gpu_total{0};
+        rt::FiberPool* pool_ptr = nullptr;
+
         for (std::size_t i = 0; i < passes_.size(); ++i) {
             auto& p = passes_[i];
-            Fence fence;
-            std::atomic<hal::Duration::rep> gpu_ns{0};
+            std::shared_ptr<std::atomic<hal::Duration::rep>> gpu_ns;
+            std::shared_ptr<Fence> fence;
             if (p.gpu) {
-                fence = submit([&, pass_idx = i]() {
+                gpu_ns = std::make_shared<std::atomic<hal::Duration::rep>>(0);
+                fence = std::make_shared<Fence>(submit([&, pass_idx = i, gpu_ns]() {
                     auto start = hal::now();
                     cpu_timeline_.wait(pass_idx + 1);
                     p.gpu();
                     auto end = hal::now();
-                    gpu_ns.store(hal::elapsed(start, end).count(), std::memory_order_release);
+                    gpu_ns->store(hal::elapsed(start, end).count(), std::memory_order_release);
                     gpu_timeline_.signal();
-                });
+                }));
             }
+            bool cpu_signaled = false;
             if (p.cpu) {
                 auto start = hal::now();
                 p.cpu();
                 budget.cpu += hal::elapsed(start, hal::now());
                 cpu_timeline_.signal();
+                cpu_signaled = true;
+            }
+            if (p.gpu && !cpu_signaled) {
+                cpu_timeline_.signal();
+                cpu_signaled = true;
             }
             if (p.gpu) {
-                ::simcore::hal::gpu::fence_wait(
-                    fence,
-                    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::hours(24)));
-                budget.gpu += hal::Duration{gpu_ns.load(std::memory_order_acquire)};
+                if (!pool_ptr)
+                    pool_ptr = &ensure_pool();
+                auto* pool = pool_ptr;
+                auto wait_task = [this, fence, gpu_ns, pool, &gpu_total]() -> rt::Task {
+                    co_await rt::FiberPool::FenceAwaiter{*fence, *pool};
+                    gpu_total.fetch_add(gpu_ns->load(std::memory_order_acquire),
+                                        std::memory_order_acq_rel);
+                    co_return;
+                };
+                pool->spawn(wait_task());
             }
-            free_dead_resources(i);
         }
+        if (pool_ptr)
+            pool_ptr->drain();
+        for (std::size_t i = 0; i < passes_.size(); ++i)
+            free_dead_resources(i);
+        budget.gpu = hal::Duration{gpu_total.load(std::memory_order_acquire)};
         auto total = hal::elapsed(total_start, hal::now());
         auto raw = budget.cpu + budget.gpu - total;
         overlap_ = raw.count() > 0 ? raw : hal::Duration{0};
@@ -128,6 +155,20 @@ private:
     TimelineSemaphore cpu_timeline_;
     TimelineSemaphore gpu_timeline_;
     hal::Duration overlap_{0};
+    rt::FiberPool* externalPool_{nullptr};
+    std::unique_ptr<rt::FiberPool> ownedPool_;
+
+    rt::FiberPool& ensure_pool() {
+        if (externalPool_)
+            return *externalPool_;
+        if (!ownedPool_) {
+            auto threads = std::thread::hardware_concurrency();
+            if (threads == 0)
+                threads = 1;
+            ownedPool_ = std::make_unique<rt::FiberPool>(threads);
+        }
+        return *ownedPool_;
+    }
 };
 
 // Stubs for mixed compute submissions.

--- a/rt/include/rt/fiber_pool.hpp
+++ b/rt/include/rt/fiber_pool.hpp
@@ -61,10 +61,8 @@ public:
     }
 
     void drain() {
-        using namespace std::chrono_literals;
-        while (pending_.load(std::memory_order_acquire) > 0) {
-            std::this_thread::sleep_for(1ms);
-        }
+        std::unique_lock<std::mutex> lock(pendingMutex_);
+        pendingCv_.wait(lock, [this] { return pending_.load(std::memory_order_acquire) == 0; });
     }
 
     void stop() {
@@ -135,7 +133,10 @@ private:
             h.resume();
             if (h.done()) {
                 h.destroy();
-                pending_.fetch_sub(1, std::memory_order_acq_rel);
+                if (pending_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+                    std::lock_guard<std::mutex> lock(pendingMutex_);
+                    pendingCv_.notify_all();
+                }
             }
         }
     }
@@ -171,6 +172,8 @@ private:
     std::vector<WaitItem> waiters_;
     std::thread poller_;
 
+    std::mutex pendingMutex_;
+    std::condition_variable pendingCv_;
     std::atomic<std::size_t> pending_{0};
 };
 

--- a/rt/include/rt/fiber_pool.hpp
+++ b/rt/include/rt/fiber_pool.hpp
@@ -60,6 +60,8 @@ public:
         task.h = {};
     }
 
+    void wait_for_fence(simcore::hal::Fence fence);
+
     void drain() {
         std::unique_lock<std::mutex> lock(pendingMutex_);
         pendingCv_.wait(lock, [this] { return pending_.load(std::memory_order_acquire) == 0; });

--- a/rt/src/fiber_pool.cpp
+++ b/rt/src/fiber_pool.cpp
@@ -1,0 +1,21 @@
+#include <rt/fiber_pool.hpp>
+
+#include <utility>
+
+namespace rt {
+
+namespace {
+
+Task wait_for_fence_task(simcore::hal::Fence fence, FiberPool& pool) {
+    co_await FiberPool::FenceAwaiter{fence, pool};
+    co_return;
+}
+
+} // namespace
+
+void FiberPool::wait_for_fence(simcore::hal::Fence fence) {
+    spawn(wait_for_fence_task(std::move(fence), *this));
+}
+
+} // namespace rt
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ set(TEST_SOURCES
     test_narrowphase.cpp
     test_hal.cpp
     test_gpu_stub.cpp
+    test_gpu_overlap.cpp
     test_frame_graph.cpp
     test_watchdog.cpp
     test_rt_watchdog.cpp

--- a/tests/test_gpu_overlap.cpp
+++ b/tests/test_gpu_overlap.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include <gpu/frame_graph.hpp>
+#include <simcore/hal.hpp>
+
+#include <chrono>
+#include <thread>
+
+using simcore::hal::gpu::FrameGraph;
+
+TEST(GPUOverlap, FiberFenceAwaitYieldsWork) {
+    using namespace std::chrono_literals;
+
+    FrameGraph fg;
+    constexpr auto gpu_time = 80ms;
+    constexpr auto cpu_time = 60ms;
+
+    fg.add_pass(
+        []() {},
+        [&]() {
+            std::this_thread::sleep_for(gpu_time);
+        });
+
+    fg.add_pass(
+        [&]() {
+            auto start = simcore::hal::now();
+            while (simcore::hal::elapsed(start, simcore::hal::now()) < cpu_time) {
+                std::this_thread::yield();
+            }
+        },
+        FrameGraph::PassFn{}
+    );
+
+    auto start = simcore::hal::now();
+    auto budget = fg.execute();
+    auto total = simcore::hal::elapsed(start, simcore::hal::now());
+
+    auto cpu_ms = std::chrono::duration_cast<std::chrono::milliseconds>(budget.cpu).count();
+    auto gpu_ms = std::chrono::duration_cast<std::chrono::milliseconds>(budget.gpu).count();
+    auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(total).count();
+    auto overlap_ms = std::chrono::duration_cast<std::chrono::milliseconds>(fg.overlap()).count();
+
+    EXPECT_GE(cpu_ms, cpu_time.count() - 10);
+    EXPECT_GE(gpu_ms, gpu_time.count() - 10);
+    EXPECT_LT(total_ms, cpu_ms + gpu_ms);
+    EXPECT_GT(overlap_ms, 0);
+}


### PR DESCRIPTION
## Summary
- have FrameGraph submit GPU work and await completion through the fiber pool so CPU passes can keep running
- extend FiberPool::drain to use a condition variable for fast wakeups when tasks finish
- add a GPU/CPU overlap regression test and wire it into the test suite

## Testing
- cmake --preset dev *(fails: cannot download googletest because outbound network is blocked in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68ca125caef8832bba4d1eecdf6b19e2