### PR TITLE
Fix autotune config prefetch flag and emergency mapping

### DIFF
--- a/tools/autotune/make_config.py
+++ b/tools/autotune/make_config.py
@@ -343,7 +343,7 @@ def build_config(params: Mapping[str, Any]) -> Dict[str, Any]:
         "fma_mode": ("numerics", "fma"),
         "arena_per_thread_mb": ("memory", "arena_per_thread_mb"),
         "huge_pages": ("memory", "huge_pages"),
-        "emergency_spawn_enabled": ("emergency", "enabled"),
+        "emergency_spawn_enabled": ("scheduler", "emergency_spawn"),
         "governor_target_util": ("governor", "target_util"),
         "governor_hysteresis": ("governor", "hysteresis"),
     }
@@ -352,6 +352,10 @@ def build_config(params: Mapping[str, Any]) -> Dict[str, Any]:
         if name not in params:
             continue
         set_path(config, path, params[name])
+
+    if "prefetch_distance_bytes" in params:
+        enabled = params["prefetch_distance_bytes"] > 0
+        set_path(config, ("prefetch", "enabled"), enabled)
 
     # Emit the original params alongside the resolved config for traceability.
     config["params"] = dict(params)


### PR DESCRIPTION
## Summary
- write emergency_spawn_enabled into scheduler.emergency_spawn so the generated config matches the runtime schema
- set prefetch.enabled based on whether prefetch_distance_bytes is greater than zero

## Testing
- python3 tools/autotune/make_config.py --spec tools/autotune/spec.yaml --params-json '{"threads":"physical","chunk_target_us":140,"aosoa_block":256,"steal_threshold":3,"prefetch_distance_bytes":1024,"fma_mode":"on","arena_per_thread_mb":64,"huge_pages":true,"emergency_spawn_enabled":false,"governor_target_util":0.93,"governor_hysteresis":0.02}' --out /tmp/config.json
- python3 tools/autotune/make_config.py --spec tools/autotune/spec.yaml --params-json '{"threads":"physical","chunk_target_us":140,"aosoa_block":256,"steal_threshold":3,"prefetch_distance_bytes":0,"fma_mode":"on","arena_per_thread_mb":64,"huge_pages":true,"emergency_spawn_enabled":true,"governor_target_util":0.93,"governor_hysteresis":0.02}' --out /tmp/config_zero.json

------
https://chatgpt.com/codex/tasks/task_e_68e3d7e05440832bbe881b29600b0d21