### PR TITLE
Enforce arena binding invariant for scratch allocations

### DIFF
--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -107,8 +107,9 @@ public:
   double recoveredMs() const { return recoveredMs_; }
   double precoveredMs() const { return precoveredMs_; }
   FrameArena &frameArena() {
-    RTFW_DEBUG_ASSERT(tls_arena_bound &&
-                      "Thread arena not bound—call bindCurrentThread() before allocating");
+    RTFW_DEBUG_ASSERT(
+        tls_arena_bound,
+        "Thread arena not bound—call bindCurrentThread() before allocating");
     return frameArenas_->tls();
   }
   rt::FiberPool &fiberPool() { return *fiberPool_; }

--- a/include/simcore/frame_arena.hpp
+++ b/include/simcore/frame_arena.hpp
@@ -5,9 +5,15 @@
 
 #ifndef RTFW_DEBUG_ASSERT
 #  ifdef NDEBUG
-#    define RTFW_DEBUG_ASSERT(expr) ((void)0)
+#    define RTFW_DEBUG_ASSERT(...) ((void)0)
 #  else
-#    define RTFW_DEBUG_ASSERT(expr) assert(expr)
+namespace simcore::detail {
+inline void debug_assert(bool expr) { assert(expr); }
+inline void debug_assert(bool expr, const char *msg) {
+  assert(expr && msg);
+}
+} // namespace simcore::detail
+#    define RTFW_DEBUG_ASSERT(...) ::simcore::detail::debug_assert(__VA_ARGS__)
 #  endif
 #endif
 

--- a/include/simcore/frame_arena.hpp
+++ b/include/simcore/frame_arena.hpp
@@ -2,6 +2,9 @@
 #include "rt_memory.hpp"
 #include <rt/numa.hpp>
 #include <cassert>
+#ifndef NDEBUG
+#  include <cstdio>
+#endif
 
 #ifndef RTFW_DEBUG_ASSERT
 #  ifdef NDEBUG
@@ -10,7 +13,11 @@
 namespace simcore::detail {
 inline void debug_assert(bool expr) { assert(expr); }
 inline void debug_assert(bool expr, const char *msg) {
-  assert(expr && msg);
+  if (!expr) {
+    std::fputs(msg, stderr);
+    std::fputc('\n', stderr);
+  }
+  assert(expr);
 }
 } // namespace simcore::detail
 #    define RTFW_DEBUG_ASSERT(...) ::simcore::detail::debug_assert(__VA_ARGS__)

--- a/tests/test_arena_binding_assert.cpp
+++ b/tests/test_arena_binding_assert.cpp
@@ -12,8 +12,9 @@ TEST(FrameArenaBindingAssert, DeathBeforeBinding) {
   EXPECT_DEATH(
       {
         tls_arena_bound = false;
-        RTFW_DEBUG_ASSERT(tls_arena_bound &&
-                          "Thread arena not bound—call bindCurrentThread() before allocating");
+        RTFW_DEBUG_ASSERT(
+            tls_arena_bound,
+            "Thread arena not bound—call bindCurrentThread() before allocating");
         auto &arena = pool.tls();
         (void)arena.allocate(64, 64);
       },


### PR DESCRIPTION
## Summary
- guard SimCore::frameArena with a debug assertion that verifies the thread arena is bound before handing out scratch memory
- extend the frame arena header helper so RTFW_DEBUG_ASSERT accepts an optional message while exposing the TLS binding flag for tests
- update the arena binding death test to use the new debug assertion form

## Testing
- ctest --preset dev --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d34be24948832bbaece9ea78800de1