### PR TITLE
Add backpressure tokens to logging and trace metrics

### DIFF
--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -322,9 +322,12 @@ public:
       registry->set_counter(
           "thermal.events",
           thermalEvents_.load(std::memory_order_acquire));
-      const std::uint64_t drops =
+      const std::uint64_t loggerDrops =
           logger_ ? static_cast<std::uint64_t>(logger_->dropped()) : 0;
-      registry->set_counter("logger.dropped", drops);
+      const std::uint64_t traceDrops = bintrace_.dropped();
+      registry->set_counter("logger.dropped", loggerDrops);
+      registry->set_counter("trace.dropped", traceDrops);
+      registry->set_counter("log_drops", loggerDrops + traceDrops);
       registry->set_counter("worker.queue_max", 0);
       registry->set_counter("worker.steals_total", 0);
     }
@@ -648,9 +651,12 @@ private:
     registry->set_counter("thermal.events",
                           thermalEvents_.load(std::memory_order_acquire));
 
-    const std::uint64_t drops =
+    const std::uint64_t loggerDrops =
         logger_ ? static_cast<std::uint64_t>(logger_->dropped()) : 0;
-    registry->set_counter("logger.dropped", drops);
+    const std::uint64_t traceDrops = bintrace_.dropped();
+    registry->set_counter("logger.dropped", loggerDrops);
+    registry->set_counter("trace.dropped", traceDrops);
+    registry->set_counter("log_drops", loggerDrops + traceDrops);
 
     if (pool_) {
       auto sample = metrics::make_sample(pool_->stats());

--- a/include/simcore/backpressure.hpp
+++ b/include/simcore/backpressure.hpp
@@ -2,6 +2,8 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
+#include <cstddef>
+#include <limits>
 
 namespace simcore {
 
@@ -12,6 +14,14 @@ class TokenBucket {
   const double refill_rate_; // tokens per second
   std::atomic<int> tokens_;
   std::atomic<std::int64_t> last_ns_;
+
+  static int clamp_to_int(std::size_t value) {
+    constexpr std::size_t kMax =
+        static_cast<std::size_t>(std::numeric_limits<int>::max());
+    if (value > kMax)
+      return std::numeric_limits<int>::max();
+    return static_cast<int>(value);
+  }
 
   static std::int64_t now_ns() {
     return std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -39,6 +49,9 @@ class TokenBucket {
   }
 
 public:
+  TokenBucket(std::size_t capacity, double refill_rate)
+      : TokenBucket(clamp_to_int(capacity), refill_rate) {}
+
   TokenBucket(int capacity, double refill_rate)
       : capacity_(capacity), refill_rate_(refill_rate), tokens_(capacity),
         last_ns_(now_ns()) {}
@@ -51,6 +64,12 @@ public:
         return true;
     }
     return false;
+  }
+
+  bool try_acquire(std::size_t n) {
+    if (n == 0)
+      return true;
+    return try_acquire(clamp_to_int(n));
   }
 };
 

--- a/include/simcore/bintrace.hpp
+++ b/include/simcore/bintrace.hpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <new>
 #include <fstream>
+#include "backpressure.hpp"
 #include "highres_clock.hpp"
 
 namespace bintrace {
@@ -50,12 +51,15 @@ public:
     void init(std::size_t threads, std::size_t eventsPerThread, bool enabled) {
         enabled_ = enabled;
         eventsPerThread_ = eventsPerThread;
+        throttleRate_ = eventsPerThread_ ? static_cast<double>(eventsPerThread_)
+                                         : 1.0;
+        dropped_.store(0, std::memory_order_relaxed);
         buffers_.clear();
         buffers_.reserve(threads);
         for (std::size_t i = 0; i < threads; ++i) {
             auto buf = std::make_unique<Buffer>();
             if (eventsPerThread_) {
-                buf->allocate(eventsPerThread_);
+                buf->allocate(eventsPerThread_, throttleRate_);
             }
             buffers_.emplace_back(std::move(buf));
         }
@@ -73,6 +77,8 @@ public:
         buffers_.clear();
         tlsBuf_ = nullptr;
         tlsThreadIdx_ = ~std::size_t{0};
+        dropped_.store(0, std::memory_order_relaxed);
+        throttleRate_ = 1.0;
     }
 
     std::size_t threadCount() const noexcept { return buffers_.size(); }
@@ -85,7 +91,7 @@ public:
         for (std::size_t i = 0; i < count; ++i) {
             auto buf = std::make_unique<Buffer>();
             if (eventsPerThread_) {
-                buf->allocate(eventsPerThread_);
+                buf->allocate(eventsPerThread_, throttleRate_);
             }
             buffers_.emplace_back(std::move(buf));
         }
@@ -105,6 +111,16 @@ public:
         Buffer* buf = tlsBuf_;
         if (!buf) return;
         const std::size_t cap = buf->cap;
+        if (cap == 0) {
+            buf->dropped.fetch_add(1, std::memory_order_relaxed);
+            dropped_.fetch_add(1, std::memory_order_relaxed);
+            return;
+        }
+        if (buf->throttle && !buf->throttle->try_acquire()) {
+            buf->dropped.fetch_add(1, std::memory_order_relaxed);
+            dropped_.fetch_add(1, std::memory_order_relaxed);
+            return;
+        }
         const std::size_t i   = buf->write.load(std::memory_order_relaxed);
         Event* e = buf->base + (i % cap);
         e->tsc    = rdtsc();
@@ -155,6 +171,10 @@ public:
         return s;
     }
 
+    std::uint64_t dropped() const noexcept {
+        return dropped_.load(std::memory_order_acquire);
+    }
+
     bool writeFile(const char* path) const {
         std::ofstream f(path, std::ios::binary);
         if (!f) return false;
@@ -193,6 +213,8 @@ private:
         Event*    base  = nullptr;
         std::size_t cap = 0;
         std::atomic<std::size_t> write{0};
+        std::unique_ptr<simcore::TokenBucket> throttle;
+        std::atomic<std::uint64_t> dropped{0};
 
         Buffer() = default;
         Buffer(const Buffer&) = delete;
@@ -200,7 +222,7 @@ private:
 
         ~Buffer() { release(); }
 
-        void allocate(std::size_t newCap) {
+        void allocate(std::size_t newCap, double refillRate) {
             release();
             if (newCap == 0)
                 return;
@@ -208,6 +230,8 @@ private:
             mem = ::operator new(cap * sizeof(Event), std::align_val_t(64));
             base = static_cast<Event*>(mem);
             write.store(0, std::memory_order_relaxed);
+            throttle = std::make_unique<simcore::TokenBucket>(newCap, refillRate);
+            dropped.store(0, std::memory_order_relaxed);
         }
 
         void release() {
@@ -218,12 +242,16 @@ private:
                 cap = 0;
                 write.store(0, std::memory_order_relaxed);
             }
+            throttle.reset();
+            dropped.store(0, std::memory_order_relaxed);
         }
     };
 
     std::vector<std::unique_ptr<Buffer>> buffers_;
     bool enabled_ = false;
     std::size_t eventsPerThread_ = 0;
+    double throttleRate_ = 1.0;
+    std::atomic<std::uint64_t> dropped_{0};
 
     // TLS writer cursor
     static thread_local Buffer* tlsBuf_;

--- a/include/simcore/logger.hpp
+++ b/include/simcore/logger.hpp
@@ -6,6 +6,7 @@
 #include <mutex>
 #include <chrono>
 #include <thread>
+#include "backpressure.hpp"
 #include "debug.hpp"
 #include <cstdio>
 #include <fstream>
@@ -78,7 +79,9 @@ public:
                                    std::chrono::milliseconds syncEvery = std::chrono::milliseconds(100),
                                    bool directSync = false,
                                    std::size_t preallocate = 0)
-            : fd_(-1), cap_(cap), syncEvery_(syncEvery) {
+            : fd_(-1), cap_(cap),
+              backpressure_(cap, refillRate(cap, syncEvery)),
+              syncEvery_(syncEvery) {
 #ifdef _WIN32
             int tmp = -1;
             int oflag = _O_CREAT | _O_APPEND | _O_WRONLY;
@@ -137,9 +140,13 @@ public:
 
         void write(const Record& r) override {
             if (fd_ < 0) return;
+            if (!backpressure_.try_acquire()) {
+                dropped_.fetch_add(1, std::memory_order_relaxed);
+                return;
+            }
             std::lock_guard<std::mutex> lk(m_);
             if (queue_.size() >= cap_) {
-                ++dropped_;
+                dropped_.fetch_add(1, std::memory_order_relaxed);
                 return;
             }
             queue_.push_back(r.msg);
@@ -194,6 +201,7 @@ public:
         int fd_;
         std::deque<std::string> queue_;
         std::size_t cap_;
+        simcore::TokenBucket backpressure_;
         std::atomic<std::size_t> dropped_{0};
         std::chrono::milliseconds syncEvery_;
         std::chrono::steady_clock::time_point lastSync_{};
@@ -201,6 +209,18 @@ public:
         std::condition_variable cv_;
         bool stop_ = false;
         std::thread worker_;
+
+        static double refillRate(std::size_t cap,
+                                 std::chrono::milliseconds interval) {
+            if (cap == 0)
+                return 1.0;
+            const double seconds =
+                static_cast<double>(interval.count()) / 1000.0;
+            if (seconds <= 0.0)
+                return static_cast<double>(cap);
+            const double rate = static_cast<double>(cap) / seconds;
+            return rate < 1.0 ? 1.0 : rate;
+        }
     };
 
     class RingBufferSink : public Sink {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ set(TEST_SOURCES
     test_simcore_determinism.cpp
     test_logging.cpp
     test_async_logger.cpp
+    test_logger_backpressure.cpp
     test_profiler.cpp
     test_adaptive_param.cpp
     test_soa.cpp

--- a/tests/test_logger_backpressure.cpp
+++ b/tests/test_logger_backpressure.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <future>
+#include <simcore/logger.hpp>
+
+TEST(LoggerBackpressure, DropsUnderFloodWithoutBlocking) {
+  namespace fs = std::filesystem;
+  auto path = fs::temp_directory_path() / "logger_backpressure.log";
+  std::error_code ec;
+  fs::remove(path, ec);
+
+  auto sink = std::make_shared<Logger::AsyncRingFileSink>(
+      path.string(), 8, std::chrono::milliseconds(500));
+
+  Logger log;
+  log.addSink(sink);
+
+  constexpr int kMessages = 5000;
+  auto future = std::async(std::launch::async, [&] {
+    for (int i = 0; i < kMessages; ++i) {
+      log.info("msg{}", i);
+    }
+  });
+
+  EXPECT_EQ(future.wait_for(std::chrono::seconds(5)),
+            std::future_status::ready);
+  future.get();
+
+  const auto drops = sink->dropped();
+  EXPECT_GT(drops, 0u);
+
+  sink.reset();
+  fs::remove(path, ec);
+}
+

--- a/tests/test_metrics_json.cpp
+++ b/tests/test_metrics_json.cpp
@@ -64,6 +64,8 @@ TEST(MetricsJson, EmitsPhaseStatsAndCounters) {
   EXPECT_NE(counters.find("worker.queue_max"), counters.end());
   EXPECT_NE(counters.find("worker.steals_total"), counters.end());
   EXPECT_NE(counters.find("logger.dropped"), counters.end());
+  EXPECT_NE(counters.find("trace.dropped"), counters.end());
+  EXPECT_NE(counters.find("log_drops"), counters.end());
   EXPECT_NE(counters.find("thermal.events"), counters.end());
 
   const std::string json = registry.to_json();
@@ -86,5 +88,7 @@ TEST(MetricsJson, EmitsPhaseStatsAndCounters) {
   expectKey("\"worker.queue_max\"");
   expectKey("\"worker.steals_total\"");
   expectKey("\"logger.dropped\"");
+  expectKey("\"trace.dropped\"");
+  expectKey("\"log_drops\"");
   expectKey("\"thermal.events\"");
 }


### PR DESCRIPTION
## Summary
- throttle the asynchronous logger ring buffer with a token bucket and count dropped records
- add token-based throttling and drop accounting for trace export buffers
- surface combined log drop metrics and add a stress test exercising logger backpressure

## Testing
- cmake --preset dev *(fails: proxy blocks googletest download)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1d7d7e88832bbe063d979f76aeca