### PR TITLE
Trace emergency worker spawns

### DIFF
--- a/include/simcore/bintrace.hpp
+++ b/include/simcore/bintrace.hpp
@@ -39,6 +39,7 @@ enum : std::uint32_t {
     EV_SnapshotSave      = 0x0C,
     EV_SnapshotLoad      = 0x0D,
     EV_PlatformCrumb     = 0x0E,
+    EV_EmergencySpawn    = 0x0F,
 };
 
 static inline std::uint64_t rdtsc() noexcept {

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -80,6 +80,7 @@ public:
       }
       if (threads_.size() > 1) {
         simcore::debug::assert_thread_creation_allowed();
+        logEmergencySpawn();
         std::thread([this, job = std::move(job)]() mutable {
           rt::init_fp_env();
           active_.fetch_add(1, std::memory_order_acq_rel);
@@ -132,6 +133,7 @@ public:
               return true;
             }
             simcore::debug::assert_thread_creation_allowed();
+            logEmergencySpawn();
             std::thread([this, job = std::move(job)]() mutable {
               rt::init_fp_env();
               active_.fetch_add(1, std::memory_order_acq_rel);
@@ -168,6 +170,7 @@ public:
           return true;
         }
         simcore::debug::assert_thread_creation_allowed();
+        logEmergencySpawn();
         std::thread([this, job = std::move(job)]() mutable {
           rt::init_fp_env();
           active_.fetch_add(1, std::memory_order_acq_rel);
@@ -237,6 +240,17 @@ public:
   }
 
 private:
+  void logEmergencySpawn() {
+    if (auto *trace = trace_.load(std::memory_order_acquire)) {
+      constexpr std::uint32_t kUnknownThread = ~std::uint32_t{0};
+      const std::uint64_t outstandingCount =
+          static_cast<std::uint64_t>(
+              outstanding_.load(std::memory_order_acquire));
+      trace->log(bintrace::EV_EmergencySpawn, kUnknownThread,
+                 outstandingCount);
+    }
+  }
+
   void workerLoop(std::size_t index) {
     bool bound = false;
     bool stealLogged = false;

--- a/tools/trace_export.hpp
+++ b/tools/trace_export.hpp
@@ -15,6 +15,7 @@ inline const char* codeToCat(std::uint32_t code) {
     case bintrace::EV_QueuePush:          return "queue";
     case bintrace::EV_QueuePop:           return "queue";
     case bintrace::EV_WorkSteal:          return "WorkSteal";
+    case bintrace::EV_EmergencySpawn:     return "WorkerPool";
     case bintrace::EV_WatchdogTrip:       return "WatchdogTrip";
     case bintrace::EV_GpuFenceWaitBegin:  return "GpuFenceWaitBegin";
     case bintrace::EV_GpuFenceWaitEnd:    return "GpuFenceWaitEnd";
@@ -35,6 +36,7 @@ inline const char* codeToName(std::uint32_t code) {
     case bintrace::EV_QueuePush:          return "queue_push";
     case bintrace::EV_QueuePop:           return "queue_pop";
     case bintrace::EV_WorkSteal:          return "Work Steal";
+    case bintrace::EV_EmergencySpawn:     return "Emergency Spawn";
     case bintrace::EV_WatchdogTrip:       return "Watchdog Trip";
     case bintrace::EV_GpuFenceWaitBegin:  return "GPU Fence Wait Begin";
     case bintrace::EV_GpuFenceWaitEnd:    return "GPU Fence Wait End";
@@ -65,6 +67,15 @@ inline void write_chrome_trace(const bintrace::Trace::Snapshot& snap, std::ostre
                 os << ",\"capacity\":" << e.b;
             }
             os << "}";
+            break;
+        case bintrace::EV_EmergencySpawn:
+            os << "{\"thread_idx\":";
+            if (e.a == ~std::uint32_t{0}) {
+                os << -1;
+            } else {
+                os << e.a;
+            }
+            os << ",\"outstanding\":" << e.b << "}";
             break;
         default:
             os << "{\"a\":" << e.a << ",\"b\":" << e.b << "}";


### PR DESCRIPTION
## Summary
- add a bintrace event code for emergency worker spawns
- log the event whenever WorkerPool has to detach a high-priority thread
- expose the new event in the trace exporter with descriptive Chrome trace args

## Testing
- cmake --preset dev
- cmake --build --preset dev
- ctest --preset dev

------
https://chatgpt.com/codex/tasks/task_e_68d32ef4e710832bbf87f2946bee8175