### PR TITLE
Remove worker pool queue push/pop trace duplicates

### DIFF
--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -94,10 +94,6 @@ public:
     }
     while (true) {
       if (queue_.try_push(std::move(job))) {
-        if (auto *trace = trace_.load(std::memory_order_acquire)) {
-          trace->log(bintrace::EV_QueuePush,
-                     static_cast<std::uint32_t>(queue_.size()));
-        }
         break;
       }
       std::this_thread::yield();
@@ -148,10 +144,6 @@ public:
             outstanding_.fetch_sub(1, std::memory_order_acq_rel);
             return false;
           }
-          if (auto *trace = trace_.load(std::memory_order_acquire)) {
-            trace->log(bintrace::EV_QueuePush,
-                       static_cast<std::uint32_t>(queue_.size()));
-          }
           return true;
         }
       }
@@ -184,10 +176,6 @@ public:
       if (!queue_.try_push(std::move(job))) {
         outstanding_.fetch_sub(1, std::memory_order_acq_rel);
         return false;
-      }
-      if (auto *trace = trace_.load(std::memory_order_acquire)) {
-        trace->log(bintrace::EV_QueuePush,
-                   static_cast<std::uint32_t>(queue_.size()));
       }
       return true;
     }
@@ -264,12 +252,6 @@ private:
       }
       Job job;
       if (queue_.try_pop(job)) {
-        if (bound) {
-          if (auto *trace = trace_.load(std::memory_order_acquire)) {
-            trace->log(bintrace::EV_QueuePop,
-                       static_cast<std::uint32_t>(queue_.size()));
-          }
-        }
         active_.fetch_add(1, std::memory_order_acq_rel);
         if (job.fn)
           job.fn();


### PR DESCRIPTION
## Summary
- stop WorkerPool from logging EV_QueuePush when enqueueing work
- remove EV_QueuePop emission from the worker loop to rely on queue instrumentation

## Testing
- cmake --build --preset dev
- ctest --preset dev --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d33fa20fcc832bb3d186abb2d8fbd6