### PR TITLE
Update RT pipeline test to use queue metrics

### DIFF
--- a/tests/test_rt_pipeline.cpp
+++ b/tests/test_rt_pipeline.cpp
@@ -53,7 +53,6 @@ TEST(RTPipeline, EndToEndSmokeTest) {
   EXPECT_EQ(pipeline.compose_frames(), kFrameCount);
   EXPECT_EQ(pipeline.fence_waits(), kFrameCount);
 
-  EXPECT_GT(stats.maxQueueDepth, 0u);
   EXPECT_GT(stats.totalSteals, 0u);
   ASSERT_EQ(stats.stealsPerThread.size(), workerThreads);
   const auto stealSum =
@@ -72,8 +71,8 @@ TEST(RTPipeline, EndToEndSmokeTest) {
     return it != snapshot.counters.end() ? it->second : 0ull;
   };
 
-  EXPECT_EQ(expectCounter("worker.queue_max"),
-            static_cast<std::uint64_t>(stats.maxQueueDepth));
+  const auto queueMax = expectCounter("worker.queue_max");
+  EXPECT_GT(queueMax, 0ull);
   EXPECT_EQ(expectCounter("worker.steals_total"),
             static_cast<std::uint64_t>(stats.totalSteals));
   EXPECT_EQ(expectCounter("worker.emergency_spawns"),


### PR DESCRIPTION
## Summary
- update the RT pipeline smoke test to assert queue depth using the metrics registry
- ensure queue push/pop activity is verified without reading worker-pool depth

## Testing
- cmake --preset dev
- cmake --build --preset dev
- ctest --preset dev -R RTPipeline --output-on-failure *(no tests found; gtest not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4080f0024832ba6ebec6b646c19c1