### PR TITLE
Use last JSON metrics line in autotune runner

### DIFF
--- a/tools/autotune/run_one.py
+++ b/tools/autotune/run_one.py
@@ -113,8 +113,8 @@ def run_command(
         raise SystemExit("\n".join(msg)) from exc
 
 
-def find_first_json_line(output: str) -> Dict[str, Any]:
-    for line in output.splitlines():
+def find_last_json_line(output: str) -> Dict[str, Any]:
+    for line in reversed(output.splitlines()):
         stripped = line.strip()
         if not stripped:
             continue
@@ -371,7 +371,7 @@ def main() -> None:
     run_cmd = base_cmd + ["--metrics-json-interval", "--run", format_duration(args.run)]
     completed = run_command(run_cmd, capture=True, extra_env=scenario_env)
 
-    payload = find_first_json_line(completed.stdout)
+    payload = find_last_json_line(completed.stdout)
     metrics_summary = extract_metrics(payload)
     if budget_ms is not None:
         metrics_summary["frame_budget_ms"] = budget_ms


### PR DESCRIPTION
## Summary
- update the autotune runner to scan captured stdout from the end
- ensure the last JSON metrics line is parsed even when earlier JSON lines exist

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea1738a1c832b9af8d66e9f36ca81