### PR TITLE
Stabilize autotune JSONL schema and hardened logging

### DIFF
--- a/tools/autotune/README.md
+++ b/tools/autotune/README.md
@@ -35,3 +35,28 @@ Enumerates the tunable configuration parameters. Each key defines a parameter wi
 * `bool` — Boolean toggle (no additional fields required).
 
 These definitions drive the design-of-experiments sampling, local search bounds, and downstream validation.
+
+## JSONL result schema
+
+Every invocation of `run_one.py` produces a single JSON object describing the sampled run. These rows are appended verbatim to
+`results/experiments.jsonl` and `results/validation_runs.jsonl`. Each record follows the stable schema below:
+
+```
+{
+  "ok": bool,
+  "objective": float | Infinity,
+  "metrics": { ... raw interval JSON from the application ... },
+  "_summary": { ... derived metrics such as p50_frame_ms ... },
+  "_params": { ... resolved parameter values ... },
+  "_seed": int,
+  "_scenario": str,
+  "_ts": "<ISO8601 timestamp>",
+  "env": { "cpu": str, "cores": int, "os": str },
+  "_schema": "v1"
+}
+```
+
+`objective` is set to `Infinity` when hard constraints fail. `_summary` mirrors the previous aggregate metrics payload and is used
+by the optimisation routines, while `metrics` keeps the raw interval JSON emitted by the realtime application for traceability.
+Append operations are crash-safe: each line is flushed and `fsync`'d before the next record is written so that interrupted runs
+cannot corrupt the log.

--- a/tools/autotune/optimize.py
+++ b/tools/autotune/optimize.py
@@ -29,6 +29,16 @@ from tools.autotune.make_config import (  # noqa: E402
 )
 
 
+def get_metrics_summary(run: Mapping[str, Any]) -> Mapping[str, Any]:
+    summary = run.get("_summary")
+    if isinstance(summary, Mapping):
+        return summary
+    metrics = run.get("metrics")
+    if isinstance(metrics, Mapping):
+        return metrics
+    return {}
+
+
 @dataclass(frozen=True)
 class ObjectiveSpec:
     expression: str
@@ -337,8 +347,8 @@ class Evaluator:
                 ok = False
                 if failure_reason is None:
                     failure_reason = str(result.get("reason", "unspecified failure"))
-            metrics = result.get("metrics")
-            if not isinstance(metrics, Mapping):
+            metrics = get_metrics_summary(result)
+            if not metrics:
                 continue
             objective_value, tiebreakers = self._evaluate_metrics(metrics)
             objective_samples.append(objective_value)

--- a/tools/autotune/run_experiments.py
+++ b/tools/autotune/run_experiments.py
@@ -7,6 +7,7 @@ import argparse
 import datetime
 import json
 import math
+import os
 import pathlib
 import platform
 import random
@@ -96,6 +97,8 @@ class ExperimentLog:
         with self.path.open("a", encoding="utf-8") as fh:
             fh.write(json.dumps(record, sort_keys=True))
             fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
 
     def all_entries(self) -> List[Dict[str, Any]]:
         return list(self.entries.values())
@@ -128,6 +131,16 @@ def safe_float(value: Any) -> Optional[float]:
     return None
 
 
+def get_metrics_summary(run: Mapping[str, Any]) -> Mapping[str, Any]:
+    summary = run.get("_summary")
+    if isinstance(summary, Mapping):
+        return summary
+    metrics = run.get("metrics")
+    if isinstance(metrics, Mapping):
+        return metrics
+    return {}
+
+
 def aggregate_runs(
     runs: Sequence[Mapping[str, Any]],
     objective: ObjectiveSpec,
@@ -153,8 +166,8 @@ def aggregate_runs(
             if isinstance(reason, str) and reason:
                 reasons.append(reason)
         ok = ok and run_ok
-        metrics = run.get("metrics")
-        if not isinstance(metrics, Mapping):
+        metrics = get_metrics_summary(run)
+        if not metrics:
             continue
         context: Dict[str, Any] = dict(metrics)
         if frame_budget is not None and "frame_budget_ms" not in context:
@@ -368,6 +381,8 @@ def append_jsonl(path: pathlib.Path, records: Sequence[Mapping[str, Any]]) -> No
         for record in records:
             fh.write(json.dumps(record, sort_keys=True))
             fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
 
 
 def sanitise_filename(text: str) -> str:

--- a/tools/autotune/run_one.py
+++ b/tools/autotune/run_one.py
@@ -4,9 +4,12 @@
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import math
+import os
 import pathlib
+import platform
 import subprocess
 import sys
 from typing import Any, Dict, Iterable, List, Optional
@@ -122,6 +125,82 @@ def extract_params(config_path: pathlib.Path, config_data: Dict[str, Any]) -> Di
     return {}
 
 
+def _try_parse_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and math.isfinite(value):
+        integer = int(value)
+        if math.isclose(value, integer):
+            return integer
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def _try_parse_str(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped:
+            return stripped
+    return None
+
+
+def _find_nested_value(data: Any, keys: Iterable[str], parser) -> Optional[Any]:
+    if isinstance(data, dict):
+        for key in keys:
+            if key in data:
+                parsed = parser(data[key])
+                if parsed is not None:
+                    return parsed
+        for value in data.values():
+            found = _find_nested_value(value, keys, parser)
+            if found is not None:
+                return found
+    elif isinstance(data, list):
+        for item in data:
+            found = _find_nested_value(item, keys, parser)
+            if found is not None:
+                return found
+    return None
+
+
+def extract_seed(config_data: Dict[str, Any], config_path: pathlib.Path) -> int:
+    seed = _find_nested_value(config_data, ["seed", "random_seed", "rng_seed"], _try_parse_int)
+    if seed is not None:
+        return seed
+    stem = config_path.stem
+    if "_" in stem:
+        candidate = stem.rsplit("_", 1)[-1]
+        parsed = _try_parse_int(candidate)
+        if parsed is not None:
+            return parsed
+    return -1
+
+
+def extract_scenario(config_data: Dict[str, Any], config_path: pathlib.Path) -> str:
+    scenario = _find_nested_value(config_data, ["scenario", "scenario_name"], _try_parse_str)
+    if scenario is not None:
+        return scenario
+    return config_path.stem or "default"
+
+
+def collect_env_info() -> Dict[str, Any]:
+    uname = platform.uname()
+    cpu_name = uname.processor or uname.machine or "unknown"
+    cores = os.cpu_count() or 0
+    os_name = platform.platform()
+    return {
+        "cpu": str(cpu_name),
+        "cores": int(cores),
+        "os": str(os_name),
+    }
+
+
 def extract_metrics(payload: Dict[str, Any]) -> Dict[str, Any]:
     phases = payload.get("phases", {})
     counters = payload.get("counters", {})
@@ -225,19 +304,28 @@ def main() -> None:
     completed = run_command(run_cmd, capture=True)
 
     payload = find_first_json_line(completed.stdout)
-    metrics = extract_metrics(payload)
+    metrics_summary = extract_metrics(payload)
     if budget_ms is not None:
-        metrics["frame_budget_ms"] = budget_ms
+        metrics_summary["frame_budget_ms"] = budget_ms
 
-    objective = compute_objective(metrics, budget_ms)
-    failures = evaluate_constraints(metrics, budget_ms)
+    objective = compute_objective(metrics_summary, budget_ms)
+    failures = evaluate_constraints(metrics_summary, budget_ms)
+
+    ok = not failures
+    if failures:
+        objective = math.inf
 
     result: Dict[str, Any] = {
-        "ok": not failures,
+        "ok": ok,
         "objective": objective,
-        "metrics": metrics,
-        "params": params,
-        "config_path": str(config_path),
+        "metrics": payload,
+        "_summary": metrics_summary,
+        "_params": params,
+        "_seed": extract_seed(config_data, config_path),
+        "_scenario": extract_scenario(config_data, config_path),
+        "_ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "env": collect_env_info(),
+        "_schema": "v1",
     }
     if failures:
         result["reason"] = "; ".join(failures)

--- a/tools/autotune/validate.py
+++ b/tools/autotune/validate.py
@@ -34,6 +34,16 @@ from tools.autotune.optimize import AppSpec, parse_app_spec  # noqa: E402
 RUN_ONE = REPO_ROOT / "tools" / "autotune" / "run_one.py"
 
 
+def get_metrics_summary(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    summary = payload.get("_summary")
+    if isinstance(summary, Mapping):
+        return summary
+    metrics = payload.get("metrics")
+    if isinstance(metrics, Mapping):
+        return metrics
+    return {}
+
+
 @dataclass(frozen=True)
 class ScenarioSpec:
     name: str
@@ -368,9 +378,7 @@ def run_validation(
                             "reason": f"Failed to parse JSON output: {stdout}",
                         }
 
-                metrics = payload.get("metrics")
-                if not isinstance(metrics, Mapping):
-                    metrics = {}
+                metrics = get_metrics_summary(payload)
                 objective_value = payload.get("objective")
                 if isinstance(objective_value, (int, float)) and not math.isnan(objective_value):
                     objective = float(objective_value)
@@ -509,6 +517,8 @@ def append_experiments_log(path: pathlib.Path, records: Sequence[Mapping[str, An
         for record in records:
             fh.write(json.dumps(record))
             fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
 
 
 def write_candidate_summaries(path: pathlib.Path, summaries: Sequence[Mapping[str, Any]]) -> None:


### PR DESCRIPTION
## Summary
- extend run_one output with metadata, environment details, and a `_summary` payload while keeping raw metrics for traceability
- update optimize, run_experiments, and validate helpers to consume the new summary field and flush+fsync JSONL appends
- document the v1 JSONL schema for autotune results

## Testing
- python -m compileall tools/autotune

------
https://chatgpt.com/codex/tasks/task_e_68db3461397c832b8cf023751ff64e19