### PR TITLE
Rate limit worker pool emergency spawns

### DIFF
--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -340,6 +340,7 @@ public:
       registry->set_counter("log_drops", loggerDrops + traceDrops);
       registry->set_counter("worker.queue_max", 0);
       registry->set_counter("worker.steals_total", 0);
+      registry->set_counter("worker.emergency_spawns", 0);
     }
     publishCounters();
   }
@@ -674,6 +675,8 @@ private:
                             static_cast<std::uint64_t>(sample.queueMaxDepth));
       registry->set_counter("worker.steals_total",
                             static_cast<std::uint64_t>(sample.totalSteals));
+      registry->set_counter("worker.emergency_spawns",
+                            sample.emergencySpawns);
       for (std::size_t i = sample.stealsPerThread.size();
            i < lastWorkerStealCounterCount_; ++i) {
         registry->set_counter(workerStealCounterName(i), 0);
@@ -687,6 +690,7 @@ private:
     } else {
       registry->set_counter("worker.queue_max", 0);
       registry->set_counter("worker.steals_total", 0);
+      registry->set_counter("worker.emergency_spawns", 0);
       for (std::size_t i = 0; i < lastWorkerStealCounterCount_; ++i) {
         registry->set_counter(workerStealCounterName(i), 0);
       }

--- a/include/simcore/metrics.hpp
+++ b/include/simcore/metrics.hpp
@@ -24,6 +24,7 @@ struct CounterSample {
 struct WorkerPoolSample {
   std::size_t queueMaxDepth = 0;
   std::size_t totalSteals = 0;
+  std::uint64_t emergencySpawns = 0;
   std::vector<std::size_t> stealsPerThread;
 };
 
@@ -31,6 +32,7 @@ inline WorkerPoolSample make_sample(WorkerPool::Stats stats) {
   WorkerPoolSample sample;
   sample.queueMaxDepth = stats.maxQueueDepth;
   sample.totalSteals = stats.totalSteals;
+  sample.emergencySpawns = stats.emergencySpawns;
   sample.stealsPerThread = std::move(stats.stealsPerThread);
   return sample;
 }
@@ -43,7 +45,7 @@ inline std::vector<CounterSample>
 worker_pool_counters(const WorkerPoolSample &sample,
                      std::string_view prefix = "worker_pool") {
   std::vector<CounterSample> counters;
-  counters.reserve(2 + sample.stealsPerThread.size());
+  counters.reserve(3 + sample.stealsPerThread.size());
   std::string prefixStr(prefix);
   counters.push_back(
       CounterSample{prefixStr + ".queue_max",
@@ -51,6 +53,9 @@ worker_pool_counters(const WorkerPoolSample &sample,
   counters.push_back(
       CounterSample{prefixStr + ".steals_total",
                     static_cast<std::uint64_t>(sample.totalSteals)});
+  counters.push_back(
+      CounterSample{prefixStr + ".emergency_spawns",
+                    sample.emergencySpawns});
   for (std::size_t i = 0; i < sample.stealsPerThread.size(); ++i) {
     std::ostringstream name;
     name << prefixStr << ".steals[" << i << "]";
@@ -68,7 +73,8 @@ inline std::string worker_pool_json(const WorkerPoolSample &sample) {
       os << ',';
     os << sample.stealsPerThread[i];
   }
-  os << "],\"steals_total\":" << sample.totalSteals << "}";
+  os << "],\"steals_total\":" << sample.totalSteals
+     << ",\"emergency_spawns\":" << sample.emergencySpawns << "}";
   return os.str();
 }
 

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -1,8 +1,12 @@
 #pragma once
+#include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <limits>
+#include <mutex>
 #include <thread>
 #include <vector>
 #include <rt/numerics.hpp>
@@ -28,6 +32,7 @@ public:
     std::size_t maxQueueDepth;
     std::size_t totalSteals;
     std::vector<std::size_t> stealsPerThread;
+    std::uint64_t emergencySpawns;
   };
 
   WorkerPool(std::size_t numThreads, std::size_t queueSizePow2 = 1024,
@@ -38,6 +43,7 @@ public:
     active_.store(0, std::memory_order_relaxed);
     outstanding_.store(0, std::memory_order_relaxed);
     maxOutstanding_ = maxOutstanding;
+    emergencyLastRefill_ = std::chrono::steady_clock::now();
     for (std::size_t i = 0; i < numThreads; ++i) {
       simcore::debug::assert_thread_creation_allowed();
       threads_.emplace_back([this, i] {
@@ -68,27 +74,11 @@ public:
       outstanding_.fetch_add(1, std::memory_order_acq_rel);
     }
     Job job{std::move(fn), pr, cat};
-    if (pr == Priority::High &&
-        outstanding_.load(std::memory_order_acquire) >= threads_.size()) {
-      if (threads_.size() == 1) {
-        active_.fetch_add(1, std::memory_order_acq_rel);
-        if (job.fn)
-          job.fn();
-        active_.fetch_sub(1, std::memory_order_acq_rel);
-        outstanding_.fetch_sub(1, std::memory_order_acq_rel);
-        return;
-      }
-      if (threads_.size() > 1) {
-        simcore::debug::assert_thread_creation_allowed();
-        logEmergencySpawn();
-        std::thread([this, job = std::move(job)]() mutable {
-          rt::init_fp_env();
-          active_.fetch_add(1, std::memory_order_acq_rel);
-          if (job.fn)
-            job.fn();
-          active_.fetch_sub(1, std::memory_order_acq_rel);
-          outstanding_.fetch_sub(1, std::memory_order_acq_rel);
-        }).detach();
+    if (pr == Priority::High) {
+      const std::size_t outstandingCount =
+          outstanding_.load(std::memory_order_acquire);
+      if (outstandingCount >= threads_.size() &&
+          handleEmergency(job, outstandingCount)) {
         return;
       }
     }
@@ -118,27 +108,13 @@ public:
                                                std::memory_order_acq_rel,
                                                std::memory_order_relaxed)) {
           Job job{std::move(fn), pr, cat};
-          if (pr == Priority::High &&
-              outstanding_.load(std::memory_order_acquire) >= threads_.size()) {
-            if (threads_.size() == 1) {
-              active_.fetch_add(1, std::memory_order_acq_rel);
-              if (job.fn)
-                job.fn();
-              active_.fetch_sub(1, std::memory_order_acq_rel);
-              outstanding_.fetch_sub(1, std::memory_order_acq_rel);
+          if (pr == Priority::High) {
+            const std::size_t outstandingCount =
+                outstanding_.load(std::memory_order_acquire);
+            if (outstandingCount >= threads_.size() &&
+                handleEmergency(job, outstandingCount)) {
               return true;
             }
-            simcore::debug::assert_thread_creation_allowed();
-            logEmergencySpawn();
-            std::thread([this, job = std::move(job)]() mutable {
-              rt::init_fp_env();
-              active_.fetch_add(1, std::memory_order_acq_rel);
-              if (job.fn)
-                job.fn();
-              active_.fetch_sub(1, std::memory_order_acq_rel);
-              outstanding_.fetch_sub(1, std::memory_order_acq_rel);
-            }).detach();
-            return true;
           }
           if (!queue_.try_push(std::move(job))) {
             outstanding_.fetch_sub(1, std::memory_order_acq_rel);
@@ -151,27 +127,13 @@ public:
     } else {
       outstanding_.fetch_add(1, std::memory_order_acq_rel);
       Job job{std::move(fn), pr, cat};
-      if (pr == Priority::High &&
-          outstanding_.load(std::memory_order_acquire) >= threads_.size()) {
-        if (threads_.size() == 1) {
-          active_.fetch_add(1, std::memory_order_acq_rel);
-          if (job.fn)
-            job.fn();
-          active_.fetch_sub(1, std::memory_order_acq_rel);
-          outstanding_.fetch_sub(1, std::memory_order_acq_rel);
+      if (pr == Priority::High) {
+        const std::size_t outstandingCount =
+            outstanding_.load(std::memory_order_acquire);
+        if (outstandingCount >= threads_.size() &&
+            handleEmergency(job, outstandingCount)) {
           return true;
         }
-        simcore::debug::assert_thread_creation_allowed();
-        logEmergencySpawn();
-        std::thread([this, job = std::move(job)]() mutable {
-          rt::init_fp_env();
-          active_.fetch_add(1, std::memory_order_acq_rel);
-          if (job.fn)
-            job.fn();
-          active_.fetch_sub(1, std::memory_order_acq_rel);
-          outstanding_.fetch_sub(1, std::memory_order_acq_rel);
-        }).detach();
-        return true;
       }
       if (!queue_.try_push(std::move(job))) {
         outstanding_.fetch_sub(1, std::memory_order_acq_rel);
@@ -224,18 +186,72 @@ public:
       totalSteals += steals;
     }
     s.totalSteals = totalSteals;
+    s.emergencySpawns =
+        emergencySpawns_.load(std::memory_order_acquire);
     return s;
   }
 
 private:
-  void logEmergencySpawn() {
+  static constexpr double kEmergencySpawnRatePerSecond = 2.0;
+  static constexpr double kEmergencySpawnCapacity = 2.0;
+
+  bool tryConsumeEmergencyToken() {
+    using Clock = std::chrono::steady_clock;
+    const auto now = Clock::now();
+    std::lock_guard<std::mutex> lock(emergencyMutex_);
+    const auto elapsed =
+        std::chrono::duration<double>(now - emergencyLastRefill_).count();
+    if (elapsed > 0.0) {
+      emergencyTokens_ =
+          std::min(kEmergencySpawnCapacity,
+                   emergencyTokens_ + elapsed * kEmergencySpawnRatePerSecond);
+      emergencyLastRefill_ = now;
+    }
+    if (emergencyTokens_ >= 1.0) {
+      emergencyTokens_ -= 1.0;
+      return true;
+    }
+    return false;
+  }
+
+  bool handleEmergency(Job &job, std::size_t outstandingCount) {
+    if (threads_.size() == 1) {
+      active_.fetch_add(1, std::memory_order_acq_rel);
+      if (job.fn)
+        job.fn();
+      active_.fetch_sub(1, std::memory_order_acq_rel);
+      outstanding_.fetch_sub(1, std::memory_order_acq_rel);
+      return true;
+    }
+    if (threads_.size() <= 1)
+      return false;
+
+    const bool rateAllowed = tryConsumeEmergencyToken();
+    logEmergencySpawn(outstandingCount, rateAllowed);
+    if (!rateAllowed)
+      return false;
+
+    simcore::debug::assert_thread_creation_allowed();
+    emergencySpawns_.fetch_add(1, std::memory_order_acq_rel);
+    std::thread([this, job = std::move(job)]() mutable {
+      rt::init_fp_env();
+      active_.fetch_add(1, std::memory_order_acq_rel);
+      if (job.fn)
+        job.fn();
+      active_.fetch_sub(1, std::memory_order_acq_rel);
+      outstanding_.fetch_sub(1, std::memory_order_acq_rel);
+    }).detach();
+    return true;
+  }
+
+  void logEmergencySpawn(std::size_t outstandingCount, bool rateAllowed) {
     if (auto *trace = trace_.load(std::memory_order_acquire)) {
-      constexpr std::uint32_t kUnknownThread = ~std::uint32_t{0};
-      const std::uint64_t outstandingCount =
-          static_cast<std::uint64_t>(
-              outstanding_.load(std::memory_order_acquire));
-      trace->log(bintrace::EV_EmergencySpawn, kUnknownThread,
-                 outstandingCount);
+      const std::uint32_t outstandingTruncated =
+          outstandingCount > std::numeric_limits<std::uint32_t>::max()
+              ? std::numeric_limits<std::uint32_t>::max()
+              : static_cast<std::uint32_t>(outstandingCount);
+      trace->log(bintrace::EV_EmergencySpawn, outstandingTruncated,
+                 rateAllowed ? 1u : 0u);
     }
   }
 
@@ -299,5 +315,9 @@ private:
   std::vector<std::atomic<std::size_t>> stealsPerThread_{};
   std::atomic<bintrace::Trace *> trace_{nullptr};
   std::atomic<std::size_t> traceBase_{0};
+  std::mutex emergencyMutex_;
+  double emergencyTokens_ = kEmergencySpawnCapacity;
+  std::chrono::steady_clock::time_point emergencyLastRefill_{};
+  std::atomic<std::uint64_t> emergencySpawns_{0};
 };
 

--- a/tests/test_metrics_json.cpp
+++ b/tests/test_metrics_json.cpp
@@ -286,6 +286,7 @@ TEST(MetricsJson, EmitsPhaseStatsAndCounters) {
   expectCounter("watchdog.trips");
   expectCounter("worker.queue_max");
   expectCounter("worker.steals_total");
+  expectCounter("worker.emergency_spawns");
   expectCounter("logger.dropped");
   expectCounter("trace.dropped");
   expectCounter("log_drops");

--- a/tests/test_queue_metrics.cpp
+++ b/tests/test_queue_metrics.cpp
@@ -49,6 +49,7 @@ TEST(QueueMetrics, PublishesDepthAndSteals) {
   EXPECT_NE(json.find("\"queue_max\""), std::string::npos);
   EXPECT_NE(json.find("\"steals\""), std::string::npos);
   EXPECT_NE(json.find("\"steals_total\""), std::string::npos);
+  EXPECT_NE(json.find("\"emergency_spawns\""), std::string::npos);
   EXPECT_NE(json.find(std::to_string(sample.queueMaxDepth)), std::string::npos);
 
   auto counters = metrics::worker_pool_counters(sample, "pool");
@@ -68,5 +69,9 @@ TEST(QueueMetrics, PublishesDepthAndSteals) {
   ASSERT_NE(itSteals, counters.end());
   EXPECT_EQ(itSteals->value,
             static_cast<std::uint64_t>(sample.totalSteals));
+
+  auto itEmergency = findCounter("pool.emergency_spawns");
+  ASSERT_NE(itEmergency, counters.end());
+  EXPECT_EQ(itEmergency->value, sample.emergencySpawns);
 }
 

--- a/tests/test_rt_pipeline.cpp
+++ b/tests/test_rt_pipeline.cpp
@@ -76,6 +76,8 @@ TEST(RTPipeline, EndToEndSmokeTest) {
             static_cast<std::uint64_t>(stats.maxQueueDepth));
   EXPECT_EQ(expectCounter("worker.steals_total"),
             static_cast<std::uint64_t>(stats.totalSteals));
+  EXPECT_EQ(expectCounter("worker.emergency_spawns"),
+            stats.emergencySpawns);
   EXPECT_NE(snapshot.counters.find("missed_frames"), snapshot.counters.end());
   EXPECT_NE(snapshot.counters.find("watchdog.trips"), snapshot.counters.end());
   EXPECT_NE(snapshot.counters.find("log_drops"), snapshot.counters.end());

--- a/tools/trace_export.hpp
+++ b/tools/trace_export.hpp
@@ -69,13 +69,8 @@ inline void write_chrome_trace(const bintrace::Trace::Snapshot& snap, std::ostre
             os << "}";
             break;
         case bintrace::EV_EmergencySpawn:
-            os << "{\"thread_idx\":";
-            if (e.a == ~std::uint32_t{0}) {
-                os << -1;
-            } else {
-                os << e.a;
-            }
-            os << ",\"outstanding\":" << e.b << "}";
+            os << "{\"outstanding\":" << e.a
+               << ",\"rate_allowed\":" << (e.b ? "true" : "false") << "}";
             break;
         default:
             os << "{\"a\":" << e.a << ",\"b\":" << e.b << "}";


### PR DESCRIPTION
## Summary
- throttle the worker pool emergency spawn path with a per-second token bucket that logs rate allowance
- surface emergency spawn counts through worker metrics/JSON and ensure regression tests cover the new counter
- update trace export output to report emergency spawn allowance instead of thread id

## Testing
- cmake --build --preset dev
- ctest --preset dev

------
https://chatgpt.com/codex/tasks/task_e_68d3f6d85fb4832ba592f2bebe4c3d0d