### PR TITLE
Add worker metadata trace events

### DIFF
--- a/include/simcore/bintrace.hpp
+++ b/include/simcore/bintrace.hpp
@@ -43,6 +43,7 @@ enum : std::uint32_t {
     EV_PlatformCrumb     = 0x0E,
     EV_EmergencySpawn    = 0x0F,
     EV_PriorityEnqueue   = 0x10,
+    EV_WorkerMeta        = 0x11,
 };
 
 static inline std::uint64_t rdtsc() noexcept {
@@ -291,6 +292,16 @@ inline void log_queue_pop(std::uint32_t depth, std::uint64_t capacity = 0) {
     if (auto* trace = global_trace()) {
         trace->log(EV_QueuePop, depth, capacity);
     }
+}
+
+inline std::uint64_t encode_worker_meta(std::int32_t numaNode) noexcept {
+    return static_cast<std::uint64_t>(
+        static_cast<std::uint32_t>(static_cast<std::int32_t>(numaNode)));
+}
+
+inline std::int32_t decode_worker_meta_node(std::uint64_t payload) noexcept {
+    return static_cast<std::int32_t>(
+        static_cast<std::uint32_t>(payload & 0xFFFFFFFFu));
 }
 
 } // namespace bintrace

--- a/include/simcore/worker_pool.hpp
+++ b/include/simcore/worker_pool.hpp
@@ -9,6 +9,12 @@
 #include <mutex>
 #include <thread>
 #include <vector>
+#ifdef __linux__
+#include <sched.h>
+#endif
+#if defined(__linux__) && defined(SIM_USE_NUMA)
+#include <numa.h>
+#endif
 #include <rt/arch.hpp>
 #include <rt/numerics.hpp>
 #include "bintrace.hpp"
@@ -374,6 +380,20 @@ private:
     }
   }
 
+  static std::int32_t current_numa_node() noexcept {
+#if defined(__linux__) && defined(SIM_USE_NUMA)
+    if (numa_available() == -1)
+      return -1;
+    const int cpu = ::sched_getcpu();
+    if (cpu < 0)
+      return -1;
+    const int node = numa_node_of_cpu(cpu);
+    return node >= 0 ? node : -1;
+#else
+    return -1;
+#endif
+  }
+
   void workerLoop(std::size_t index) {
     bool bound = false;
     bool stealLogged = false;
@@ -382,6 +402,10 @@ private:
         if (auto *trace = trace_.load(std::memory_order_acquire)) {
           const std::size_t base = traceBase_.load(std::memory_order_acquire);
           trace->bindThread(base + index);
+          const std::int32_t numaNode = current_numa_node();
+          trace->log(bintrace::EV_WorkerMeta,
+                     static_cast<std::uint32_t>(index),
+                     bintrace::encode_worker_meta(numaNode));
           bound = true;
         }
       }

--- a/tests/test_rt_pipeline.cpp
+++ b/tests/test_rt_pipeline.cpp
@@ -8,6 +8,9 @@
 #include <simcore/bintrace.hpp>
 #include <simcore/metrics.hpp>
 #include <simcore/worker_pool.hpp>
+#if defined(SIM_USE_NUMA) && defined(__linux__)
+#include <numa.h>
+#endif
 
 namespace {
 
@@ -88,6 +91,7 @@ TEST(RTPipeline, EndToEndSmokeTest) {
   std::size_t queuePush = 0;
   std::size_t queuePop = 0;
   std::size_t stealEvents = 0;
+  std::size_t workerMetaEvents = 0;
   for (const auto &ev : traceSnap.events) {
     switch (ev.code) {
     case bintrace::EV_GpuFenceWaitBegin:
@@ -108,6 +112,18 @@ TEST(RTPipeline, EndToEndSmokeTest) {
     case bintrace::EV_WorkSteal:
       ++stealEvents;
       break;
+    case bintrace::EV_WorkerMeta: {
+      ++workerMetaEvents;
+      EXPECT_LT(static_cast<std::size_t>(ev.a), workerThreads);
+      const int node = bintrace::decode_worker_meta_node(ev.b);
+      EXPECT_GE(node, -1);
+#if defined(SIM_USE_NUMA) && defined(__linux__)
+      if (numa_available() != -1) {
+        EXPECT_LE(node, numa_max_node());
+      }
+#endif
+      break;
+    }
     default:
       break;
     }
@@ -119,4 +135,5 @@ TEST(RTPipeline, EndToEndSmokeTest) {
   EXPECT_GE(queuePush, 1u);
   EXPECT_GE(queuePop, 1u);
   EXPECT_GE(stealEvents, 1u);
+  EXPECT_EQ(workerMetaEvents, workerThreads);
 }

--- a/tools/trace_export.hpp
+++ b/tools/trace_export.hpp
@@ -17,6 +17,7 @@ inline const char* codeToCat(std::uint32_t code) {
     case bintrace::EV_WorkSteal:          return "WorkSteal";
     case bintrace::EV_EmergencySpawn:     return "WorkerPool";
     case bintrace::EV_PriorityEnqueue:    return "WorkerPool";
+    case bintrace::EV_WorkerMeta:         return "WorkerPool";
     case bintrace::EV_WatchdogTrip:       return "WatchdogTrip";
     case bintrace::EV_GpuFenceWaitBegin:  return "GpuFenceWaitBegin";
     case bintrace::EV_GpuFenceWaitEnd:    return "GpuFenceWaitEnd";
@@ -51,6 +52,7 @@ inline const char* codeToName(std::uint32_t code) {
     case bintrace::EV_WorkSteal:          return "Work Steal";
     case bintrace::EV_EmergencySpawn:     return "Emergency Spawn";
     case bintrace::EV_PriorityEnqueue:    return "Priority Enqueue";
+    case bintrace::EV_WorkerMeta:         return "Worker Meta";
     case bintrace::EV_WatchdogTrip:       return "Watchdog Trip";
     case bintrace::EV_GpuFenceWaitBegin:  return "GPU Fence Wait Begin";
     case bintrace::EV_GpuFenceWaitEnd:    return "GPU Fence Wait End";
@@ -65,6 +67,24 @@ inline void write_chrome_trace(const bintrace::Trace::Snapshot& snap, std::ostre
     os << "{\"traceEvents\":[";
     bool first = true;
     for (const auto& e : snap.events) {
+        if (e.code == bintrace::EV_WorkerMeta) {
+            if (!first) os << ',';
+            first = false;
+            const std::int32_t node = bintrace::decode_worker_meta_node(e.b);
+            os << "{\"cat\":\"" << codeToCat(e.code) << "\",";
+            os << "\"name\":\"thread_name\",";
+            os << "\"ph\":\"M\",";
+            os << "\"tid\":" << e.thread << ',';
+            os << "\"ts\":0,\"args\":{\"name\":\"Worker " << e.a << "\"}}";
+            os << ',';
+            os << "{\"cat\":\"" << codeToCat(e.code) << "\",";
+            os << "\"name\":\"worker_meta\",";
+            os << "\"ph\":\"M\",";
+            os << "\"tid\":" << e.thread << ',';
+            os << "\"ts\":0,\"args\":{\"worker_index\":" << e.a
+               << ",\"numa_node\":" << node << "}}";
+            continue;
+        }
         if (!first) os << ',';
         first = false;
         os << "{\"cat\":\"" << codeToCat(e.code) << "\",";


### PR DESCRIPTION
## Summary
- emit EV_WorkerMeta once per worker on bind with encoded NUMA node information
- expose worker metadata helpers and render metadata entries in the Chrome trace exporter
- extend the RT pipeline test to validate worker metadata coverage and NUMA ranges

## Testing
- cmake --build --preset dev
- ctest --preset dev --output-on-failure

------
https://chatgpt.com/codex/tasks/task_e_68d46b02d8d4832b99ccb666f463d46d