### PR TITLE
docs: add autotune quickstart guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,24 +259,29 @@ ctest --test-dir build -j --output-on-failure
 
 ## 15. DOE / Autotune Workflow
 
-**Goal**: find **robust defaults** per hardware class and optional **per-machine** profiles.
+### ⚡ 60-second Quickstart
 
-1) **Freeze env**: disable turbo/EPP changes, isolate cores/IRQs, warm-up 2–3 min.  
-2) **Define objectives**: p99 ≤ budget, missed frames, variance, (optional) power.  
-3) **Screen factors**: threads, SMT, AoSoA block, chunk target µs, prefetch distance, hugepages, steal threshold, governor gains, FTZ/DAZ/FMA gates.  
-4) **Automate runs** using **interval metrics**:
-   ```bash
-   # Example pseudo-workflow
-   for cfg in $(./tools/gen_grid.py); do
-     ./build/bin/rtfw_demo --config "$cfg" --warmup 5s >/dev/null
-     ./build/bin/rtfw_demo --metrics-json-interval --run 20s >> results.jsonl
-   done
-   ./tools/analyze_results.py results.jsonl --pareto --recommend > learned_profile.json
-   ```
-5) **Persist** the best robust profile to `~/.rtfw/profiles/<cpu>-<os>.json`.  
-6) **Ship**: keep `default_safe`/`default_fast` + load per-machine profile if present.
+```bash
+# assumes you already built ./build/bin/rtfw_demo
+python3 tools/autotune/run_experiments.py \
+  --spec tools/autotune/spec.yaml \
+  --screen 32 \
+  --replicates 3 \
+  --local-iters 40 \
+  --topk 5
+```
 
-**Note**: this repo already emits everything DOE needs (interval p95/p99, queue/steal, drops, rungs). You only need small scripts to generate configs and aggregate results.
+The orchestration script screens the parameter space, runs local search, validates the best candidates, and writes the final machine profile. All metrics are gathered in **interval mode** (`--metrics-json-interval`) so every sample represents a fresh window; cumulative outputs (`--metrics-json`) are ignored by design to keep the statistics comparable.
+
+### What lands where
+
+- **Profiles** → `profiles/<cpu>-<os>.json` (drop-in machine profile for runtime startup).
+- **Results log** → `results/experiments.jsonl` plus helpers such as `results/top_candidates.json` and `results/summary.json` for CI-friendly summaries.
+- **Reports** → `reports/` contains Pareto front JSON/CSV and the best-scoring candidate breakdown for offline analysis.
+
+### Want the long version?
+
+See [`docs/DOE_AUTOTUNE.md`](docs/DOE_AUTOTUNE.md) for pre-flight checks, interpreting objectives, and extending the factor space.
 
 ---
 

--- a/docs/DOE_AUTOTUNE.md
+++ b/docs/DOE_AUTOTUNE.md
@@ -1,0 +1,65 @@
+# DOE / Autotune Workflow
+
+This guide expands on the quickstart snippet in the [README](../README.md#15-doe--autotune-workflow). It covers the pre-flight checks, describes the generated artifacts, and shows how to extend the default experiment design.
+
+## 1. Pre-flight checklist
+
+Before launching autotune runs, stabilise the platform so every replicate produces comparable interval metrics.
+
+- **Thermals & frequency**: warm the system for a few minutes and pin clocks/turbo settings according to your reliability policy.
+- **CPU isolation**: reserve cores for realtime work (cpuset, IRQ affinity, SMT policy) matching your production target.
+- **Build artifacts**: ensure `./build/bin/rtfw_demo` exists — the orchestration script assumes a Release-equivalent binary is ready.
+
+## 2. Run the full workflow
+
+```bash
+python3 tools/autotune/run_experiments.py \
+  --spec tools/autotune/spec.yaml \
+  --screen 32 \
+  --replicates 3 \
+  --local-iters 40 \
+  --topk 5
+```
+
+### Flags explained
+
+- `--spec` — DOE description (application entry point, metrics, factor space, objectives).
+- `--screen` — number of Sobol/randomised candidates to evaluate before local search kicks in.
+- `--replicates` — interval metric samples per evaluation; >1 smooths jittery hosts.
+- `--local-iters` — bounded coordinate/local search iterations seeded from the best screening candidate.
+- `--topk` — number of unique candidates to send through robustness validation.
+
+> **Interval metrics only.** The runner always calls `rtfw_demo` with `--metrics-json-interval`. Cumulative stats (`--metrics-json`) are intentionally ignored because they hide short-lived regressions and make comparisons between runs ambiguous.
+
+## 3. Generated artifacts
+
+The workflow writes three directories at the repository root:
+
+| Directory | Purpose | Key files |
+| --- | --- | --- |
+| `profiles/` | Drop-in machine profiles named `<cpu>-<os>.json`. The runtime auto-loads these alongside stock `default_safe`/`default_fast`. | `profiles/x86_64-Linux.json` (example) |
+| `results/` | Raw experiment log and orchestration breadcrumbs suitable for CI diffing or ad-hoc plots. | `experiments.jsonl`, `summary.json`, `top_candidates.json`, `validation_summary.json` |
+| `reports/` | Aggregated analytics from `tools/autotune/analyze.py` — Pareto sets, CSV summaries, best run report. | `pareto.json`, `summary.csv`, `best.json` |
+
+All JSON files use UTF-8 + newline for easy `jq`/Python ingestion.
+
+## 4. Tweaking the design space
+
+The YAML spec drives every stage. To change what the tuner explores:
+
+1. Edit [`tools/autotune/spec.yaml`](../tools/autotune/spec.yaml).
+2. Adjust the `params` section (categorical/int/float/bool) with new ranges.
+3. Expand `metrics.hard_constraints` or the objective expression to enforce new SLAs.
+4. Re-run the command above — the script will resume from `results/experiments.jsonl` when possible.
+
+For one-off sweeps or custom analytics, inspect `results/experiments.jsonl` with `jq` or re-run `tools/autotune/analyze.py` against the saved log.
+
+## 5. Consuming the profile
+
+After the run finishes, copy the generated profile into your deployment target or point `RTFW_PROFILE` at the emitted JSON. The runtime loads this alongside existing configs:
+
+```bash
+RTFW_PROFILE=$(uname -m)-$(uname -s) ./build/bin/rtfw_demo --rt --metrics-json
+```
+
+Because the profile was derived from interval metrics, keep monitoring both cumulative and interval outputs in production to ensure no long-horizon drift.


### PR DESCRIPTION
## Summary
- add a 60-second DOE/autotune quickstart block to the README
- document the generated profiles/results/reports and link to a long-form guide
- provide a dedicated DOE_AUTOTUNE.md walkthrough with prep steps and artifact details

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68daef5118fc832b954c2a1a089978da