### PR TITLE
Add code anchors to documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,3 +33,10 @@ thread pool pulls tasks from lock-free queues, allowing phases to submit
 independent jobs that execute in parallel while respecting dependency
 edges. Phases wait for their scheduled jobs to finish before advancing,
 keeping frame latency predictable while utilising all CPU cores.
+
+## Code anchors
+
+- Phase DAG: `SimCore::buildTopoLevels`; `include/simcore/SimCore.hpp`
+- Memory layout: `CarSoA`; `include/simcore/car_soa.hpp`
+- Job system: `WorkerPool::workerLoop`, `BoundedMPMCQueue::try_push`; `include/simcore/worker_pool.hpp`, `include/simcore/job_queue.hpp`
+

--- a/docs/build_tooling.md
+++ b/docs/build_tooling.md
@@ -41,3 +41,11 @@ Enable include-what-you-use and ODR warnings by toggling the options:
 
 These checks help keep headers minimal and catch One Definition Rule
 violations early.
+
+## Code anchors
+
+- Presets and PGO flow: `configurePresets` entries (`dev`, `release`, `pgo-generate`, `pgo-use`); `CMakePresets.json`, `CMakeLists.txt` (`SIM_PGO`, `SIM_ENABLE_LTO`)
+- Clang toolchain: `CMAKE_C_COMPILER`, `CMAKE_CXX_COMPILER`; `cmake/toolchains/clang.cmake`
+- Bloaty analysis: `add_custom_target(bloaty)`; `CMakeLists.txt`
+- Header hygiene toggles: `option(SIM_ENABLE_IWYU)`, `option(SIM_WARN_ODR)`; `CMakeLists.txt`
+

--- a/docs/concurrency_patterns.md
+++ b/docs/concurrency_patterns.md
@@ -22,3 +22,9 @@ rate-based refills to avoid burst avalanches.
 
 Refer to the unit tests for usage examples.
 
+## Code anchors
+
+- SeqLock: `SeqLock::write`, `SeqLock::read`; `include/simcore/seqlock.hpp`
+- Hazard-pointer queue: `LockFreeQueue::push`, `LockFreeQueue::pop`; `include/simcore/lockfree_queue.hpp`
+- Back-pressure token bucket: `TokenBucket::try_acquire`; `include/simcore/backpressure.hpp`
+

--- a/docs/config_hot_reload.md
+++ b/docs/config_hot_reload.md
@@ -11,3 +11,9 @@ Configuration is stored on disk in a simple textual format:
 new configuration objects when it changes.  Basic validation ensures the major
 version matches the previously loaded configuration.  The hot-reload wrapper is
 header-only and has no external dependencies.
+
+## Code anchors
+
+- Config reload: `ConfigHotReloader::load`, `ConfigHotReloader::hot_reload`; `core/include/core/config_hot_reload.hpp`
+- Snapshot access: `ConfigHotReloader::get`; `core/include/core/config_hot_reload.hpp`
+

--- a/docs/contributor_guide.md
+++ b/docs/contributor_guide.md
@@ -18,3 +18,10 @@
 ## Operations
 - Logs and profiles can be toggled with `ENABLE_LOG` and `ENABLE_PROF` in CMake.
 - For sanitizer builds, use `-DSIM_SANITIZERS=address;undefined`.
+
+## Code anchors
+
+- Build configuration: `option(ENABLE_TESTS)`; `CMakeLists.txt`
+- Logging and profiling toggles: `option(ENABLE_LOG)`, `option(ENABLE_PROF)`; `CMakeLists.txt`
+- Sanitizer flag: `SIM_SANITIZERS` handling; `CMakeLists.txt`
+

--- a/docs/determinism_replay.md
+++ b/docs/determinism_replay.md
@@ -13,3 +13,11 @@
 - Seed protocol: combine a global seed with entity/chunk identifiers to guarantee reproducible streams.
 
 This document outlines the minimal requirements for deterministic gameplay and replay within the simulation core.
+
+## Code anchors
+
+- Frame snapshots: `SimCore::saveFrame`, `SimCore::loadFrame`; `include/simcore/SimCore.hpp`
+- Snapshot serialization helpers: `rt::SnapshotWriter::writeVector`, `rt::SnapshotWriter::writeMap`; `rt/include/rt/snapshot.hpp`
+- Rollback harness: `TEST(SnapshotRollback, ReplayHashEquality)`; `tests/test_snapshot.cpp`
+- Counter-based PRNG: `SimCore::prng`, `rt::prng::philox4x32_10`; `include/simcore/SimCore.hpp`, `rt/include/rt/prng.hpp`
+

--- a/docs/devex_governance.md
+++ b/docs/devex_governance.md
@@ -26,3 +26,10 @@ API or ABI changes.
   active, including `SimCore.hpp` forbids direct `std::thread` construction.
   Phases must submit asynchronous work through the provided worker pool to keep
   a single scheduling surface and maintain consistent telemetry.
+
+## Code anchors
+
+- System scaffolding: `main()` generator; `tools/new_system.py`
+- Plugin ABI contract: `RT_PLUGIN_API_VERSION_MAJOR`, `rt_plugin_desc_t`; `rt/include/rt/plugin_api.h`
+- Raw thread guard: `simcore::debug::assert_thread_creation_allowed`, `#define thread(...)`; `include/simcore/debug.hpp`, `include/simcore/SimCore.hpp`
+

--- a/docs/frame_graph.md
+++ b/docs/frame_graph.md
@@ -16,3 +16,11 @@ experiments with GPU/accelerator scheduling.  The implementation lives in
 
 The frame graph is a stub and intentionally minimal; it is meant to be
 replaced by a real implementation once a concrete GPU backend is available.
+
+## Code anchors
+
+- Resource lifetime tracking: `FrameGraph::create_resource`, `FrameGraph::free_dead_resources`; `gpu/frame_graph.hpp`
+- Timeline semaphores: `TimelineSemaphore::wait`, `TimelineSemaphore::signal`; `gpu/frame_graph.hpp`
+- Async overlap budget: `FrameGraph::execute`; `gpu/frame_graph.hpp`
+- Mixed compute stubs: `FrameGraph::add_pass`; `gpu/frame_graph.hpp`
+

--- a/docs/io_kernel_bypass.md
+++ b/docs/io_kernel_bypass.md
@@ -20,3 +20,9 @@ socket helper can opt into io_uring submission by defining
 `SIMCORE_ENABLE_IO_URING` at build time; otherwise it transparently falls back
 to non-blocking `send()` calls so the same interface works across platforms.
 
+## Code anchors
+
+- File sink: `Logger::AsyncRingFileSink::write`, `Logger::AsyncRingFileSink::run`; `include/simcore/logger.hpp`
+- Kernel-bypass sink: `Logger::AsyncKernelBypassSink::write`, `Logger::AsyncKernelBypassSink::run`; `include/simcore/logger.hpp`
+- Kernel bypass helper: `simcore::KernelBypassSocket::submit`, `simcore::KernelBypassSocket::poll`; `include/simcore/kernel_bypass.hpp`
+

--- a/docs/limp_mode.md
+++ b/docs/limp_mode.md
@@ -10,3 +10,9 @@ prioritize frame delivery under extreme load. Specifically it:
 
 This switch acts as a global guardrail for deployments that must remain
 responsive even when resources are severely constrained.
+
+## Code anchors
+
+- Settings flag: `SimCore::Settings::limpMode`; `include/simcore/SimCore.hpp`
+- Limp-mode behaviour: `SimCore::applySettings`, `SimCore::applyDegradeRung`; `include/simcore/SimCore.hpp`
+

--- a/docs/numerics.md
+++ b/docs/numerics.md
@@ -26,3 +26,10 @@ For hard real-time subsystems a small fixed-point type `rt::Q16_16`
 implements deterministic arithmetic without relying on floating point
 hardware.
 
+## Code anchors
+
+- Mixed-precision reductions: `robust::sum_fp32_to_fp64`, `robust::kahan_sum_fp32`; `include/simcore/robust_fp.hpp`
+- Shadow arithmetic: `robust::ulp_distance`; `include/simcore/robust_fp.hpp`
+- Denormals & FMA control: `rt::init_fp_env`, `rt::set_use_fma`; `rt/include/rt/numerics.hpp`
+- Fixed-point option: `rt::Q16_16`; `rt/include/rt/fixed_point.hpp`
+

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -16,3 +16,11 @@ processor.
 `trace_export::write_ebpf_trace` writes each event on its own line using a
 space separated format: `tsc thread code a b`.  This is suitable for simple
 processing by eBPF-based pipelines.
+
+## Code anchors
+
+- Trace capture: `bintrace::Trace::log`, `bintrace::Trace::snapshot`; `include/simcore/bintrace.hpp`
+- Chrome trace export: `trace_export::write_chrome_trace`; `tools/trace_export.hpp`
+- ETW CSV export: `trace_export::write_etw_trace`; `tools/trace_export.hpp`
+- eBPF text export: `trace_export::write_ebpf_trace`; `tools/trace_export.hpp`
+

--- a/docs/physics_scaffolding.md
+++ b/docs/physics_scaffolding.md
@@ -7,3 +7,11 @@ The physics module provides engine-agnostic building blocks:
 - **Narrowphase Shells**: `GJKEPANarrowPhase` and `MPRNarrowPhase` expose hooks for common convex collision detectors. `ContactCache` demonstrates temporal coherence and `ConservativeAdvancementCCD` sketches continuous collision detection.
 
 These scaffolds are intentionally lightweight and serve as extension points for real engines.
+
+## Code anchors
+
+- Hamiltonian integrators: `simphys::stormerVerlet`; `include/simcore/physics/integrators.hpp`
+- Constraint solver depth: `simphys::SolverSettings`, `simphys::IslandManager::update`; `include/simcore/physics/constraint_solver.hpp`
+- Narrowphase shells: `simphys::GJKEPANarrowPhase::generateContacts`, `simphys::MPRNarrowPhase::generateContacts`; `include/simcore/physics/collision_pipeline.hpp`
+- Temporal coherence & CCD: `simphys::ContactCache::contacts`, `simphys::ConservativeAdvancementCCD::sweep`; `include/simcore/physics/collision_pipeline.hpp`
+

--- a/docs/real_time_hardening.md
+++ b/docs/real_time_hardening.md
@@ -45,3 +45,9 @@ deep C-states.  This behaviour can be toggled at runtime by re-running the
 scripts: invoking them applies the low-latency configuration, while restoring a
 balanced power profile can be done with native tools such as `cpupower` on Linux
 or `powercfg` on Windows.
+
+## Code anchors
+
+- Linux hardening steps: `tools/rt_harden.sh`
+- Windows hardening steps: `tools/rt_harden.ps1`
+

--- a/docs/real_time_readiness_checklist.md
+++ b/docs/real_time_readiness_checklist.md
@@ -7,3 +7,12 @@ Use this checklist to assess whether the system is ready for real-time use.
 - [ ] Plugins can be hot-loaded and unloaded without restarting the runtime.
 - [ ] Watchdog timers and monitoring enabled.
 - [ ] Threat model reviewed and mitigations implemented.
+
+## Code anchors
+
+- Determinism validation: `TEST(SnapshotRollback, ReplayHashEquality)`; `tests/test_snapshot.cpp`
+- Bounded allocations: `rt::FrameArena`, `rt::FrameArenaPool`; `include/simcore/rt_memory.hpp`
+- Plugin lifecycle: `rt::PluginManager::load`, `rt::PluginManager::unload`; `rt/src/plugin_manager.cpp`
+- Watchdog monitoring: `rt::Watchdog::arm`, `SimCore::executeFrame`; `rt/include/rt/watchdog.hpp`, `include/simcore/SimCore.hpp`
+- Threat mitigations: `enable_sandbox`; `include/simcore/sandbox.hpp`
+

--- a/docs/sanitizers.md
+++ b/docs/sanitizers.md
@@ -23,3 +23,9 @@ Sanitizers are available when using Clang or GCC. Supported entries include:
 - `cfi` – Control Flow Integrity (requires LTO).
 
 Multiple sanitizers may be combined when they are compatible.
+
+## Code anchors
+
+- Sanitizer configuration: `set(SIM_SANITIZERS ...)`, `add_compile_options` for PGO/sanitizers; `CMakeLists.txt`
+- Target instrumentation: `foreach(_san IN LISTS SIM_SANITIZERS)` handling; `CMakeLists.txt`
+

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -19,3 +19,9 @@ exposes a helper `Scheduler::pop_next_with_aging` function that selects the next
 task based on the `(priority + age)` heuristic. This function is used by unit
 tests to verify the aging behaviour.
 
+## Code anchors
+
+- Task representation: `rt::Scheduler::Task`; `rt/include/rt/scheduler.hpp`
+- Aging heuristic: `rt::Scheduler::pop_next_with_aging`; `rt/include/rt/scheduler.hpp`
+- Worker execution: `rt::Scheduler::run`; `rt/include/rt/scheduler.hpp`, `rt/src/scheduler.cpp`
+

--- a/docs/security_supply_chain.md
+++ b/docs/security_supply_chain.md
@@ -29,3 +29,11 @@ third‑party dependencies.
 `tools/store_repro_build.py` stores build outputs along with a SHA256
 digest.  The resulting metadata can be kept with performance artifacts
 allowing binary reproducibility checks.
+
+## Code anchors
+
+- Sandboxing: `enable_sandbox`; `include/simcore/sandbox.hpp`
+- Minidump symbols: `write_minidump`; `include/simcore/minidump.hpp`
+- SBOM verification: `main()` runner; `tools/sbom.py`
+- Reproducible artifacts: `main()` workflow; `tools/store_repro_build.py`
+

--- a/docs/simd_autotune.md
+++ b/docs/simd_autotune.md
@@ -11,3 +11,11 @@ mask loads/stores on the final block which simplifies the generated code.
 Manual prefetching is now guarded by a small working-set heuristic. Prefetch instructions are only issued when the
 array length exceeds a conservative threshold (`PREFETCH_MIN_N`), ensuring small problems do not pay the overhead of
 prefetching.
+
+## Code anchors
+
+- Block-size autotuner: `soa::autotune_block_size`; `include/simcore/soa/autotune.hpp`
+- Benchmark helper: `soa::measure_axpy3`; `include/simcore/soa/autotune.hpp`
+- AoSoA kernel: `soa::axpy3`; `include/simcore/soa/aosoa.hpp`
+- Prefetch heuristic: `sim::PREFETCH_MIN_N`, `sim::prefetch`; `include/simcore/prefetch.hpp`
+

--- a/docs/testing_ci.md
+++ b/docs/testing_ci.md
@@ -32,3 +32,9 @@ LibFuzzer harnesses (e.g. `tests/jobqueue_fuzz.cpp`) run under
 ASan/UBSan/TSan.  Any TSan suppressions must carry written justification
 within the repository.
 
+## Code anchors
+
+- Differential testing: `TEST(DifferentialKernelTest, DriftBelowThreshold)`; `tests/test_differential_output.cpp`
+- Chaos testing: `TEST(FaultInjection, RandomDelaysStillRun)`; `tests/test_fault_injection.cpp`
+- Fuzzing harness: `LLVMFuzzerTestOneInput`; `tests/jobqueue_fuzz.cpp`
+

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -9,3 +9,10 @@ strategies.
   runtime limits and monitoring to detect and contain abuses.
 - **Denial of Service**: Malformed inputs may trigger unexpected states.
   Validate inputs and employ watchdog timers.
+
+## Code anchors
+
+- Plugin mitigations: `rt::PluginManager::load`, `rt::PluginManager::unload`; `rt/src/plugin_manager.cpp`, `rt/include/rt/plugin_api.h`
+- Resource limits: `simcore::TokenBucket::try_acquire`; `include/simcore/backpressure.hpp`
+- Watchdog guardrails: `rt::Watchdog::arm`, `rt::Watchdog::disarm`; `rt/include/rt/watchdog.hpp`
+


### PR DESCRIPTION
## Summary
- add Code anchors sections to each documentation page to reference the functions, tests, and build scripts that implement the described features

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d1fd658464832b934dea88a9dd928a