### PR TITLE
Add allocation guard for Trace::log

### DIFF
--- a/include/simcore/bintrace.hpp
+++ b/include/simcore/bintrace.hpp
@@ -23,6 +23,8 @@ struct alignas(32) Event {
     std::uint32_t _pad{};
 };
 
+static_assert(sizeof(Event) == 32, "Trace events are expected to stay 32 bytes");
+
 enum : std::uint32_t {
     EV_PhaseBegin        = 0x01,
     EV_PhaseEnd          = 0x02,
@@ -114,13 +116,11 @@ public:
         if (!buf) return;
         const std::size_t cap = buf->cap;
         if (cap == 0) {
-            buf->dropped.fetch_add(1, std::memory_order_relaxed);
-            dropped_.fetch_add(1, std::memory_order_relaxed);
+            recordDrop(buf);
             return;
         }
-        if (buf->throttle && !buf->throttle->try_acquire()) {
-            buf->dropped.fetch_add(1, std::memory_order_relaxed);
-            dropped_.fetch_add(1, std::memory_order_relaxed);
+        if (auto* throttle = buf->throttle.get(); throttle && !throttle->try_acquire()) {
+            recordDrop(buf);
             return;
         }
         const std::size_t i   = buf->write.load(std::memory_order_relaxed);
@@ -248,6 +248,11 @@ private:
             dropped.store(0, std::memory_order_relaxed);
         }
     };
+
+    inline void recordDrop(Buffer* buf) noexcept {
+        buf->dropped.fetch_add(1, std::memory_order_relaxed);
+        dropped_.fetch_add(1, std::memory_order_relaxed);
+    }
 
     std::vector<std::unique_ptr<Buffer>> buffers_;
     bool enabled_ = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ if (SIM_GTEST_AVAILABLE)
         test_prng_determinism.cpp
         test_snapshot.cpp
         test_trace_export.cpp
+        test_trace_noalloc.cpp
         test_units.cpp
         test_huge_page.cpp
         test_thermal_limp.cpp

--- a/tests/test_trace_noalloc.cpp
+++ b/tests/test_trace_noalloc.cpp
@@ -1,0 +1,263 @@
+#include <gtest/gtest.h>
+
+#include <simcore/bintrace.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <new>
+
+#if defined(_MSC_VER)
+#include <malloc.h>
+#endif
+
+namespace {
+std::atomic<std::size_t> g_allocation_count{0};
+std::atomic<bool> g_track_allocations{false};
+
+void record_allocation() noexcept {
+    if (g_track_allocations.load(std::memory_order_relaxed)) {
+        g_allocation_count.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+std::size_t align_up(std::size_t value, std::size_t alignment) {
+    const std::size_t mask = alignment - 1;
+    const std::size_t rounded = (value + mask) & ~mask;
+    if (rounded < value) {
+        throw std::bad_alloc();
+    }
+    return rounded;
+}
+
+void* allocate_raw(std::size_t size) {
+    if (size == 0) size = 1;
+    if (void* ptr = std::malloc(size)) {
+        return ptr;
+    }
+    throw std::bad_alloc();
+}
+
+void* allocate_aligned(std::size_t size, std::size_t alignment) {
+    if (alignment < alignof(std::max_align_t)) {
+        alignment = alignof(std::max_align_t);
+    }
+    if (size == 0) {
+        size = alignment;
+    }
+    size = align_up(size, alignment);
+#if defined(_MSC_VER)
+    if (void* ptr = _aligned_malloc(size, alignment)) {
+        return ptr;
+    }
+    throw std::bad_alloc();
+#else
+    void* ptr = nullptr;
+    if (posix_memalign(&ptr, alignment, size) == 0) {
+        return ptr;
+    }
+    throw std::bad_alloc();
+#endif
+}
+
+void deallocate_aligned(void* ptr) noexcept {
+#if defined(_MSC_VER)
+    _aligned_free(ptr);
+#else
+    std::free(ptr);
+#endif
+}
+
+struct AllocationGuard {
+    AllocationGuard() {
+        g_allocation_count.store(0, std::memory_order_relaxed);
+        g_track_allocations.store(true, std::memory_order_release);
+    }
+    ~AllocationGuard() {
+        g_track_allocations.store(false, std::memory_order_release);
+    }
+};
+
+std::size_t allocation_count() {
+    return g_allocation_count.load(std::memory_order_acquire);
+}
+
+} // namespace
+
+void* operator new(std::size_t size) {
+    record_allocation();
+    return allocate_raw(size);
+}
+
+void* operator new[](std::size_t size) {
+    record_allocation();
+    return allocate_raw(size);
+}
+
+void* operator new(std::size_t size, std::align_val_t alignment) {
+    record_allocation();
+    return allocate_aligned(size, static_cast<std::size_t>(alignment));
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment) {
+    record_allocation();
+    return allocate_aligned(size, static_cast<std::size_t>(alignment));
+}
+
+void* operator new(std::size_t size, const std::nothrow_t&) noexcept {
+    try {
+        return ::operator new(size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void* operator new[](std::size_t size, const std::nothrow_t&) noexcept {
+    try {
+        return ::operator new[](size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void* operator new(std::size_t size, std::align_val_t alignment,
+                   const std::nothrow_t&) noexcept {
+    try {
+        return ::operator new(size, alignment);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void* operator new[](std::size_t size, std::align_val_t alignment,
+                      const std::nothrow_t&) noexcept {
+    try {
+        return ::operator new[](size, alignment);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+void operator delete(void* ptr) noexcept {
+    std::free(ptr);
+}
+
+void operator delete[](void* ptr) noexcept {
+    std::free(ptr);
+}
+
+void operator delete(void* ptr, std::size_t) noexcept {
+    std::free(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t) noexcept {
+    std::free(ptr);
+}
+
+void operator delete(void* ptr, std::align_val_t alignment) noexcept {
+    (void)alignment;
+    if (!ptr) return;
+    deallocate_aligned(ptr);
+}
+
+void operator delete[](void* ptr, std::align_val_t alignment) noexcept {
+    (void)alignment;
+    if (!ptr) return;
+    deallocate_aligned(ptr);
+}
+
+void operator delete(void* ptr, std::size_t, std::align_val_t alignment) noexcept {
+    (void)alignment;
+    if (!ptr) return;
+    deallocate_aligned(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t, std::align_val_t alignment) noexcept {
+    (void)alignment;
+    if (!ptr) return;
+    deallocate_aligned(ptr);
+}
+
+void operator delete(void* ptr, const std::nothrow_t&) noexcept {
+    std::free(ptr);
+}
+
+void operator delete[](void* ptr, const std::nothrow_t&) noexcept {
+    std::free(ptr);
+}
+
+void operator delete(void* ptr, std::align_val_t alignment,
+                     const std::nothrow_t&) noexcept {
+    (void)alignment;
+    if (!ptr) return;
+    deallocate_aligned(ptr);
+}
+
+void operator delete[](void* ptr, std::align_val_t alignment,
+                       const std::nothrow_t&) noexcept {
+    (void)alignment;
+    if (!ptr) return;
+    deallocate_aligned(ptr);
+}
+
+void operator delete(void* ptr, std::size_t, const std::nothrow_t&) noexcept {
+    std::free(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t, const std::nothrow_t&) noexcept {
+    std::free(ptr);
+}
+
+void operator delete(void* ptr, std::size_t, std::align_val_t alignment,
+                     const std::nothrow_t&) noexcept {
+    (void)alignment;
+    if (!ptr) return;
+    deallocate_aligned(ptr);
+}
+
+void operator delete[](void* ptr, std::size_t, std::align_val_t alignment,
+                       const std::nothrow_t&) noexcept {
+    (void)alignment;
+    if (!ptr) return;
+    deallocate_aligned(ptr);
+}
+
+TEST(TraceNoAlloc, LogHotPathDoesNotAllocate) {
+    using namespace bintrace;
+
+    Trace trace;
+    constexpr std::size_t kThreads = 1;
+    constexpr std::size_t kEventsPerThread = 1u << 12;
+    trace.init(kThreads, kEventsPerThread, true);
+    trace.bindThread(0);
+
+    constexpr std::size_t kBurst = 256;
+
+    {
+        AllocationGuard guard;
+        for (std::size_t i = 0; i < kBurst; ++i) {
+            trace.log(EV_PhaseBegin, static_cast<std::uint32_t>(i), i);
+        }
+    }
+
+    const std::size_t allocations = allocation_count();
+    EXPECT_EQ(0u, allocations);
+    EXPECT_EQ(0u, trace.dropped());
+
+    auto snap = trace.snapshot();
+    ASSERT_EQ(1u, snap.perThreadCount.size());
+    EXPECT_EQ(kBurst, snap.perThreadCount[0]);
+    EXPECT_EQ(kBurst, snap.events.size());
+
+    for (std::size_t i = 0; i < kBurst; ++i) {
+        const auto& ev = snap.events[i];
+        EXPECT_EQ(EV_PhaseBegin, ev.code);
+        EXPECT_EQ(static_cast<std::uint32_t>(i), ev.a);
+        EXPECT_EQ(static_cast<std::uint64_t>(i), ev.b);
+        EXPECT_EQ(0u, ev.thread);
+    }
+
+    trace.shutdown();
+}
+


### PR DESCRIPTION
## Summary
- keep Trace::log on the allocation-free ring buffer fast path by centralising drop accounting and asserting the 32-byte event layout
- introduce a global new/delete shim test that tracks allocations and verifies Trace::log records events without triggering dynamic allocation
- register the no-allocation regression test with the unit test target

## Testing
- cmake --build --preset dev
- ctest --preset dev -R TraceNoAlloc *(not run: GoogleTest unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d41793f110832bb100c8d1172f0b4d