### PR TITLE
Add detailed runtime trace events and coverage test

### DIFF
--- a/gpu/frame_graph.hpp
+++ b/gpu/frame_graph.hpp
@@ -12,6 +12,7 @@
 #include "hal/hal.hpp"
 #include "hal/gpu_stub.hpp"
 #include <rt/fiber_pool.hpp>
+#include <simcore/bintrace.hpp>
 
 namespace simcore::hal::gpu {
 
@@ -83,6 +84,7 @@ public:
         auto total_start = hal::now();
         std::atomic<hal::Duration::rep> gpu_total{0};
         rt::FiberPool* pool_ptr = nullptr;
+        std::size_t pendingFences = 0;
 
         for (std::size_t i = 0; i < passes_.size(); ++i) {
             auto& p = passes_[i];
@@ -113,11 +115,27 @@ public:
                 if (!pool_ptr)
                     pool_ptr = &ensure_pool();
                 auto* pool = pool_ptr;
+                pendingFences++;
                 pool->wait_for_fence(std::move(fence));
             }
         }
-        if (pool_ptr)
+        if (pool_ptr) {
+            if (pendingFences) {
+                if (auto* trace = bintrace::global_trace()) {
+                    trace->log(bintrace::EV_GpuFenceWaitBegin,
+                               static_cast<std::uint32_t>(pendingFences),
+                               static_cast<std::uint64_t>(passes_.size()));
+                }
+            }
             pool_ptr->drain();
+            if (pendingFences) {
+                if (auto* trace = bintrace::global_trace()) {
+                    trace->log(bintrace::EV_GpuFenceWaitEnd,
+                               static_cast<std::uint32_t>(pendingFences),
+                               static_cast<std::uint64_t>(passes_.size()));
+                }
+            }
+        }
         for (std::size_t i = 0; i < passes_.size(); ++i)
             free_dead_resources(i);
         budget.gpu = hal::Duration{gpu_total.load(std::memory_order_acquire)};

--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -284,6 +284,7 @@ public:
         std::chrono::hours(24), std::chrono::hours(24), [this] {
           watchdogTrips_.fetch_add(1, std::memory_order_acq_rel);
           watchdogLimp_.store(true, std::memory_order_release);
+          watchdogTripPending_.fetch_add(1, std::memory_order_acq_rel);
           if (logger_)
             LOG_TRACE(logger_, "[WD] trip frame={} ", frame_);
           applyDegradeRung(4);
@@ -297,7 +298,11 @@ public:
 
   void setLogger(Logger *l) { logger_ = l; }
   void setProfiler(Profiler *p) { profiler_ = p; }
-  void setWorkerPool(WorkerPool *pool) { pool_ = pool; }
+  void setWorkerPool(WorkerPool *pool) {
+    pool_ = pool;
+    workerPoolTraceAttached_ = false;
+    attachWorkerPoolTrace();
+  }
   void setBudgetCallback(std::function<void(const BudgetSample &)> cb) {
     budgetCb_ = std::move(cb);
   }
@@ -489,6 +494,9 @@ public:
   double lastDriftMs() const { return lastDriftMs_; }
 
   std::vector<std::uint8_t> saveFrame() const {
+    const_cast<SimCore *>(this)->bintrace_.log(
+        bintrace::EV_SnapshotSave, static_cast<std::uint32_t>(frame_),
+        static_cast<std::uint64_t>(frame_));
     rt::SnapshotWriter w;
     w.write<std::uint64_t>(static_cast<std::uint64_t>(frame_));
     w.write<std::uint64_t>(rngSeed_);
@@ -527,6 +535,9 @@ public:
     std::uint64_t tmp = 0;
     r.read(tmp);
     frame_ = static_cast<std::int64_t>(tmp);
+    bintrace_.log(bintrace::EV_SnapshotLoad,
+                  static_cast<std::uint32_t>(frame_),
+                  static_cast<std::uint64_t>(frame_));
     r.read(rngSeed_);
     r.read(tmp);
     subSteps_ = static_cast<int>(tmp);
@@ -605,8 +616,11 @@ private:
     workerCount_ = settings_.threads;
     std::vector<int> threadNodes(workerCount_ + 1, -1);
 
+    workerPoolTraceAttached_ = false;
+    workerPoolTraceBase_ = 0;
     bintrace_.init(workerCount_ + 1, settings_.bintraceEventsPerThread,
                    settings_.bintraceEnable);
+    bintrace::set_global_trace(&bintrace_);
 
     shutdown_.store(false, std::memory_order_relaxed);
 
@@ -681,6 +695,7 @@ private:
     }
     frameArenas_->bindCurrentThread(workerCount_); // main
     bintrace_.bindThread(workerCount_);
+    attachWorkerPoolTrace();
     rt::init_fp_env();
     fiberPool_ = std::make_unique<rt::FiberPool>(workerCount_);
   }
@@ -692,6 +707,10 @@ private:
         fiberPool_.reset();
       }
       bintrace_.shutdown();
+      if (bintrace::global_trace() == &bintrace_)
+        bintrace::set_global_trace(nullptr);
+      workerPoolTraceAttached_ = false;
+      workerPoolTraceBase_ = 0;
       return;
     }
     shutdown_.store(true, std::memory_order_release);
@@ -704,6 +723,23 @@ private:
       fiberPool_.reset();
     }
     bintrace_.shutdown();
+    if (bintrace::global_trace() == &bintrace_)
+      bintrace::set_global_trace(nullptr);
+    workerPoolTraceAttached_ = false;
+    workerPoolTraceBase_ = 0;
+  }
+
+  void attachWorkerPoolTrace() {
+    if (!pool_ || !bintrace_.enabled())
+      return;
+    const std::size_t threads = pool_->thread_count();
+    if (threads == 0)
+      return;
+    if (!workerPoolTraceAttached_) {
+      workerPoolTraceBase_ = bintrace_.appendThreads(threads);
+      workerPoolTraceAttached_ = true;
+    }
+    pool_->setTrace(&bintrace_, workerPoolTraceBase_);
   }
 
   void workerLoop() {
@@ -1295,6 +1331,13 @@ private:
   }
 
   void executeFrame() {
+    int pendingTrips = watchdogTripPending_.exchange(0, std::memory_order_acq_rel);
+    while (pendingTrips-- > 0) {
+      bintrace_.log(bintrace::EV_WatchdogTrip,
+                    static_cast<std::uint32_t>(frame_),
+                    static_cast<std::uint64_t>(
+                        watchdogTrips_.load(std::memory_order_acquire)));
+    }
     if (watchdog_) {
       auto budget =
           std::chrono::duration_cast<std::chrono::milliseconds>(outerDt_ * 1.25);
@@ -1554,12 +1597,15 @@ private:
   std::unique_ptr<rt::Watchdog> watchdog_;
   std::atomic<int> watchdogTrips_{0};
   std::atomic<bool> watchdogLimp_{false};
+  std::atomic<int> watchdogTripPending_{0};
   std::unordered_map<std::string, std::size_t> chunkCache_;
   std::string machineId_;
 
   Logger *logger_ = nullptr;
   Profiler *profiler_ = nullptr;
   WorkerPool *pool_ = nullptr;
+  std::size_t workerPoolTraceBase_ = 0;
+  bool workerPoolTraceAttached_ = false;
 };
 
 #if RTFW_ENFORCE_NO_RAW_THREADS

--- a/include/simcore/bintrace.hpp
+++ b/include/simcore/bintrace.hpp
@@ -2,9 +2,9 @@
 #include <cstdint>
 #include <cstddef>
 #include <vector>
+#include <memory>
 #include <atomic>
 #include <cstring>
-#include <memory>
 #include <cassert>
 #include <new>
 #include <fstream>
@@ -51,13 +51,13 @@ public:
         enabled_ = enabled;
         eventsPerThread_ = eventsPerThread;
         buffers_.clear();
-        buffers_.resize(threads); // needs movable/default-constructible Buffer
-        for (std::size_t i=0;i<threads;++i) {
-            Buffer& b = buffers_[i];
-            b.cap = eventsPerThread;
-            b.mem = ::operator new(b.cap * sizeof(Event), std::align_val_t(64));
-            b.base = static_cast<Event*>(b.mem);
-            b.write.store(0, std::memory_order_relaxed);
+        buffers_.reserve(threads);
+        for (std::size_t i = 0; i < threads; ++i) {
+            auto buf = std::make_unique<Buffer>();
+            if (eventsPerThread_) {
+                buf->allocate(eventsPerThread_);
+            }
+            buffers_.emplace_back(std::move(buf));
         }
         tlsBuf_ = nullptr;
         tlsThreadIdx_ = ~std::size_t{0};
@@ -66,10 +66,8 @@ public:
     void shutdown() {
         eventsPerThread_ = 0;
         for (auto& b : buffers_) {
-            if (b.mem) {
-                ::operator delete(b.mem, std::align_val_t(64));
-                b.mem = nullptr; b.base = nullptr; b.cap = 0;
-                b.write.store(0, std::memory_order_relaxed);
+            if (b) {
+                b->release();
             }
         }
         buffers_.clear();
@@ -83,15 +81,13 @@ public:
         if (count == 0)
             return buffers_.size();
         const std::size_t base = buffers_.size();
-        buffers_.resize(base + count);
-        if (eventsPerThread_ == 0)
-            return base;
-        for (std::size_t i = base; i < buffers_.size(); ++i) {
-            Buffer &b = buffers_[i];
-            b.cap = eventsPerThread_;
-            b.mem = ::operator new(b.cap * sizeof(Event), std::align_val_t(64));
-            b.base = static_cast<Event *>(b.mem);
-            b.write.store(0, std::memory_order_relaxed);
+        buffers_.reserve(base + count);
+        for (std::size_t i = 0; i < count; ++i) {
+            auto buf = std::make_unique<Buffer>();
+            if (eventsPerThread_) {
+                buf->allocate(eventsPerThread_);
+            }
+            buffers_.emplace_back(std::move(buf));
         }
         return base;
     }
@@ -100,7 +96,7 @@ public:
 
     void bindThread(std::size_t idx) {
         if (idx >= buffers_.size()) return;
-        tlsBuf_ = &buffers_[idx];
+        tlsBuf_ = buffers_[idx].get();
         tlsThreadIdx_ = idx;
     }
 
@@ -129,7 +125,7 @@ public:
         s.perThreadCount.resize(buffers_.size(), 0);
         std::size_t total = 0;
         for (std::size_t t=0; t<buffers_.size(); ++t) {
-            const Buffer& b = buffers_[t];
+            const Buffer& b = *buffers_[t];
             const std::size_t w = b.write.load(std::memory_order_acquire);
             std::size_t n = (w < b.cap) ? w : b.cap;
             s.perThreadCount[t] = n;
@@ -139,7 +135,7 @@ public:
 
         std::size_t cursor = 0;
         for (std::size_t t=0; t<buffers_.size(); ++t) {
-            const Buffer& b = buffers_[t];
+            const Buffer& b = *buffers_[t];
             const std::size_t w = b.write.load(std::memory_order_acquire);
             const std::size_t cap = b.cap;
             const std::size_t n = s.perThreadCount[t];
@@ -171,7 +167,7 @@ public:
              static_cast<std::uint32_t>(sizeof(Event))};
         f.write(reinterpret_cast<const char*>(&h), sizeof(h));
         for (std::size_t t=0; t<buffers_.size(); ++t) {
-            const Buffer& b = buffers_[t];
+            const Buffer& b = *buffers_[t];
             const std::size_t w = b.write.load(std::memory_order_acquire);
             const std::size_t n = (w < b.cap) ? w : b.cap;
             std::uint64_t cnt = static_cast<std::uint64_t>(n);
@@ -196,30 +192,36 @@ private:
         void*     mem   = nullptr;
         Event*    base  = nullptr;
         std::size_t cap = 0;
-        std::atomic<std::size_t> write;
+        std::atomic<std::size_t> write{0};
 
-        Buffer() : write(0) {}
-
-        // non-copyable (atomic)
+        Buffer() = default;
         Buffer(const Buffer&) = delete;
         Buffer& operator=(const Buffer&) = delete;
 
-        // movable (manual because atomic is non-movable)
-        Buffer(Buffer&& o) noexcept
-            : mem(o.mem), base(o.base), cap(o.cap), write(o.write.load(std::memory_order_relaxed)) {
-            o.mem = nullptr; o.base = nullptr; o.cap = 0; o.write.store(0, std::memory_order_relaxed);
+        ~Buffer() { release(); }
+
+        void allocate(std::size_t newCap) {
+            release();
+            if (newCap == 0)
+                return;
+            cap = newCap;
+            mem = ::operator new(cap * sizeof(Event), std::align_val_t(64));
+            base = static_cast<Event*>(mem);
+            write.store(0, std::memory_order_relaxed);
         }
-        Buffer& operator=(Buffer&& o) noexcept {
-            if (this != &o) {
-                mem = o.mem; base = o.base; cap = o.cap;
-                write.store(o.write.load(std::memory_order_relaxed), std::memory_order_relaxed);
-                o.mem = nullptr; o.base = nullptr; o.cap = 0; o.write.store(0, std::memory_order_relaxed);
+
+        void release() {
+            if (mem) {
+                ::operator delete(mem, std::align_val_t(64));
+                mem = nullptr;
+                base = nullptr;
+                cap = 0;
+                write.store(0, std::memory_order_relaxed);
             }
-            return *this;
         }
     };
 
-    std::vector<Buffer> buffers_;
+    std::vector<std::unique_ptr<Buffer>> buffers_;
     bool enabled_ = false;
     std::size_t eventsPerThread_ = 0;
 

--- a/include/simcore/bintrace.hpp
+++ b/include/simcore/bintrace.hpp
@@ -23,11 +23,20 @@ struct alignas(32) Event {
 };
 
 enum : std::uint32_t {
-    EV_PhaseBegin  = 0x01,
-    EV_PhaseEnd    = 0x02,
-    EV_ChunkStart  = 0x03,
-    EV_ChunkDone   = 0x04,
-    EV_BudgetLadder = 0x05,
+    EV_PhaseBegin        = 0x01,
+    EV_PhaseEnd          = 0x02,
+    EV_ChunkStart        = 0x03,
+    EV_ChunkDone         = 0x04,
+    EV_GovernorRung      = 0x05,
+    EV_BudgetLadder      = EV_GovernorRung,
+    EV_QueuePush         = 0x06,
+    EV_QueuePop          = 0x07,
+    EV_WorkSteal         = 0x08,
+    EV_WatchdogTrip      = 0x09,
+    EV_GpuFenceWaitBegin = 0x0A,
+    EV_GpuFenceWaitEnd   = 0x0B,
+    EV_SnapshotSave      = 0x0C,
+    EV_SnapshotLoad      = 0x0D,
 };
 
 static inline std::uint64_t rdtsc() noexcept {
@@ -40,6 +49,7 @@ public:
 
     void init(std::size_t threads, std::size_t eventsPerThread, bool enabled) {
         enabled_ = enabled;
+        eventsPerThread_ = eventsPerThread;
         buffers_.clear();
         buffers_.resize(threads); // needs movable/default-constructible Buffer
         for (std::size_t i=0;i<threads;++i) {
@@ -54,6 +64,7 @@ public:
     }
 
     void shutdown() {
+        eventsPerThread_ = 0;
         for (auto& b : buffers_) {
             if (b.mem) {
                 ::operator delete(b.mem, std::align_val_t(64));
@@ -64,6 +75,25 @@ public:
         buffers_.clear();
         tlsBuf_ = nullptr;
         tlsThreadIdx_ = ~std::size_t{0};
+    }
+
+    std::size_t threadCount() const noexcept { return buffers_.size(); }
+
+    std::size_t appendThreads(std::size_t count) {
+        if (count == 0)
+            return buffers_.size();
+        const std::size_t base = buffers_.size();
+        buffers_.resize(base + count);
+        if (eventsPerThread_ == 0)
+            return base;
+        for (std::size_t i = base; i < buffers_.size(); ++i) {
+            Buffer &b = buffers_[i];
+            b.cap = eventsPerThread_;
+            b.mem = ::operator new(b.cap * sizeof(Event), std::align_val_t(64));
+            b.base = static_cast<Event *>(b.mem);
+            b.write.store(0, std::memory_order_relaxed);
+        }
+        return base;
     }
 
     bool enabled() const noexcept { return enabled_; }
@@ -191,6 +221,7 @@ private:
 
     std::vector<Buffer> buffers_;
     bool enabled_ = false;
+    std::size_t eventsPerThread_ = 0;
 
     // TLS writer cursor
     static thread_local Buffer* tlsBuf_;
@@ -199,5 +230,29 @@ private:
 
 inline thread_local typename Trace::Buffer* Trace::tlsBuf_ = nullptr;
 inline thread_local std::size_t            Trace::tlsThreadIdx_ = ~std::size_t{0};
+
+namespace detail {
+inline std::atomic<Trace*> g_trace{nullptr};
+} // namespace detail
+
+inline void set_global_trace(Trace* trace) {
+    detail::g_trace.store(trace, std::memory_order_release);
+}
+
+inline Trace* global_trace() {
+    return detail::g_trace.load(std::memory_order_acquire);
+}
+
+inline void log_queue_push(std::uint32_t depth, std::uint64_t capacity = 0) {
+    if (auto* trace = global_trace()) {
+        trace->log(EV_QueuePush, depth, capacity);
+    }
+}
+
+inline void log_queue_pop(std::uint32_t depth, std::uint64_t capacity = 0) {
+    if (auto* trace = global_trace()) {
+        trace->log(EV_QueuePop, depth, capacity);
+    }
+}
 
 } // namespace bintrace

--- a/include/simcore/job_queue.hpp
+++ b/include/simcore/job_queue.hpp
@@ -3,9 +3,12 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <new>
 #include <utility>
 #include <vector>
+
+#include "bintrace.hpp"
 
 #if defined(_MSC_VER)
 #pragma warning(push)
@@ -66,11 +69,16 @@ public:
     enqueueCache_ = pos + 1;
     cell->data = std::forward<U>(v);
     cell->sequence.store(pos + 1, std::memory_order_release);
-    auto depth = count_.fetch_add(1, std::memory_order_acq_rel) + 1;
+    auto prevCount = count_.fetch_add(1, std::memory_order_acq_rel);
+    auto depth = prevCount + 1;
     auto prev = maxDepth_.load(std::memory_order_relaxed);
     while (depth > prev &&
            !maxDepth_.compare_exchange_weak(prev, depth,
                                             std::memory_order_relaxed)) {
+    }
+    if (depth <= std::numeric_limits<std::uint32_t>::max()) {
+        bintrace::log_queue_push(static_cast<std::uint32_t>(depth),
+                                 static_cast<std::uint64_t>(mask_ + 1));
     }
     return true;
   }
@@ -100,7 +108,12 @@ public:
     dequeueCache_ = pos + 1;
     out = std::move(cell->data);
     cell->sequence.store(pos + buffer_.size(), std::memory_order_release);
-    count_.fetch_sub(1, std::memory_order_acq_rel);
+    auto prevCount = count_.fetch_sub(1, std::memory_order_acq_rel);
+    auto depth = (prevCount > 0) ? (prevCount - 1) : 0;
+    if (depth <= std::numeric_limits<std::uint32_t>::max()) {
+        bintrace::log_queue_pop(static_cast<std::uint32_t>(depth),
+                                static_cast<std::uint64_t>(mask_ + 1));
+    }
     return true;
   }
 

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -1,10 +1,12 @@
 #pragma once
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <thread>
 #include <vector>
 #include <rt/numerics.hpp>
+#include "bintrace.hpp"
 #include "job_queue.hpp"
 #include "debug.hpp"
 
@@ -200,6 +202,11 @@ public:
     return outstanding_.load(std::memory_order_acquire);
   }
 
+  void setTrace(bintrace::Trace *trace, std::size_t baseIndex) {
+    traceBase_.store(baseIndex, std::memory_order_release);
+    trace_.store(trace, std::memory_order_release);
+  }
+
   Stats stats() const {
     Stats s;
     s.maxQueueDepth = queue_.max_depth();
@@ -216,7 +223,15 @@ public:
 
 private:
   void workerLoop(std::size_t index) {
+    bool bound = false;
     for (;;) {
+      if (!bound) {
+        if (auto *trace = trace_.load(std::memory_order_acquire)) {
+          const std::size_t base = traceBase_.load(std::memory_order_acquire);
+          trace->bindThread(base + index);
+          bound = true;
+        }
+      }
       Job job;
       if (queue_.try_pop(job)) {
         active_.fetch_add(1, std::memory_order_acq_rel);
@@ -228,6 +243,13 @@ private:
       }
       if (index < stealsPerThread_.size()) {
         stealsPerThread_[index].fetch_add(1, std::memory_order_relaxed);
+      }
+      if (auto *trace = trace_.load(std::memory_order_acquire)) {
+        if (outstanding_.load(std::memory_order_acquire) > 0) {
+          trace->log(bintrace::EV_WorkSteal,
+                     static_cast<std::uint32_t>(index),
+                     static_cast<std::uint64_t>(queue_.size()));
+        }
       }
       if (stopping_.load(std::memory_order_acquire) &&
           outstanding_.load(std::memory_order_acquire) == 0) {
@@ -244,5 +266,7 @@ private:
   std::atomic<std::size_t> outstanding_{0};
   std::size_t maxOutstanding_ = 0;
   std::vector<std::atomic<std::size_t>> stealsPerThread_{};
+  std::atomic<bintrace::Trace *> trace_{nullptr};
+  std::atomic<std::size_t> traceBase_{0};
 };
 

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -224,6 +224,7 @@ public:
 private:
   void workerLoop(std::size_t index) {
     bool bound = false;
+    bool stealLogged = false;
     for (;;) {
       if (!bound) {
         if (auto *trace = trace_.load(std::memory_order_acquire)) {
@@ -239,6 +240,7 @@ private:
           job.fn();
         active_.fetch_sub(1, std::memory_order_acq_rel);
         outstanding_.fetch_sub(1, std::memory_order_acq_rel);
+        stealLogged = false;
         continue;
       }
       if (index < stealsPerThread_.size()) {
@@ -246,9 +248,14 @@ private:
       }
       if (auto *trace = trace_.load(std::memory_order_acquire)) {
         if (outstanding_.load(std::memory_order_acquire) > 0) {
-          trace->log(bintrace::EV_WorkSteal,
-                     static_cast<std::uint32_t>(index),
-                     static_cast<std::uint64_t>(queue_.size()));
+          if (!stealLogged) {
+            trace->log(bintrace::EV_WorkSteal,
+                       static_cast<std::uint32_t>(index),
+                       static_cast<std::uint64_t>(queue_.size()));
+            stealLogged = true;
+          }
+        } else {
+          stealLogged = false;
         }
       }
       if (stopping_.load(std::memory_order_acquire) &&

--- a/tests/test_rt_pipeline.cpp
+++ b/tests/test_rt_pipeline.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <vector>
 #include <thread>
@@ -11,6 +12,8 @@
 #include <gtest/gtest.h>
 #include <simcore/SimCore.hpp>
 #include <simcore/worker_pool.hpp>
+#include <gpu/frame_graph.hpp>
+#include "tools/trace_export.hpp"
 
 static void busy_for(double ms) {
   using Clock = std::chrono::steady_clock;
@@ -128,5 +131,81 @@ TEST(RTPipeline, RateGovernorClampsFrameBudget) {
   double p99 = sorted[index];
   double budget = 1000.0 / s.hz;
   EXPECT_LE(p99, budget * 1.05);
+}
+
+TEST(RTPipeline, TraceIncludesCriticalEvents) {
+  WorkerPool pool(3);
+  SimCore::Settings s;
+  s.hz = 60.0;
+  s.maxFrames = 100;
+  s.threads = 3;
+  s.autoTuneChunks = false;
+  s.chunkSize = 64;
+  s.bintraceEnable = true;
+  s.bintraceEventsPerThread = 1u << 14;
+  s.budgetMonitor = false;
+  SimCore sim(s);
+  sim.setWorkerPool(&pool);
+
+  sim.applyDegradeRung(1);
+
+  auto rangePhase = sim.addPhase("range", 1024);
+  sim.addParallelRangeTask(rangePhase,
+                           [](std::size_t, std::size_t, std::int64_t,
+                              SimCore::Seconds) { busy_for(0.2); });
+
+  auto slowPhase = sim.addPhase("slow");
+  sim.addSerialSubsystem(slowPhase, [](std::int64_t frame, SimCore::Seconds) {
+    if (frame % 25 == 0)
+      std::this_thread::sleep_for(std::chrono::milliseconds(25));
+    else
+      busy_for(1.0);
+  });
+
+  sim.run();
+
+  EXPECT_GE(sim.watchdogTrips(), 1);
+
+  auto frameSnapshot = sim.saveFrame();
+  sim.loadFrame(frameSnapshot);
+
+  simcore::hal::gpu::FrameGraph fg;
+  fg.add_pass([]() { busy_for(1.0); },
+              []() { std::this_thread::sleep_for(std::chrono::milliseconds(5)); });
+  (void)fg.execute();
+
+  auto snap = sim.bintrace().snapshot();
+
+  std::ostringstream os;
+  trace_export::write_chrome_trace(snap, os);
+  auto json = os.str();
+  EXPECT_FALSE(json.empty());
+
+  auto countCat = [&json](const std::string &cat) {
+    std::string pattern = "\"cat\":\"" + cat + "\"";
+    std::size_t count = 0;
+    std::size_t pos = 0;
+    while ((pos = json.find(pattern, pos)) != std::string::npos) {
+      ++count;
+      pos += pattern.size();
+    }
+    return count;
+  };
+
+  EXPECT_GE(countCat("PhaseBegin"), 200u);
+  EXPECT_GE(countCat("PhaseEnd"), 200u);
+  EXPECT_GE(countCat("ChunkStart"), 1u);
+  EXPECT_GE(countCat("ChunkDone"), 1u);
+  EXPECT_GE(countCat("QueuePush"), 1u);
+  EXPECT_GE(countCat("QueuePop"), 1u);
+  EXPECT_GE(countCat("WorkSteal"), 1u);
+  EXPECT_GE(countCat("GovernorRung"), 1u);
+  EXPECT_GE(countCat("WatchdogTrip"), 1u);
+  EXPECT_GE(countCat("GpuFenceWaitBegin"), 1u);
+  EXPECT_GE(countCat("GpuFenceWaitEnd"), 1u);
+  EXPECT_GE(countCat("SnapshotSave"), 1u);
+  EXPECT_GE(countCat("SnapshotLoad"), 1u);
+
+  pool.stop();
 }
 

--- a/tools/trace_export.hpp
+++ b/tools/trace_export.hpp
@@ -11,7 +11,15 @@ inline const char* codeToCat(std::uint32_t code) {
     case bintrace::EV_PhaseEnd:    return "PhaseEnd";
     case bintrace::EV_ChunkStart:  return "ChunkStart";
     case bintrace::EV_ChunkDone:   return "ChunkDone";
-    case bintrace::EV_BudgetLadder:return "BudgetLadder";
+    case bintrace::EV_GovernorRung:return "GovernorRung";
+    case bintrace::EV_QueuePush:   return "QueuePush";
+    case bintrace::EV_QueuePop:    return "QueuePop";
+    case bintrace::EV_WorkSteal:   return "WorkSteal";
+    case bintrace::EV_WatchdogTrip:return "WatchdogTrip";
+    case bintrace::EV_GpuFenceWaitBegin: return "GpuFenceWaitBegin";
+    case bintrace::EV_GpuFenceWaitEnd:   return "GpuFenceWaitEnd";
+    case bintrace::EV_SnapshotSave:      return "SnapshotSave";
+    case bintrace::EV_SnapshotLoad:      return "SnapshotLoad";
     default: return "Unknown";
     }
 }


### PR DESCRIPTION
## Summary
- extend bintrace with new event codes, dynamic thread slots, and global trace helpers used by queues and worker pools
- instrument the worker queue, worker pool, SimCore, and GPU frame graph to emit queue depth, work steal, watchdog, GPU fence, and snapshot events
- update trace export mappings and add an RT pipeline test that verifies trace coverage via JSON analysis

## Testing
- `cmake --preset dev` *(fails: unable to download googletest over the proxy, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cae064fb70832bba80dd7b511c2ea3