### PR TITLE
Adjust autotune objective to minimize p99 ratio

### DIFF
--- a/tools/autotune/run_one.py
+++ b/tools/autotune/run_one.py
@@ -262,10 +262,10 @@ def extract_metrics(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def compute_objective(metrics: Dict[str, Any], budget_ms: Optional[float]) -> float:
-    p99 = metrics.get("p99_frame_ms", 0.0)
+    p99 = float(metrics.get("p99_frame_ms", 0.0))
     if budget_ms and budget_ms > 0.0:
-        return budget_ms / max(p99, 1e-9)
-    return 1.0 / (1.0 + max(p99, 0.0))
+        return p99 / budget_ms
+    return p99
 
 
 def evaluate_constraints(metrics: Dict[str, Any], budget_ms: Optional[float]) -> List[str]:


### PR DESCRIPTION
## Summary
- update the autotune objective to minimize p99 frame time against the frame budget

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc55cafd54832ba068cd13415e6d9e