### PR TITLE
Adjust fiber poller wait strategy

### DIFF
--- a/rt/include/rt/fiber_pool.hpp
+++ b/rt/include/rt/fiber_pool.hpp
@@ -160,8 +160,10 @@ private:
         using namespace std::chrono_literals;
         while (!stopping_.load(std::memory_order_acquire)) {
             std::vector<std::coroutine_handle<>> ready;
+            bool hasWaiters = false;
             {
                 std::lock_guard<std::mutex> lock(waitMutex_);
+                hasWaiters = !waiters_.empty();
                 for (auto it = waiters_.begin(); it != waiters_.end();) {
                     if (it->fence->is_signaled()) {
                         ready.push_back(it->handle);
@@ -173,7 +175,10 @@ private:
             }
             for (auto h : ready)
                 schedule(h);
-            std::this_thread::sleep_for(1ms);
+            if (hasWaiters)
+                std::this_thread::yield();
+            else
+                std::this_thread::sleep_for(1ms);
         }
     }
 


### PR DESCRIPTION
## Summary
- update the fiber pool poller loop to yield when fences are pending and sleep otherwise to reduce wait latency

## Testing
- not run (requires Windows environment)

------
https://chatgpt.com/codex/tasks/task_e_68dbfc381a70832b98fbf7119ccb4a4d