### PR TITLE
Fix fiber pool waiter cleanup and add regression test

### DIFF
--- a/rt/include/rt/fiber_pool.hpp
+++ b/rt/include/rt/fiber_pool.hpp
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <chrono>
 #include <utility>
+#include <algorithm>
 
 #include <simcore/hal.hpp>
 
@@ -121,6 +122,13 @@ private:
         waiters_.push_back(WaitItem{f, h});
     }
 
+    void remove_waiter(std::coroutine_handle<> h) {
+        std::lock_guard<std::mutex> lock(waitMutex_);
+        auto it = std::remove_if(waiters_.begin(), waiters_.end(),
+                                 [h](const WaitItem& item) { return item.handle == h; });
+        waiters_.erase(it, waiters_.end());
+    }
+
     void worker_loop() {
         for (;;) {
             std::coroutine_handle<> h;
@@ -134,6 +142,7 @@ private:
             }
             h.resume();
             if (h.done()) {
+                remove_waiter(h);
                 h.destroy();
                 if (pending_.fetch_sub(1, std::memory_order_acq_rel) == 1) {
                     std::lock_guard<std::mutex> lock(pendingMutex_);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ if (SIM_GTEST_AVAILABLE)
         test_arena_binding_assert.cpp
         test_rt_overflow_death.cpp
         test_fiber_pool.cpp
+        test_fiber_pool_race.cpp
         test_bintrace.cpp
         test_budget_degrade.cpp
         test_predictive_adaptive.cpp

--- a/tests/test_fiber_pool_race.cpp
+++ b/tests/test_fiber_pool_race.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+#include <simcore/SimCore.hpp>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include <rt/fiber_pool.hpp>
+#include <simcore/hal.hpp>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+struct WaitState {
+  std::atomic<std::size_t> resumed{0};
+};
+
+static rt::Task unique_fence_task(rt::FiberPool &pool, simcore::hal::Fence &f,
+                                  std::atomic<std::size_t> &duplicates,
+                                  std::atomic<std::size_t> &completed,
+                                  WaitState &state) {
+  co_await rt::FiberPool::FenceAwaiter{f, pool};
+  auto previous = state.resumed.fetch_add(1, std::memory_order_relaxed);
+  if (previous != 0) {
+    duplicates.fetch_add(1, std::memory_order_relaxed);
+  }
+  completed.fetch_add(1, std::memory_order_relaxed);
+}
+
+} // namespace
+
+TEST(FiberPool, FenceStressNoDuplicateResumes) {
+  constexpr std::size_t kRounds = 16;
+  constexpr std::size_t kFencesPerRound = 64;
+
+  for (int threads : {1, 4}) {
+    SimCore::Settings settings;
+    settings.threads = static_cast<std::size_t>(threads);
+    SimCore sim(settings);
+    auto &pool = sim.fiberPool();
+
+    std::atomic<std::size_t> duplicates{0};
+    std::atomic<std::size_t> completed{0};
+
+    for (std::size_t round = 0; round < kRounds; ++round) {
+      std::vector<simcore::hal::Fence> fences(kFencesPerRound);
+      std::vector<WaitState> states(kFencesPerRound);
+
+      for (std::size_t i = 0; i < kFencesPerRound; ++i) {
+        pool.spawn(unique_fence_task(pool, fences[i], duplicates, completed,
+                                     states[i]));
+      }
+
+      std::vector<std::thread> signalers;
+      signalers.reserve(kFencesPerRound);
+      for (auto &f : fences) {
+        signalers.emplace_back([&f]() {
+          std::this_thread::sleep_for(1ms);
+          simcore::hal::fence_signal(f);
+        });
+      }
+
+      pool.drain();
+
+      for (auto &t : signalers) {
+        if (t.joinable()) {
+          t.join();
+        }
+      }
+
+      for (auto &state : states) {
+        EXPECT_EQ(state.resumed.load(std::memory_order_relaxed), 1u)
+            << "Fence waiter resumed "
+            << state.resumed.load(std::memory_order_relaxed)
+            << " times";
+      }
+    }
+
+    EXPECT_EQ(duplicates.load(std::memory_order_relaxed), 0u);
+    EXPECT_EQ(completed.load(std::memory_order_relaxed),
+              kRounds * kFencesPerRound);
+  }
+}


### PR DESCRIPTION
## Summary
- ensure fiber pool workers remove any pending waiters before destroying completed coroutine handles
- add a stress regression test that exercises many concurrent fence waits to detect duplicate resumptions
- register the new regression test with the test suite build

## Testing
- cmake -S . -B build *(fails: cannot download googletest through proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68daed50a6a0832ba9e79f56d1217b04