### PR TITLE
Add switch to disable worker pool emergency spawns

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -27,6 +27,12 @@ inline to avoid additional allocations. Emergency launches are logged to the
 trace ring and counted in `worker.emergency_spawns` so monitoring can alert on
 sustained overload.
 
+The emergency path can be disabled at build time via the
+`RTFW_DISABLE_EMERGENCY_SPAWN` switch (set it to `1` to disable). When disabled,
+high priority submissions remain on the shared queue even under saturation.
+Instead of `EV_EmergencySpawn`, the trace emits `EV_PriorityEnqueue` events to
+indicate that the job was redirected through the priority lane of the queue.
+
 Tasks are represented by the nested `Scheduler::Task` struct. The scheduler
 exposes a helper `Scheduler::pop_next_with_aging` function that selects the next
 task based on the `(priority + age)` heuristic. This function is used by unit

--- a/include/simcore/bintrace.hpp
+++ b/include/simcore/bintrace.hpp
@@ -42,6 +42,7 @@ enum : std::uint32_t {
     EV_SnapshotLoad      = 0x0D,
     EV_PlatformCrumb     = 0x0E,
     EV_EmergencySpawn    = 0x0F,
+    EV_PriorityEnqueue   = 0x10,
 };
 
 static inline std::uint64_t rdtsc() noexcept {

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -15,6 +15,10 @@
 #include "job_queue.hpp"
 #include "debug.hpp"
 
+#ifndef RTFW_DISABLE_EMERGENCY_SPAWN
+#define RTFW_DISABLE_EMERGENCY_SPAWN 0
+#endif
+
 // Worker pool backed by a bounded MPMC ring buffer.  All work is submitted
 // through the ring which provides a single scheduling surface and enables
 // unified telemetry/backpressure.
@@ -75,16 +79,32 @@ public:
       outstanding_.fetch_add(1, std::memory_order_acq_rel);
     }
     Job job{std::move(fn), pr, cat};
+#if RTFW_DISABLE_EMERGENCY_SPAWN
+    bool redirectedToPriorityLane = false;
+    std::size_t redirectedOutstanding = 0;
+#endif
     if (pr == Priority::High) {
       const std::size_t outstandingCount =
           outstanding_.load(std::memory_order_acquire);
-      if (outstandingCount >= threads_.size() &&
-          handleEmergency(job, outstandingCount)) {
-        return;
+      if (outstandingCount >= threads_.size()) {
+#if RTFW_DISABLE_EMERGENCY_SPAWN
+        redirectedToPriorityLane = true;
+        redirectedOutstanding = outstandingCount;
+#else
+        if (handleEmergency(job, outstandingCount)) {
+          return;
+        }
+#endif
       }
     }
     while (true) {
       if (queue_.try_push(std::move(job))) {
+#if RTFW_DISABLE_EMERGENCY_SPAWN
+        if (redirectedToPriorityLane) {
+          logPriorityEnqueue(redirectedOutstanding, job.priority,
+                             job.category);
+        }
+#endif
         break;
       }
       rt::cpu_relax();
@@ -108,19 +128,35 @@ public:
         if (outstanding_.compare_exchange_weak(cur, cur + 1,
                                                std::memory_order_acq_rel,
                                                std::memory_order_relaxed)) {
+#if RTFW_DISABLE_EMERGENCY_SPAWN
+          bool redirectedToPriorityLane = false;
+          std::size_t redirectedOutstanding = 0;
+#endif
           Job job{std::move(fn), pr, cat};
           if (pr == Priority::High) {
             const std::size_t outstandingCount =
                 outstanding_.load(std::memory_order_acquire);
-            if (outstandingCount >= threads_.size() &&
-                handleEmergency(job, outstandingCount)) {
-              return true;
+            if (outstandingCount >= threads_.size()) {
+#if RTFW_DISABLE_EMERGENCY_SPAWN
+              redirectedToPriorityLane = true;
+              redirectedOutstanding = outstandingCount;
+#else
+              if (handleEmergency(job, outstandingCount)) {
+                return true;
+              }
+#endif
             }
           }
           if (!queue_.try_push(std::move(job))) {
             outstanding_.fetch_sub(1, std::memory_order_acq_rel);
             return false;
           }
+#if RTFW_DISABLE_EMERGENCY_SPAWN
+          if (redirectedToPriorityLane) {
+            logPriorityEnqueue(redirectedOutstanding, job.priority,
+                               job.category);
+          }
+#endif
           return true;
         }
       }
@@ -128,18 +164,34 @@ public:
     } else {
       outstanding_.fetch_add(1, std::memory_order_acq_rel);
       Job job{std::move(fn), pr, cat};
+#if RTFW_DISABLE_EMERGENCY_SPAWN
+      bool redirectedToPriorityLane = false;
+      std::size_t redirectedOutstanding = 0;
+#endif
       if (pr == Priority::High) {
         const std::size_t outstandingCount =
             outstanding_.load(std::memory_order_acquire);
-        if (outstandingCount >= threads_.size() &&
-            handleEmergency(job, outstandingCount)) {
-          return true;
+        if (outstandingCount >= threads_.size()) {
+#if RTFW_DISABLE_EMERGENCY_SPAWN
+          redirectedToPriorityLane = true;
+          redirectedOutstanding = outstandingCount;
+#else
+          if (handleEmergency(job, outstandingCount)) {
+            return true;
+          }
+#endif
         }
       }
       if (!queue_.try_push(std::move(job))) {
         outstanding_.fetch_sub(1, std::memory_order_acq_rel);
         return false;
       }
+#if RTFW_DISABLE_EMERGENCY_SPAWN
+      if (redirectedToPriorityLane) {
+        logPriorityEnqueue(redirectedOutstanding, job.priority,
+                           job.category);
+      }
+#endif
       return true;
     }
   }
@@ -216,6 +268,11 @@ private:
   }
 
   bool handleEmergency(Job &job, std::size_t outstandingCount) {
+#if RTFW_DISABLE_EMERGENCY_SPAWN
+    (void)job;
+    (void)outstandingCount;
+    return false;
+#else
     if (threads_.size() == 1) {
       active_.fetch_add(1, std::memory_order_acq_rel);
       if (job.fn)
@@ -244,6 +301,7 @@ private:
       outstanding_.fetch_sub(1, std::memory_order_acq_rel);
     }).detach();
     return true;
+#endif
   }
 
   static constexpr std::uint32_t encodePriority(Priority priority) {
@@ -291,6 +349,28 @@ private:
       const std::uint64_t payload =
           encodeEmergencySpawnPayload(rateAllowed, priority, category);
       trace->log(bintrace::EV_EmergencySpawn, outstandingTruncated, payload);
+    }
+  }
+
+  static constexpr std::uint64_t
+  encodePriorityEnqueuePayload(Priority priority, Category category) {
+    const std::uint64_t priorityBits =
+        static_cast<std::uint64_t>(encodePriority(priority));
+    const std::uint64_t categoryBits =
+        static_cast<std::uint64_t>(encodeCategory(category)) << 32;
+    return priorityBits | categoryBits;
+  }
+
+  void logPriorityEnqueue(std::size_t outstandingCount, Priority priority,
+                          Category category) {
+    if (auto *trace = trace_.load(std::memory_order_acquire)) {
+      const std::uint32_t outstandingTruncated =
+          outstandingCount > std::numeric_limits<std::uint32_t>::max()
+              ? std::numeric_limits<std::uint32_t>::max()
+              : static_cast<std::uint32_t>(outstandingCount);
+      const std::uint64_t payload =
+          encodePriorityEnqueuePayload(priority, category);
+      trace->log(bintrace::EV_PriorityEnqueue, outstandingTruncated, payload);
     }
   }
 

--- a/tools/trace_export.hpp
+++ b/tools/trace_export.hpp
@@ -16,6 +16,7 @@ inline const char* codeToCat(std::uint32_t code) {
     case bintrace::EV_QueuePop:           return "queue";
     case bintrace::EV_WorkSteal:          return "WorkSteal";
     case bintrace::EV_EmergencySpawn:     return "WorkerPool";
+    case bintrace::EV_PriorityEnqueue:    return "WorkerPool";
     case bintrace::EV_WatchdogTrip:       return "WatchdogTrip";
     case bintrace::EV_GpuFenceWaitBegin:  return "GpuFenceWaitBegin";
     case bintrace::EV_GpuFenceWaitEnd:    return "GpuFenceWaitEnd";
@@ -49,6 +50,7 @@ inline const char* codeToName(std::uint32_t code) {
     case bintrace::EV_QueuePop:           return "queue_pop";
     case bintrace::EV_WorkSteal:          return "Work Steal";
     case bintrace::EV_EmergencySpawn:     return "Emergency Spawn";
+    case bintrace::EV_PriorityEnqueue:    return "Priority Enqueue";
     case bintrace::EV_WatchdogTrip:       return "Watchdog Trip";
     case bintrace::EV_GpuFenceWaitBegin:  return "GPU Fence Wait Begin";
     case bintrace::EV_GpuFenceWaitEnd:    return "GPU Fence Wait End";
@@ -86,6 +88,12 @@ inline void write_chrome_trace(const bintrace::Trace::Snapshot& snap, std::ostre
                << ",\"category\":" << decodeEmergencyCategory(e.b)
                << ",\"rate_allowed\":"
                << (decodeEmergencyRateAllowed(e.b) ? "true" : "false") << "}";
+            break;
+        case bintrace::EV_PriorityEnqueue:
+            os << "{\"outstanding\":" << e.a
+               << ",\"priority\":" << decodeEmergencyPriority(e.b)
+               << ",\"category\":" << decodeEmergencyCategory(e.b)
+               << "}";
             break;
         default:
             os << "{\"a\":" << e.a << ",\"b\":" << e.b << "}";


### PR DESCRIPTION
## Summary
- gate worker pool emergency spawns behind the RTFW_DISABLE_EMERGENCY_SPAWN toggle and emit EV_PriorityEnqueue when rerouting
- add the new trace event to the bintrace definitions and exporter helpers
- document how to disable emergency spawns in the scheduler guide

## Testing
- cmake --preset dev
- cmake --build --preset dev
- ctest --preset dev

------
https://chatgpt.com/codex/tasks/task_e_68d465793df0832b95c3b2c3203dc451