### PR TITLE
Update queue trace export labels

### DIFF
--- a/tools/trace_export.hpp
+++ b/tools/trace_export.hpp
@@ -60,7 +60,11 @@ inline void write_chrome_trace(const bintrace::Trace::Snapshot& snap, std::ostre
         switch (e.code) {
         case bintrace::EV_QueuePush:
         case bintrace::EV_QueuePop:
-            os << "{\"depth\":" << e.a << "}";
+            os << "{\"depth\":" << e.a;
+            if (e.b) {
+                os << ",\"capacity\":" << e.b;
+            }
+            os << "}";
             break;
         default:
             os << "{\"a\":" << e.a << ",\"b\":" << e.b << "}";


### PR DESCRIPTION
## Summary
- rename the queue push/pop trace event labels to queue_push and queue_pop
- emit queue depth (and capacity when available) when exporting Chrome traces

## Testing
- cmake --build --preset dev
- ctest --preset dev

------
https://chatgpt.com/codex/tasks/task_e_68d30f5c3fe8832b8df53c6f5032a403