### PR TITLE
Add autotune smoke workflow

### DIFF
--- a/.github/workflows/autotune-smoke.yml
+++ b/.github/workflows/autotune-smoke.yml
@@ -1,0 +1,43 @@
+name: Autotune Smoke
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  autotune-smoke:
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Prepare workspace
+        run: |
+          rm -rf results profiles reports
+      - name: Run autotune smoke workflow
+        run: |
+          python3 tools/autotune/run_experiments.py \
+            --spec tools/autotune/spec_smoke.yaml \
+            --screen 4 \
+            --replicates 1 \
+            --local-iters 1 \
+            --topk 1 \
+            --seed 0 \
+            --warmup-sec 1 \
+            --run-sec 2
+      - name: Upload autotune smoke artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: autotune-smoke-artifacts
+          path: |
+            results/**
+            reports/**
+            profiles/**

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ python3 tools/autotune/run_experiments.py \
   --topk 5
 ```
 
+Use `--warmup-sec` / `--run-sec` to temporarily shorten the sampling window for smoke tests or CI runs.
+
 The orchestration script screens the parameter space, runs local search, validates the best candidates, and writes the final machine profile. All metrics are gathered in **interval mode** (`--metrics-json-interval`) so every sample represents a fresh window; cumulative outputs (`--metrics-json`) are ignored by design to keep the statistics comparable.
 
 ### What lands where

--- a/docs/DOE_AUTOTUNE.md
+++ b/docs/DOE_AUTOTUNE.md
@@ -28,6 +28,8 @@ python3 tools/autotune/run_experiments.py \
 - `--replicates` — interval metric samples per evaluation; >1 smooths jittery hosts.
 - `--local-iters` — bounded coordinate/local search iterations seeded from the best screening candidate.
 - `--topk` — number of unique candidates to send through robustness validation.
+- `--warmup-sec` — optional override for the warmup duration defined in the spec (seconds).
+- `--run-sec` — optional override for the metrics sampling window (seconds).
 
 > **Interval metrics only.** The runner always calls `rtfw_demo` with `--metrics-json-interval`. Cumulative stats (`--metrics-json`) are intentionally ignored because they hide short-lived regressions and make comparisons between runs ambiguous.
 

--- a/tools/autotune/run_experiments.py
+++ b/tools/autotune/run_experiments.py
@@ -20,6 +20,7 @@ from collections import OrderedDict
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 import hashlib
+from dataclasses import replace
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
@@ -192,6 +193,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--local-iters", required=True, type=int, help="Iterations for local search")
     parser.add_argument("--topk", required=True, type=int, help="Top K candidates to validate")
     parser.add_argument("--seed", type=int, default=0, help="Seed for screening candidate generation")
+    parser.add_argument(
+        "--warmup-sec",
+        type=float,
+        default=None,
+        help="Override warmup duration from the spec (seconds)",
+    )
+    parser.add_argument(
+        "--run-sec",
+        type=float,
+        default=None,
+        help="Override run duration from the spec (seconds)",
+    )
     return parser.parse_args()
 
 
@@ -489,8 +502,15 @@ def sanitise_filename(text: str) -> str:
     return cleaned.strip("-") or "unknown"
 
 
-def compute_spec_digest(path: pathlib.Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
+def compute_spec_digest(
+    path: pathlib.Path, overrides: Optional[Mapping[str, Any]] = None
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(path.read_bytes())
+    if overrides:
+        payload = json.dumps(overrides, sort_keys=True).encode("utf-8")
+        digest.update(payload)
+    return digest.hexdigest()
 
 
 def main() -> None:
@@ -505,6 +525,21 @@ def main() -> None:
         raise SystemExit("Spec YAML must contain a mapping at the top level")
 
     app_spec = parse_app_spec(spec_data, spec_path.parent)
+
+    app_overrides: Dict[str, float] = {}
+    if args.warmup_sec is not None:
+        if args.warmup_sec < 0:
+            raise SystemExit("--warmup-sec must be non-negative")
+        app_overrides["warmup"] = float(args.warmup_sec)
+    if args.run_sec is not None:
+        if args.run_sec <= 0:
+            raise SystemExit("--run-sec must be positive")
+        app_overrides["run"] = float(args.run_sec)
+    if app_overrides:
+        app_spec = replace(app_spec, **app_overrides)
+
+    metadata_overrides = {"app_overrides": dict(app_overrides)} if app_overrides else {}
+
     objective_spec = parse_objective_spec(spec_data)
     objective_eval = ExpressionEvaluator(objective_spec.expression)
     tiebreakers_eval = [ExpressionEvaluator(expr) for expr in objective_spec.tiebreakers]
@@ -520,7 +555,7 @@ def main() -> None:
     experiments_log_path = results_dir / "experiments.jsonl"
     experiments_log_path.touch(exist_ok=True)
     log = ExperimentLog(experiments_log_path, objective_spec)
-    spec_digest = compute_spec_digest(spec_path)
+    spec_digest = compute_spec_digest(spec_path, app_overrides if app_overrides else None)
 
     rng = random.Random(args.seed)
 
@@ -533,7 +568,7 @@ def main() -> None:
     write_json_file(screen_candidates_path, {"generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(), "candidates": screen_candidates})
 
     for index, candidate in enumerate(screen_candidates):
-        metadata = {"source": "screen", "index": index}
+        metadata = {**metadata_overrides, "source": "screen", "index": index}
         evaluate_candidate(
             stage="screen",
             params=candidate,
@@ -585,7 +620,7 @@ def main() -> None:
     evaluate_candidate(
         stage="local",
         params=local_params,
-        metadata={"source": "local_opt", "path": str(local_output_path)},
+        metadata={**metadata_overrides, "source": "local_opt", "path": str(local_output_path)},
         app=app_spec,
         param_specs=param_specs,
         objective=objective_spec,
@@ -612,7 +647,7 @@ def main() -> None:
         params = candidate.get("params")
         if not isinstance(params, Mapping):
             continue
-        metadata = {"rank": rank, "source_stage": candidate.get("stage")}
+        metadata = {**metadata_overrides, "rank": rank, "source_stage": candidate.get("stage")}
         cached = log.get("validate", params)
         if cached is not None and cached.get("runs"):
             runs = cached.get("runs", [])
@@ -626,7 +661,7 @@ def main() -> None:
                 run_records.append(run)
         else:
             run_records_map: Dict[Tuple[str, Optional[int]], Dict[str, Any]] = {}
-            missing: Dict[Any, List[Optional[int]]] = {}
+            missing: Dict[str, Dict[str, Any]] = {}
             for scenario in robustness_spec.scenarios:
                 scenario_name = scenario.name
                 for seed in robustness_spec.seeds:
@@ -637,11 +672,17 @@ def main() -> None:
                         log.remember_run(cached_run)
                         run_records_map[(scenario_name, seed)] = cached_run
                     else:
-                        missing.setdefault(scenario, []).append(seed)
+                        record = missing.setdefault(
+                            scenario_name,
+                            {"spec": scenario, "seeds": []},
+                        )
+                        record["seeds"].append(seed)
 
             raw_records: List[Dict[str, Any]] = []
             if missing:
-                for scenario, seeds in missing.items():
+                for record in missing.values():
+                    scenario = record["spec"]
+                    seeds = record["seeds"]
                     partial_spec = RobustnessSpec(
                         seeds=tuple(seeds),
                         scenarios=(scenario,),
@@ -653,7 +694,7 @@ def main() -> None:
                         app_spec,
                         partial_spec,
                         params,
-                        {"rank": rank, "stage": candidate.get("stage")},
+                        {**metadata_overrides, "rank": rank, "stage": candidate.get("stage")},
                     )
                     for run in new_runs:
                         if not isinstance(run, Mapping):
@@ -700,7 +741,12 @@ def main() -> None:
             log.register("validate", params, record)
             log.append(record)
             run_records = runs
-        summary = summarise_candidate(rank - 1, {"rank": rank, "stage": candidate.get("stage")}, params, run_records)
+        summary = summarise_candidate(
+            rank - 1,
+            {**metadata_overrides, "rank": rank, "stage": candidate.get("stage")},
+            params,
+            run_records,
+        )
         validation_summaries.append(summary)
 
     if validation_raw_records:
@@ -776,6 +822,7 @@ def main() -> None:
         "profile": str(profile_path),
         "best_objective": best_payload.get("objective"),
         "best_params": best_params_final,
+        "app_overrides": app_overrides,
     }
     write_json_file(summary_path, summary_payload)
 
@@ -784,6 +831,7 @@ def main() -> None:
         "best_objective": best_payload.get("objective"),
         "best_params": best_params_final,
         "analysis_dir": str(reports_dir),
+        "app_overrides": app_overrides,
     }
     print(json.dumps(ci_summary, sort_keys=True))
 

--- a/tools/autotune/smoke_app.py
+++ b/tools/autotune/smoke_app.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Synthetic app used for CI smoke tests of the autotune pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import pathlib
+import random
+import sys
+from typing import Any, Dict
+
+
+def parse_duration(text: str) -> float:
+    if not text:
+        return 0.0
+    stripped = text.strip().lower()
+    if stripped.endswith("s"):
+        stripped = stripped[:-1]
+    try:
+        return float(stripped)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid duration: {text!r}") from exc
+
+
+def load_config(path: pathlib.Path) -> Dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError as exc:
+        raise SystemExit(f"Config file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Failed to parse config JSON: {exc}") from exc
+
+
+def compute_metrics(params: Dict[str, Any], run_seconds: float) -> Dict[str, Any]:
+    threads = int(params.get("threads", 1))
+    mode = str(params.get("mode", "balanced"))
+    prefetch = int(params.get("prefetch_distance", 0))
+
+    base = {"fast": 3.0, "balanced": 3.6, "safe": 4.2}.get(mode, 3.6)
+    improvement = 0.08 * max(threads - 1, 0)
+    prefetch_bonus = 0.0005 * prefetch
+    seed_material = f"{threads}:{mode}:{prefetch}".encode("utf-8")
+    seed = int(hashlib.sha256(seed_material).hexdigest()[:8], 16)
+    jitter = random.Random(seed).uniform(-0.05, 0.05)
+
+    p99 = max(base - improvement - prefetch_bonus + jitter, 1.0)
+    p95 = max(p99 - 0.15, 0.5)
+    p50 = max(p95 - 0.1, 0.25)
+    stdev = max((p95 - p50) / 1.645, 0.01)
+
+    queue_max = max(1, 6 - threads)
+
+    scale = max(run_seconds, 0.5) / 2.0
+    counters = {
+        "missed_frames": 0,
+        "watchdog.trips": 0,
+        "log_drops": 0,
+        "worker.queue_max": queue_max,
+        "worker.emergency_spawns": 0,
+    }
+
+    phases = {
+        "frame": {
+            "p50_ms": round(p50 * scale, 3),
+            "p95_ms": round(p95 * scale, 3),
+            "p99_ms": round(p99 * scale, 3),
+        }
+    }
+
+    return {
+        "ok": True,
+        "phases": phases,
+        "counters": counters,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Synthetic autotune target")
+    parser.add_argument("--config", required=True, help="Path to config JSON")
+    parser.add_argument("--run", required=True, help="Duration to sample (e.g. 2s)")
+    parser.add_argument("--warmup", default=None, help="Warmup duration")
+    parser.add_argument("--metrics-json-interval", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--scenario", default=os.environ.get("SCENARIO", "default"))
+    parser.add_argument("extra", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    config_path = pathlib.Path(args.config)
+    config = load_config(config_path)
+    params = {}
+    if isinstance(config, dict):
+        params = config.get("params", {}) or {}
+        if not isinstance(params, dict):
+            params = {}
+
+    run_seconds = parse_duration(args.run)
+    metrics_payload = compute_metrics(params, run_seconds)
+
+    budget_ms = None
+    if isinstance(config, dict):
+        budget_ms = config.get("frame_budget_ms")
+        if budget_ms is None:
+            budget_ms = config.get("params", {}).get("frame_budget_ms")
+        if budget_ms is None:
+            hz = config.get("hz")
+            if isinstance(hz, (int, float)) and hz > 0:
+                budget_ms = 1000.0 / float(hz)
+
+    if args.metrics_json_interval:
+        payload: Dict[str, Any] = {
+            "scenario": args.scenario,
+            "config": str(config_path),
+            "phases": metrics_payload["phases"],
+            "counters": metrics_payload["counters"],
+            "metadata": {
+                "params": params,
+                "warmup": args.warmup,
+                "run": args.run,
+            },
+        }
+        if budget_ms is not None and isinstance(budget_ms, (int, float)) and math.isfinite(float(budget_ms)):
+            payload["frame_budget_ms"] = float(budget_ms)
+
+        json.dump(payload, sys.stdout)
+        sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/autotune/spec_smoke.yaml
+++ b/tools/autotune/spec_smoke.yaml
@@ -1,0 +1,35 @@
+app:
+  path: "./smoke_app.py"
+  warmup_sec: 1
+  run_sec: 2
+  frame_budget_ms: 5.0
+
+metrics:
+  hard_constraints:
+    missed_frames: "== 0"
+    watchdog_trips: "== 0"
+    log_drops: "== 0"
+  objective:
+    expr: "p99_frame_ms"
+    tiebreakers:
+      - "queue_max"
+      - "stdev_frame_ms"
+    maximize: false
+
+params:
+  mode:
+    type: "categorical"
+    values:
+      - "fast"
+      - "balanced"
+      - "safe"
+  threads:
+    type: "int"
+    min: 1
+    max: 4
+    step: 1
+  prefetch_distance:
+    type: "int"
+    min: 0
+    max: 256
+    step: 64


### PR DESCRIPTION
## Summary
- add a synthetic autotune spec and runner to drive the pipeline with tiny settings
- allow overriding warmup/run sampling windows and surface the options in the docs
- add a CI workflow that runs the smoke sweep and uploads the generated artifacts

## Testing
- python3 tools/autotune/run_experiments.py --spec tools/autotune/spec_smoke.yaml --screen 4 --replicates 1 --local-iters 1 --topk 1 --seed 0 --warmup-sec 1 --run-sec 2

------
https://chatgpt.com/codex/tasks/task_e_68dbdae78ae4832ba74a24cdbe5c6802