### PR TITLE
docs: document emergency path and metrics

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -17,10 +17,35 @@ processor.
 space separated format: `tsc thread code a b`.  This is suitable for simple
 processing by eBPF-based pipelines.
 
+## Queue instrumentation
+
+The worker pool's bounded MPMC ring emits `queue_push` and `queue_pop` trace
+events whenever a job is enqueued or dequeued. These samples include the queue
+depth (`a`) and capacity (`b`), allowing dashboards to visualise saturation and
+alert when the buffer is routinely full.
+
+## Worker pool counters
+
+Emergency launches increment the `worker.emergency_spawns` counter. The value is
+reported via the metrics registry and mirrors the number of detached helper
+threads created by the emergency path, making it straightforward to detect when
+overload handling is triggered.
+
+## Log drop accounting
+
+The `log_drops` counter is the sum of two low-level metrics: `logger.dropped`
+records how many log lines the async logger could not enqueue, while
+`trace.dropped` tracks trace ring buffer losses. Keeping the composite counter
+ensures alerting stays robust even if individual sources fluctuate.
+
 ## Code anchors
 
 - Trace capture: `bintrace::Trace::log`, `bintrace::Trace::snapshot`; `include/simcore/bintrace.hpp`
 - Chrome trace export: `trace_export::write_chrome_trace`; `tools/trace_export.hpp`
 - ETW CSV export: `trace_export::write_etw_trace`; `tools/trace_export.hpp`
 - eBPF text export: `trace_export::write_ebpf_trace`; `tools/trace_export.hpp`
+- Queue events: `bintrace::log_queue_push`, `bintrace::log_queue_pop`; `include/simcore/bintrace.hpp`
+- Ring buffer hooks: `BoundedMPMCQueue::try_push`, `BoundedMPMCQueue::try_pop`; `include/simcore/job_queue.hpp`
+- Emergency counter: `WorkerPool::handleEmergency`; `include/simcore/worker_pool.hpp`
+- Log drop aggregation: `SimCore::setMetrics`, `SimCore::publishCounters`; `include/simcore/SimCore.hpp`
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -14,6 +14,19 @@ reduce remote NUMA traffic. Tasks have priorities and an aging counter; every
 time a task waits in the queue its age increases, effectively boosting its
 priority so that low priority tasks will eventually run and avoid starvation.
 
+### Emergency path
+
+High priority tasks have access to an emergency execution path that bypasses
+the shared queue when the pool is saturated. If the number of outstanding jobs
+is at least the worker count, the scheduler attempts to spawn a detached helper
+thread to run the task immediately. Spawns are guarded by a token bucket with a
+capacity of two and a refill rate of two per second, ensuring that short bursts
+of overload can be absorbed without allowing unbounded thread creation. When
+the pool only contains a single worker thread the fallback executes the task
+inline to avoid additional allocations. Emergency launches are logged to the
+trace ring and counted in `worker.emergency_spawns` so monitoring can alert on
+sustained overload.
+
 Tasks are represented by the nested `Scheduler::Task` struct. The scheduler
 exposes a helper `Scheduler::pop_next_with_aging` function that selects the next
 task based on the `(priority + age)` heuristic. This function is used by unit
@@ -24,4 +37,6 @@ tests to verify the aging behaviour.
 - Task representation: `rt::Scheduler::Task`; `rt/include/rt/scheduler.hpp`
 - Aging heuristic: `rt::Scheduler::pop_next_with_aging`; `rt/include/rt/scheduler.hpp`
 - Worker execution: `rt::Scheduler::run`; `rt/include/rt/scheduler.hpp`, `rt/src/scheduler.cpp`
+- Emergency handling: `WorkerPool::handleEmergency`, `WorkerPool::tryConsumeEmergencyToken`,
+  `WorkerPool::logEmergencySpawn`; `include/simcore/worker_pool.hpp`
 


### PR DESCRIPTION
## Summary
- describe the worker pool emergency path policy and link to the implementation
- document queue depth events, the worker emergency spawn counter, and log drop aggregation

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d4203f0c44832bb34027cd7d4458eb