### PR TITLE
Add autotune spec definition

### DIFF
--- a/tools/autotune/README.md
+++ b/tools/autotune/README.md
@@ -1,0 +1,37 @@
+# Autotune Specification
+
+This directory contains configuration and orchestration scripts for the runtime autotuning workflow.  The `spec.yaml` file is the machine-readable source of truth for the tuner describing how to execute the application, what metrics to enforce, and the parameter space to explore.
+
+## File: `spec.yaml`
+
+The YAML document is organized into three top-level sections:
+
+### `app`
+Describes how to run the realtime application when gathering interval metrics.
+
+| Field | Description |
+| --- | --- |
+| `path` | Executable path to the demo binary that emits metrics. |
+| `warmup_sec` | Seconds to run before samples are collected, allowing the app to reach steady state. |
+| `run_sec` | Seconds of metric sampling after warmup. |
+| `frame_budget_ms` | Target frame duration used in objective normalization. |
+| `extra_args` | Additional CLI arguments always passed to the executable. |
+
+### `metrics`
+Defines success criteria and the optimization objective derived from the reported metrics.
+
+* `hard_constraints` — Map of metric names to comparison expressions that must hold for a run to be considered valid.
+* `objective` — Specifies how scores are computed:
+  * `expr` — Primary scalar objective expression (lower is better when `maximize: false`).
+  * `tiebreakers` — Ordered list of secondary expressions used when two configurations share the same primary objective.
+  * `maximize` — Boolean indicating whether higher (`true`) or lower (`false`) values are preferred.
+
+### `params`
+Enumerates the tunable configuration parameters. Each key defines a parameter with one of the following types:
+
+* `categorical` — Explicit list of `values` to choose from.
+* `int` — Integer parameter with inclusive `min`/`max` bounds and an optional `step` size.
+* `float` — Floating-point parameter with inclusive bounds and step size.
+* `bool` — Boolean toggle (no additional fields required).
+
+These definitions drive the design-of-experiments sampling, local search bounds, and downstream validation.

--- a/tools/autotune/spec.yaml
+++ b/tools/autotune/spec.yaml
@@ -1,0 +1,74 @@
+app:
+  path: "./build/bin/rtfw_demo"
+  warmup_sec: 5
+  run_sec: 20
+  frame_budget_ms: 5.0
+  extra_args:
+    - "--rt"
+
+metrics:
+  hard_constraints:
+    missed_frames: "== 0"
+    watchdog_trips: "== 0"
+    log_drops: "<= 0"
+  objective:
+    expr: "p99_frame_ms / frame_budget_ms"
+    tiebreakers:
+      - "p95_frame_ms / frame_budget_ms"
+      - "stdev_frame_ms"
+      - "queue_max"
+      - "emergency_spawns"
+    maximize: false
+
+params:
+  threads:
+    type: "categorical"
+    values:
+      - "physical"
+      - "physical_plus_smt"
+  chunk_target_us:
+    type: "int"
+    min: 50
+    max: 300
+    step: 10
+  aosoa_block:
+    type: "int"
+    values:
+      - 128
+      - 256
+      - 512
+  steal_threshold:
+    type: "int"
+    min: 0
+    max: 8
+    step: 1
+  prefetch_distance_bytes:
+    type: "int"
+    min: 0
+    max: 4096
+    step: 64
+  huge_pages:
+    type: "bool"
+  governor_target_util:
+    type: "float"
+    min: 0.85
+    max: 0.98
+    step: 0.01
+  governor_hysteresis:
+    type: "float"
+    min: 0.01
+    max: 0.05
+    step: 0.005
+  fma_mode:
+    type: "categorical"
+    values:
+      - "on"
+      - "off"
+      - "auto_no_when_deterministic"
+  emergency_spawn_enabled:
+    type: "bool"
+  arena_per_thread_mb:
+    type: "int"
+    min: 8
+    max: 128
+    step: 8


### PR DESCRIPTION
## Summary
- add the initial autotune specification describing the app entry point, metrics, and tuning parameters
- document the spec format in tools/autotune/README.md

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d563fe2740832bbbd7edc648358420