### PR TITLE
Improve spin loop performance with cpu_relax hints

### DIFF
--- a/gpu/frame_graph.hpp
+++ b/gpu/frame_graph.hpp
@@ -9,6 +9,8 @@
 #include <thread>
 #include <vector>
 
+#include <rt/arch.hpp>
+
 #include "hal/hal.hpp"
 #include "hal/gpu_stub.hpp"
 #include <rt/fiber_pool.hpp>
@@ -26,7 +28,7 @@ struct TimelineSemaphore {
 
     void wait(uint64_t target) {
         while (value.load(std::memory_order_acquire) < target) {
-            std::this_thread::yield();
+            rt::cpu_relax();
         }
     }
 

--- a/include/simcore/SimCore.hpp
+++ b/include/simcore/SimCore.hpp
@@ -32,6 +32,7 @@
 #include "rate_governor.hpp"
 #include "highres_clock.hpp"
 #include "worker_pool.hpp"
+#include <rt/arch.hpp>
 #include <rt/fiber_pool.hpp>
 #include <rt/numa.hpp>
 #include <rt/numerics.hpp>
@@ -1346,7 +1347,7 @@ private:
         while (remaining_.load(std::memory_order_acquire) > 0) {
           std::size_t idx = nextChunk_.fetch_add(1, std::memory_order_relaxed);
           if (idx >= totalChunks) {
-            std::this_thread::yield();
+            rt::cpu_relax();
             continue;
           }
           std::size_t begin = idx * active_.chunkSize;
@@ -1438,7 +1439,7 @@ private:
         while (remaining_.load(std::memory_order_acquire) > 0) {
           std::size_t idx = nextChunk_.fetch_add(1, std::memory_order_relaxed);
           if (idx >= totalChunks) {
-            std::this_thread::yield();
+            rt::cpu_relax();
             continue;
           }
           const std::size_t b = idx * chunk;
@@ -1509,7 +1510,7 @@ private:
           });
         }
         while (remaining.load(std::memory_order_acquire) != 0)
-          std::this_thread::yield();
+          rt::cpu_relax();
       }
     }
     if (watchdog_)

--- a/include/simcore/job_queue.hpp
+++ b/include/simcore/job_queue.hpp
@@ -8,6 +8,8 @@
 #include <utility>
 #include <vector>
 
+#include <rt/arch.hpp>
+
 #include "bintrace.hpp"
 
 #if defined(_MSC_VER)
@@ -65,6 +67,7 @@ public:
       } else {
         pos = enqueuePos_.load(std::memory_order_relaxed);
       }
+      rt::cpu_relax();
     }
     enqueueCache_ = pos + 1;
     cell->data = std::forward<U>(v);
@@ -104,6 +107,7 @@ public:
       } else {
         pos = dequeuePos_.load(std::memory_order_relaxed);
       }
+      rt::cpu_relax();
     }
     dequeueCache_ = pos + 1;
     out = std::move(cell->data);

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+#include <rt/arch.hpp>
 #include <rt/numerics.hpp>
 #include "bintrace.hpp"
 #include "job_queue.hpp"
@@ -61,7 +62,7 @@ public:
       for (;;) {
         std::size_t cur = outstanding_.load(std::memory_order_acquire);
         if (cur >= maxOutstanding_) {
-          std::this_thread::yield();
+          rt::cpu_relax();
           continue;
         }
         if (outstanding_.compare_exchange_weak(cur, cur + 1,
@@ -86,7 +87,7 @@ public:
       if (queue_.try_push(std::move(job))) {
         break;
       }
-      std::this_thread::yield();
+      rt::cpu_relax();
     }
   }
 

--- a/rt/include/rt/arch.hpp
+++ b/rt/include/rt/arch.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
+#include <immintrin.h>
+#elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64)
+#  if defined(__has_include)
+#    if __has_include(<arm_acle.h>)
+#      include <arm_acle.h>
+#    endif
+#  endif
+#endif
+
+namespace rt {
+
+inline void cpu_relax() noexcept {
+#if defined(__i386__) || defined(__x86_64__) || defined(_M_IX86) || defined(_M_X64)
+    _mm_pause();
+#elif defined(__aarch64__) || defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64)
+#  if defined(_MSC_VER)
+    __yield();
+#  else
+    __asm__ __volatile__("yield");
+#  endif
+#else
+    // Fallback to no-op when no architecture-specific hint is available.
+#endif
+}
+
+} // namespace rt
+

--- a/rt/src/scheduler.cpp
+++ b/rt/src/scheduler.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 
+#include <rt/arch.hpp>
+
 namespace rt {
 
 Scheduler::Scheduler(std::size_t threads) {
@@ -60,7 +62,7 @@ void Scheduler::workerLoop(std::size_t index) {
       if (!stealTask(index, task)) {
         if (remaining_.load(std::memory_order_acquire) == 0)
           break; // all tasks done
-        std::this_thread::yield();
+        rt::cpu_relax();
         continue;
       }
     }


### PR DESCRIPTION
## Summary
- add an architecture-specific `rt::cpu_relax()` intrinsic for x86 and ARM
- use the new relax hint inside the bounded MPMC queue and other hot spin loops
- switch timeline semaphore, worker pool, SimCore, and scheduler waits to the relax primitive to lower contention

## Testing
- cmake --preset dev
- cmake --build --preset dev
- ctest --preset dev

------
https://chatgpt.com/codex/tasks/task_e_68d40fbb7ce4832b86946bd70984571c