### PR TITLE
Add GPU overlap integration test with trace verification

### DIFF
--- a/tests/test_gpu_overlap.cpp
+++ b/tests/test_gpu_overlap.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <gpu/frame_graph.hpp>
+#include <simcore/bintrace.hpp>
 #include <simcore/hal.hpp>
 
 #include <chrono>
@@ -10,9 +11,16 @@ using simcore::hal::gpu::FrameGraph;
 TEST(GPUOverlap, FiberFenceAwaitYieldsWork) {
     using namespace std::chrono_literals;
 
+    bintrace::Trace trace;
+    trace.init(/*threads=*/1, /*eventsPerThread=*/128, /*enabled=*/true);
+    trace.bindThread(0);
+    bintrace::set_global_trace(&trace);
+
     FrameGraph fg;
     constexpr auto gpu_time = 80ms;
     constexpr auto cpu_time = 60ms;
+    constexpr auto epsilon = 20ms;
+    constexpr auto tolerance = 15ms;
 
     fg.add_pass(
         []() {},
@@ -22,10 +30,7 @@ TEST(GPUOverlap, FiberFenceAwaitYieldsWork) {
 
     fg.add_pass(
         [&]() {
-            auto start = simcore::hal::now();
-            while (simcore::hal::elapsed(start, simcore::hal::now()) < cpu_time) {
-                std::this_thread::yield();
-            }
+            std::this_thread::sleep_for(cpu_time);
         },
         FrameGraph::PassFn{}
     );
@@ -33,14 +38,32 @@ TEST(GPUOverlap, FiberFenceAwaitYieldsWork) {
     auto start = simcore::hal::now();
     auto budget = fg.execute();
     auto total = simcore::hal::elapsed(start, simcore::hal::now());
+    auto overlap = fg.overlap();
 
-    auto cpu_ms = std::chrono::duration_cast<std::chrono::milliseconds>(budget.cpu).count();
-    auto gpu_ms = std::chrono::duration_cast<std::chrono::milliseconds>(budget.gpu).count();
-    auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(total).count();
-    auto overlap_ms = std::chrono::duration_cast<std::chrono::milliseconds>(fg.overlap()).count();
+    auto snapshot = trace.snapshot();
+    bintrace::set_global_trace(nullptr);
+    trace.shutdown();
 
-    EXPECT_GE(cpu_ms, cpu_time.count() - 10);
-    EXPECT_GE(gpu_ms, gpu_time.count() - 10);
-    EXPECT_LT(total_ms, cpu_ms + gpu_ms);
-    EXPECT_GT(overlap_ms, 0);
+    auto cpu_ms = std::chrono::duration<double, std::milli>(budget.cpu).count();
+    auto gpu_ms = std::chrono::duration<double, std::milli>(budget.gpu).count();
+    auto total_ms = std::chrono::duration<double, std::milli>(total).count();
+    auto overlap_ms = std::chrono::duration<double, std::milli>(overlap).count();
+
+    EXPECT_GE(cpu_ms, static_cast<double>((cpu_time - tolerance).count()));
+    EXPECT_GE(gpu_ms, static_cast<double>((gpu_time - tolerance).count()));
+    EXPECT_LT(total_ms, static_cast<double>((cpu_time + gpu_time - epsilon).count()));
+    EXPECT_GE(overlap_ms, static_cast<double>((cpu_time - tolerance).count()));
+
+    std::size_t fenceBegin = 0;
+    std::size_t fenceEnd = 0;
+    for (const auto& ev : snapshot.events) {
+        if (ev.code == bintrace::EV_GpuFenceWaitBegin) {
+            ++fenceBegin;
+        } else if (ev.code == bintrace::EV_GpuFenceWaitEnd) {
+            ++fenceEnd;
+        }
+    }
+    EXPECT_GE(fenceBegin, 1u);
+    EXPECT_GE(fenceEnd, 1u);
+    EXPECT_EQ(fenceBegin, fenceEnd);
 }


### PR DESCRIPTION
## Summary
- add an integration-style GPU overlap test that drives the frame graph with CPU and GPU workloads
- verify the recorded overlap budget and GPU fence wait trace events to demonstrate concurrency

## Testing
- ctest --preset dev -R GPUOverlap --output-on-failure *(no tests were found; GoogleTest is unavailable in this configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d180c06b98832baa8fcc94552244d0