### PR TITLE
Enrich emergency spawn trace metadata

### DIFF
--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -228,7 +228,8 @@ private:
       return false;
 
     const bool rateAllowed = tryConsumeEmergencyToken();
-    logEmergencySpawn(outstandingCount, rateAllowed);
+    logEmergencySpawn(outstandingCount, rateAllowed, job.priority,
+                      job.category);
     if (!rateAllowed)
       return false;
 
@@ -245,14 +246,51 @@ private:
     return true;
   }
 
-  void logEmergencySpawn(std::size_t outstandingCount, bool rateAllowed) {
+  static constexpr std::uint32_t encodePriority(Priority priority) {
+    switch (priority) {
+    case Priority::Low:
+      return 0u;
+    case Priority::Normal:
+      return 1u;
+    case Priority::High:
+      return 2u;
+    }
+    return 0u;
+  }
+
+  static constexpr std::uint32_t encodeCategory(Category category) {
+    switch (category) {
+    case Category::CPU:
+      return 0u;
+    case Category::GPU:
+      return 1u;
+    case Category::IO:
+      return 2u;
+    }
+    return 0u;
+  }
+
+  static constexpr std::uint64_t
+  encodeEmergencySpawnPayload(bool rateAllowed, Priority priority,
+                              Category category) {
+    const std::uint64_t priorityBits =
+        static_cast<std::uint64_t>(encodePriority(priority));
+    const std::uint64_t categoryBits =
+        static_cast<std::uint64_t>(encodeCategory(category)) << 32;
+    const std::uint64_t rateBit = rateAllowed ? (1ull << 63) : 0ull;
+    return rateBit | categoryBits | priorityBits;
+  }
+
+  void logEmergencySpawn(std::size_t outstandingCount, bool rateAllowed,
+                         Priority priority, Category category) {
     if (auto *trace = trace_.load(std::memory_order_acquire)) {
       const std::uint32_t outstandingTruncated =
           outstandingCount > std::numeric_limits<std::uint32_t>::max()
               ? std::numeric_limits<std::uint32_t>::max()
               : static_cast<std::uint32_t>(outstandingCount);
-      trace->log(bintrace::EV_EmergencySpawn, outstandingTruncated,
-                 rateAllowed ? 1u : 0u);
+      const std::uint64_t payload =
+          encodeEmergencySpawnPayload(rateAllowed, priority, category);
+      trace->log(bintrace::EV_EmergencySpawn, outstandingTruncated, payload);
     }
   }
 

--- a/tools/trace_export.hpp
+++ b/tools/trace_export.hpp
@@ -26,6 +26,18 @@ inline const char* codeToCat(std::uint32_t code) {
     }
 }
 
+inline bool decodeEmergencyRateAllowed(std::uint64_t payload) {
+    return (payload >> 63) != 0;
+}
+
+inline std::uint32_t decodeEmergencyPriority(std::uint64_t payload) {
+    return static_cast<std::uint32_t>(payload & 0xFFFFFFFFu);
+}
+
+inline std::uint32_t decodeEmergencyCategory(std::uint64_t payload) {
+    return static_cast<std::uint32_t>((payload >> 32) & 0x7FFFFFFFu);
+}
+
 inline const char* codeToName(std::uint32_t code) {
     switch (code) {
     case bintrace::EV_PhaseBegin:         return "Phase Begin";
@@ -70,7 +82,10 @@ inline void write_chrome_trace(const bintrace::Trace::Snapshot& snap, std::ostre
             break;
         case bintrace::EV_EmergencySpawn:
             os << "{\"outstanding\":" << e.a
-               << ",\"rate_allowed\":" << (e.b ? "true" : "false") << "}";
+               << ",\"priority\":" << decodeEmergencyPriority(e.b)
+               << ",\"category\":" << decodeEmergencyCategory(e.b)
+               << ",\"rate_allowed\":"
+               << (decodeEmergencyRateAllowed(e.b) ? "true" : "false") << "}";
             break;
         default:
             os << "{\"a\":" << e.a << ",\"b\":" << e.b << "}";


### PR DESCRIPTION
## Summary
- extend the worker pool emergency spawn event payload to encode job priority and category alongside the existing rate-limit bit
- update the trace exporter to surface the new emergency spawn metadata fields when generating Chrome traces

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4410f5ac0832bab19a2c0c7d24bc4