### PR TITLE
Add AoSoA example and benchmark

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,6 +538,9 @@ target_include_directories(trace_dump PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 # Tiny sample programs
 add_subdirectory(samples)
 
+# Micro benchmarks
+add_subdirectory(bench)
+
 # Tests
 if (ENABLE_TESTS)
     enable_testing()

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(bench_aosoa_vs_soa bench_aosoa_vs_soa.cpp)
+target_link_libraries(bench_aosoa_vs_soa PRIVATE simcore_platform)

--- a/bench/bench_aosoa_vs_soa.cpp
+++ b/bench/bench_aosoa_vs_soa.cpp
@@ -1,0 +1,171 @@
+#define ENABLE_SIMD 1
+#include <simcore/soa/soa_simd.hpp>
+#include <simcore/soa/aosoa.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <vector>
+
+struct BenchResult {
+    std::size_t n;
+    int inner;
+    double soa_us;
+    double aosoa_us;
+    double ratio;
+};
+
+static int pick_inner_loops(std::size_t n) {
+    if (n <= 1'000)
+        return 4'000;
+    if (n <= 10'000)
+        return 1'200;
+    if (n <= 100'000)
+        return 320;
+    return 80;
+}
+
+int main(int argc, char** argv) {
+    int repeats = 5;
+    bool assertSpeedup = false;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--repeat") == 0 && i + 1 < argc) {
+            repeats = std::max(1, std::atoi(argv[++i]));
+        } else if (std::strcmp(argv[i], "--assert-speedup") == 0) {
+            assertSpeedup = true;
+        }
+    }
+
+    using Clock = std::chrono::steady_clock;
+    using AoSoA = soa::Vec3AoSoA<double, 256>;
+    using AoSoAConst = soa::Vec3AoSoA<const double, 256>;
+    using Tile = AoSoA::Tile;
+
+    const std::vector<std::size_t> sizes = {1'000u, 10'000u, 100'000u, 1'000'000u};
+    const double scale = 0.016;
+
+    std::mt19937 rng(1337);
+    std::uniform_real_distribution<double> dist(-5.0, 5.0);
+
+    std::vector<BenchResult> results;
+    results.reserve(sizes.size());
+
+    for (std::size_t n : sizes) {
+        const int inner = pick_inner_loops(n);
+
+        std::vector<double> basePx(n), basePy(n), basePz(n);
+        std::vector<double> baseVx(n), baseVy(n), baseVz(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            basePx[i] = dist(rng);
+            basePy[i] = dist(rng);
+            basePz[i] = dist(rng);
+            baseVx[i] = dist(rng);
+            baseVy[i] = dist(rng);
+            baseVz[i] = dist(rng);
+        }
+
+        const std::size_t tileCount = (n + AoSoA::tile_size - 1) / AoSoA::tile_size;
+        const std::size_t totalSlots = tileCount * AoSoA::tile_size;
+
+        auto fill_tiles = [&](std::vector<Tile>& tiles, const std::vector<double>& x,
+                              const std::vector<double>& y, const std::vector<double>& z) {
+            tiles.resize(tileCount);
+            for (std::size_t idx = 0; idx < totalSlots; ++idx) {
+                const std::size_t tile = idx / AoSoA::tile_size;
+                const std::size_t lane = idx % AoSoA::tile_size;
+                const double vx = (idx < x.size()) ? x[idx] : 0.0;
+                const double vy = (idx < y.size()) ? y[idx] : 0.0;
+                const double vz = (idx < z.size()) ? z[idx] : 0.0;
+                tiles[tile].x[lane] = vx;
+                tiles[tile].y[lane] = vy;
+                tiles[tile].z[lane] = vz;
+            }
+        };
+
+        std::vector<Tile> velocityTiles;
+        std::vector<Tile> positionTilesBase;
+        fill_tiles(velocityTiles, baseVx, baseVy, baseVz);
+        fill_tiles(positionTilesBase, basePx, basePy, basePz);
+        AoSoAConst velocityAo{velocityTiles.data()};
+
+        double bestSoa = std::numeric_limits<double>::max();
+        double bestAoSoa = std::numeric_limits<double>::max();
+
+        for (int rep = 0; rep < repeats; ++rep) {
+            auto soaPx = basePx;
+            auto soaPy = basePy;
+            auto soaPz = basePz;
+            soa::Vec3SoA<double> soaPos{soaPx.data(), soaPy.data(), soaPz.data()};
+            soa::Vec3SoA<const double> soaVel{baseVx.data(), baseVy.data(), baseVz.data()};
+
+            auto startSoa = Clock::now();
+            for (int iter = 0; iter < inner; ++iter)
+                soa::axpy3(scale, soaVel, soaPos, n);
+            auto endSoa = Clock::now();
+            double soaUs = std::chrono::duration<double, std::micro>(endSoa - startSoa).count();
+            soaUs /= static_cast<double>(inner);
+            bestSoa = std::min(bestSoa, soaUs);
+
+            auto positionTiles = positionTilesBase;
+            AoSoA positionAo{positionTiles.data()};
+            auto startAo = Clock::now();
+            for (int iter = 0; iter < inner; ++iter)
+                soa::axpy3<AoSoA::tile_size>(scale, velocityAo, positionAo, n);
+            auto endAo = Clock::now();
+            double aoUs = std::chrono::duration<double, std::micro>(endAo - startAo).count();
+            aoUs /= static_cast<double>(inner);
+            bestAoSoa = std::min(bestAoSoa, aoUs);
+        }
+
+        BenchResult res{};
+        res.n = n;
+        res.inner = inner;
+        res.soa_us = bestSoa;
+        res.aosoa_us = bestAoSoa;
+        res.ratio = bestSoa / bestAoSoa;
+        results.push_back(res);
+    }
+
+    bool speedupOk = true;
+    if (assertSpeedup && !results.empty()) {
+        const BenchResult& last = results.back();
+        speedupOk = last.aosoa_us <= last.soa_us;
+        if (!speedupOk)
+            std::cerr << "AoSoA slower than SoA for N=" << last.n << "\n";
+    }
+
+    std::cout.setf(std::ios::fixed);
+    std::cout << std::setprecision(3);
+    std::cout << "{\n";
+    std::cout << "  \"benchmark\": \"aosoa_vs_soa_axpy3\",\n";
+    std::cout << "  \"repeats\": " << repeats << ",\n";
+    std::cout << "  \"results\": [\n";
+    for (std::size_t i = 0; i < results.size(); ++i) {
+        const auto& r = results[i];
+        std::cout << "    {\"n\": " << r.n
+                  << ", \"inner\": " << r.inner
+                  << ", \"soa_us\": " << r.soa_us
+                  << ", \"aosoa_us\": " << r.aosoa_us
+                  << ", \"ratio\": " << r.ratio << "}";
+        if (i + 1 < results.size())
+            std::cout << ",";
+        std::cout << "\n";
+    }
+    std::cout << "  ],\n";
+    std::cout << "  \"assert_speedup\": " << (assertSpeedup ? "true" : "false");
+    if (assertSpeedup)
+        std::cout << ",\n  \"speedup_ok\": " << (speedupOk ? "true" : "false") << "\n";
+    else
+        std::cout << "\n";
+    std::cout << "}\n";
+
+    if (assertSpeedup && !speedupOk)
+        return 1;
+    return 0;
+}

--- a/examples/particles_on_plane.cpp
+++ b/examples/particles_on_plane.cpp
@@ -1,28 +1,111 @@
-#include <simcore/physics/integrators.hpp>
+#include <simcore/SimCore.hpp>
+#include <simcore/worker_pool.hpp>
+#include <simcore/soa/aosoa.hpp>
+
+#include <algorithm>
+#include <cstddef>
 #include <iostream>
-
-struct Vec2 {
-    double x{}, y{};
-    Vec2 operator+(const Vec2 &o) const { return {x + o.x, y + o.y}; }
-    Vec2 &operator+=(const Vec2 &o) { x += o.x; y += o.y; return *this; }
-    Vec2 operator*(double s) const { return {x * s, y * s}; }
-};
-
-struct Particle {
-    Vec2 pos{}; // metres
-    Vec2 vel{}; // metres/second
-};
+#include <thread>
+#include <vector>
+#include <cmath>
 
 int main() {
-    using simphys::symplecticEuler;
+    using ParticleAoSoA = soa::Vec3AoSoA<double, 256>;
+    constexpr std::size_t kParticleCount = 8192;
+    const std::size_t tileCount = (kParticleCount + ParticleAoSoA::tile_size - 1) / ParticleAoSoA::tile_size;
 
-    Particle p{{0.0, 10.0}, {1.0, 0.0}}; // start 10m up, moving sideways
-    auto gravity = [](const Particle &) { return Vec2{0.0, -9.81}; };
-    double dt = 0.016; // 60 Hz
+    std::vector<ParticleAoSoA::Tile> positionTiles(tileCount);
+    std::vector<ParticleAoSoA::Tile> velocityTiles(tileCount);
 
-    for (int step = 0; step < 60; ++step) {
-        symplecticEuler(p, dt, gravity);
-        std::cout << "t=" << (step + 1) * dt
-                  << "s pos=(" << p.pos.x << ", " << p.pos.y << ")\n";
+    for (auto &tile : positionTiles) {
+        std::fill_n(tile.x, ParticleAoSoA::tile_size, 0.0);
+        std::fill_n(tile.y, ParticleAoSoA::tile_size, 0.0);
+        std::fill_n(tile.z, ParticleAoSoA::tile_size, 0.0);
     }
+    for (auto &tile : velocityTiles) {
+        std::fill_n(tile.x, ParticleAoSoA::tile_size, 0.0);
+        std::fill_n(tile.y, ParticleAoSoA::tile_size, 0.0);
+        std::fill_n(tile.z, ParticleAoSoA::tile_size, 0.0);
+    }
+
+    ParticleAoSoA positions{positionTiles.data()};
+    ParticleAoSoA velocities{velocityTiles.data()};
+
+    for (std::size_t idx = 0; idx < kParticleCount; ++idx) {
+        const std::size_t tile = idx / ParticleAoSoA::tile_size;
+        const std::size_t lane = idx % ParticleAoSoA::tile_size;
+        positions.tiles[tile].x[lane] = static_cast<double>(idx) * 0.02;
+        positions.tiles[tile].y[lane] = 10.0;
+        positions.tiles[tile].z[lane] = 0.0;
+        velocities.tiles[tile].x[lane] = 1.0;
+        velocities.tiles[tile].y[lane] = 0.0;
+        velocities.tiles[tile].z[lane] = 0.0;
+    }
+
+    unsigned hw = std::thread::hardware_concurrency();
+    if (hw < 2)
+        hw = 2;
+    SimCore::Settings settings;
+    settings.hz = 120.0;
+    settings.maxFrames = 240;
+    settings.threads = hw;
+    settings.autoTuneChunks = false;
+    settings.chunkSize = 4;
+
+    WorkerPool pool(settings.threads, 2048);
+    SimCore sim(settings);
+    sim.setWorkerPool(&pool);
+
+    auto physics = sim.addPhase("AoSoA physics");
+    sim.setPhaseElementCount(physics, tileCount);
+
+    constexpr double gravity = -9.81;
+    constexpr double restitution = 0.35;
+
+    sim.addParallelRangeTask(
+        physics,
+        [positions, velocities, gravity, restitution, particleCount = kParticleCount](std::size_t begin, std::size_t end, std::int64_t,
+                                                                                      SimCore::Seconds dt) {
+            const double g = gravity;
+            const double bounce = restitution;
+            const double step = dt.count();
+            for (std::size_t tileIndex = begin; tileIndex < end; ++tileIndex) {
+                auto &posTile = positions.tiles[tileIndex];
+                auto &velTile = velocities.tiles[tileIndex];
+                for (std::size_t lane = 0; lane < ParticleAoSoA::tile_size; ++lane) {
+                    const std::size_t idx = tileIndex * ParticleAoSoA::tile_size + lane;
+                    if (idx >= particleCount)
+                        break;
+
+                    velTile.y[lane] += g * step;
+                    posTile.x[lane] += velTile.x[lane] * step;
+                    posTile.y[lane] += velTile.y[lane] * step;
+                    posTile.z[lane] += velTile.z[lane] * step;
+
+                    if (posTile.y[lane] < 0.0) {
+                        posTile.y[lane] = 0.0;
+                        velTile.y[lane] = -velTile.y[lane] * bounce;
+                        if (std::abs(velTile.y[lane]) < 0.05)
+                            velTile.y[lane] = 0.0;
+                    }
+                }
+            }
+        });
+
+    sim.run();
+    pool.drain();
+    pool.stop();
+    sim.setWorkerPool(nullptr);
+
+    double avgHeight = 0.0;
+    for (std::size_t idx = 0; idx < kParticleCount; ++idx) {
+        const std::size_t tile = idx / ParticleAoSoA::tile_size;
+        const std::size_t lane = idx % ParticleAoSoA::tile_size;
+        avgHeight += positions.tiles[tile].y[lane];
+    }
+    avgHeight /= static_cast<double>(kParticleCount);
+
+    std::cout << "Particles settled. First particle y=" << positions.tiles[0].y[0]
+              << ", average height=" << avgHeight << "\n";
+    return 0;
 }


### PR DESCRIPTION
## Summary
- Replace the particles_on_plane example with an AoSoA-backed SimCore phase that submits tile work through the worker pool
- Add an AoSoA vs SoA microbenchmark and hook the new bench target into the build

## Testing
- cmake --build --preset dev --target bench_aosoa_vs_soa
- ./build/dev/bench/bench_aosoa_vs_soa --repeat 2
- cmake --build --preset dev
- ctest --preset dev

------
https://chatgpt.com/codex/tasks/task_e_68d1744ecca0832b9f3345a664644dee