### PR TITLE
Align autotune objective sorting with spec

### DIFF
--- a/tools/autotune/analyze.py
+++ b/tools/autotune/analyze.py
@@ -9,10 +9,15 @@ import hashlib
 import json
 import math
 import pathlib
+import sys
 from collections import OrderedDict
 from dataclasses import dataclass
 from statistics import mean
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
 from tools.autotune.make_config import load_simple_yaml
 

--- a/tools/autotune/analyze.py
+++ b/tools/autotune/analyze.py
@@ -14,6 +14,14 @@ from dataclasses import dataclass
 from statistics import mean
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
+from tools.autotune.make_config import load_simple_yaml
+
+
+@dataclass
+class SpecInfo:
+    params: "OrderedDict[str, Any]"
+    maximize: bool
+
 
 @dataclass
 class Experiment:
@@ -42,12 +50,13 @@ class Experiment:
         metrics = self.raw.get("metrics", {})
         return metrics if isinstance(metrics, dict) else {}
 
-    def pareto_tuple(self) -> Tuple[float, float, float, float]:
+    def pareto_tuple(self, maximize: bool) -> Tuple[float, float, float, float]:
         metrics = self.metrics
         queue = _safe_metric(metrics, "queue_max")
         emergency = _safe_metric(metrics, "emergency_spawns")
         drops = _safe_metric(metrics, "log_drops")
-        return (self.objective, queue, emergency, drops)
+        objective_value = -self.objective if maximize else self.objective
+        return (objective_value, queue, emergency, drops)
 
 
 def _safe_metric(metrics: Dict[str, Any], key: str) -> float:
@@ -76,31 +85,27 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_spec(path: pathlib.Path) -> Dict[str, Any]:
-    if not path.is_file():
-        raise SystemExit(f"Spec file not found: {path}")
+def load_spec(path: pathlib.Path) -> SpecInfo:
+    data = load_simple_yaml(path)
+    if not isinstance(data, dict):
+        raise SystemExit("Spec YAML must contain a mapping at the top level")
 
+    params_section = data.get("params")
     params: "OrderedDict[str, Any]" = OrderedDict()
-    inside_params = False
-    params_indent = 0
-    with path.open("r", encoding="utf-8") as fh:
-        for raw_line in fh:
-            if not raw_line.strip() or raw_line.lstrip().startswith("#"):
-                continue
-            indent = len(raw_line) - len(raw_line.lstrip(" "))
-            stripped = raw_line.strip()
-            if not inside_params:
-                if stripped == "params:":
-                    inside_params = True
-                    params_indent = indent
-                continue
-            if indent <= params_indent:
-                break
-            if indent == params_indent + 2 and stripped.endswith(":"):
-                name = stripped[:-1].strip()
-                if name:
-                    params[name] = {}
-    return {"params": params}
+    if isinstance(params_section, dict):
+        for name in params_section.keys():
+            params[name] = {}
+
+    maximize = False
+    metrics = data.get("metrics")
+    if isinstance(metrics, dict):
+        objective_payload = metrics.get("objective")
+        if isinstance(objective_payload, dict):
+            maximize_value = objective_payload.get("maximize")
+            if isinstance(maximize_value, bool):
+                maximize = maximize_value
+
+    return SpecInfo(params=params, maximize=maximize)
 
 
 def compute_spec_digest(path: pathlib.Path) -> str:
@@ -139,21 +144,22 @@ def load_experiments(path: pathlib.Path, expected_digest: Optional[str] = None) 
     return experiments
 
 
-def compute_best(experiments: Sequence[Experiment]) -> Experiment:
+def compute_best(experiments: Sequence[Experiment], maximize: bool) -> Experiment:
     ok_results = [exp for exp in experiments if exp.ok]
     if not ok_results:
         raise SystemExit("No successful experiments (ok=true) found")
-    return min(ok_results, key=lambda exp: exp.objective)
+    selector = max if maximize else min
+    return selector(ok_results, key=lambda exp: exp.objective)
 
 
-def pareto_frontier(experiments: Iterable[Experiment]) -> List[Experiment]:
+def pareto_frontier(experiments: Iterable[Experiment], maximize: bool) -> List[Experiment]:
     frontier: List[Experiment] = []
-    for exp in sorted(experiments, key=lambda e: e.objective):
-        candidate = exp.pareto_tuple()
+    for exp in sorted(experiments, key=lambda e: e.objective, reverse=maximize):
+        candidate = exp.pareto_tuple(maximize)
         dominated = False
         new_frontier: List[Experiment] = []
         for current in frontier:
-            current_tuple = current.pareto_tuple()
+            current_tuple = current.pareto_tuple(maximize)
             if dominates(current_tuple, candidate):
                 dominated = True
                 break
@@ -236,6 +242,7 @@ def write_summary_csv(
     path: pathlib.Path,
     params_spec: Dict[str, Any],
     experiments: Sequence[Experiment],
+    maximize: bool,
     limit: int = 10,
 ) -> None:
     columns = ["objective", "ok", "reason"]
@@ -252,7 +259,13 @@ def write_summary_csv(
     ]
     columns.extend(metric_columns)
 
-    ranked = sorted(experiments, key=lambda exp: (not exp.ok, exp.objective))[:limit]
+    def rank_key(exp: Experiment) -> Tuple[bool, float]:
+        objective_value = exp.objective
+        if maximize:
+            objective_value = -objective_value
+        return (not exp.ok, objective_value)
+
+    ranked = sorted(experiments, key=rank_key)[:limit]
 
     with path.open("w", encoding="utf-8", newline="") as fh:
         writer = csv.DictWriter(fh, fieldnames=columns)
@@ -292,19 +305,19 @@ def write_summary_json(
 def main() -> None:
     args = parse_args()
     spec = load_spec(args.spec)
-    params_spec = spec.get("params", {}) if isinstance(spec, dict) else {}
+    params_spec = spec.params
     spec_digest = compute_spec_digest(args.spec)
     experiments = load_experiments(args.in_path, spec_digest)
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
 
-    best = compute_best(experiments)
-    pareto = pareto_frontier([exp for exp in experiments if exp.ok])
+    best = compute_best(experiments, spec.maximize)
+    pareto = pareto_frontier([exp for exp in experiments if exp.ok], spec.maximize)
     histograms = build_histograms(params_spec, experiments)
 
     write_best(args.out_dir / "best.json", best)
     write_pareto(args.out_dir / "pareto.json", pareto)
-    write_summary_csv(args.out_dir / "summary.csv", params_spec, experiments)
+    write_summary_csv(args.out_dir / "summary.csv", params_spec, experiments, spec.maximize)
     write_summary_json(
         args.out_dir / "summary.json",
         best,

--- a/tools/autotune/run_experiments.py
+++ b/tools/autotune/run_experiments.py
@@ -934,7 +934,7 @@ def main() -> None:
     if validation_raw_records:
         append_jsonl(validation_runs_path, validation_raw_records)
 
-    best_validation = select_best(validation_summaries)
+    best_validation = select_best(validation_summaries, objective_spec.maximize)
     write_json_file(
         validation_summaries_path,
         {

--- a/tools/autotune/run_experiments.py
+++ b/tools/autotune/run_experiments.py
@@ -476,11 +476,9 @@ def aggregate_runs(
 
     reason_text = " ; ".join(sorted(set(reasons))) if reasons else None
 
-    score_components = [aggregated_objective, *aggregated_tiebreakers]
-    if objective.maximize:
-        score_key = [(-value) if math.isfinite(value) else value for value in score_components]
-    else:
-        score_key = score_components
+    score_key = [
+        value if math.isfinite(value) else penalty for value in [aggregated_objective, *aggregated_tiebreakers]
+    ]
 
     return {
         "ok": ok,
@@ -615,25 +613,27 @@ def evaluate_candidate(
     return record
 
 
-def score_tuple(entry: Mapping[str, Any]) -> Tuple[float, ...]:
+def score_tuple(entry: Mapping[str, Any], maximize: bool) -> Tuple[float, ...]:
     raw = entry.get("score_key")
     if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes)):
         components: List[float] = []
         for value in raw:
             numeric = safe_float(value)
             if numeric is None:
-                numeric = 1e12
+                numeric = -1e12 if maximize else 1e12
             components.append(numeric)
         return tuple(components)
     objective_value = entry.get("objective")
     numeric = safe_float(objective_value)
     if numeric is None:
-        numeric = 1e12
+        numeric = -1e12 if maximize else 1e12
     return (numeric,)
 
 
-def select_unique_best(entries: Iterable[Mapping[str, Any]], limit: int) -> List[Dict[str, Any]]:
-    ordered = sorted(entries, key=score_tuple)
+def select_unique_best(
+    entries: Iterable[Mapping[str, Any]], limit: int, maximize: bool
+) -> List[Dict[str, Any]]:
+    ordered = sorted(entries, key=lambda entry: score_tuple(entry, maximize), reverse=maximize)
     seen: set[str] = set()
     results: List[Dict[str, Any]] = []
     for entry in ordered:
@@ -764,7 +764,7 @@ def main() -> None:
 
     all_entries = log.all_entries()
     screen_entries = [entry for entry in all_entries if entry.get("stage") == "screen"]
-    best_screen = select_unique_best(screen_entries, 1)
+    best_screen = select_unique_best(screen_entries, 1, objective_spec.maximize)
     if not best_screen:
         raise SystemExit("No successful screening results recorded")
     best_params = best_screen[0]["params"]
@@ -812,7 +812,7 @@ def main() -> None:
     )
 
     all_entries = log.all_entries()
-    top_candidates = select_unique_best(all_entries, args.topk)
+    top_candidates = select_unique_best(all_entries, args.topk, objective_spec.maximize)
     top_candidates_path = results_dir / "top_candidates.json"
     write_json_file(top_candidates_path, {"candidates": top_candidates})
 

--- a/tools/autotune/validate.py
+++ b/tools/autotune/validate.py
@@ -670,14 +670,21 @@ def summarise_candidate(
     return summary
 
 
-def select_best(summaries: Sequence[Mapping[str, Any]]) -> Optional[Mapping[str, Any]]:
+def select_best(
+    summaries: Sequence[Mapping[str, Any]], maximize: bool
+) -> Optional[Mapping[str, Any]]:
     if not summaries:
         return None
 
     def sort_key(summary: Mapping[str, Any]) -> Tuple[float, float, float, int]:
         fail_rate = float(summary.get("fail_rate", 1.0))
         median = summary.get("median_objective")
-        median_value = float(median) if isinstance(median, (int, float)) else math.inf
+        if isinstance(median, (int, float)):
+            median_value = float(median)
+        else:
+            median_value = math.inf if not maximize else -math.inf
+        if maximize:
+            median_value = -median_value
         iqr = summary.get("iqr_objective")
         iqr_value = float(iqr) if isinstance(iqr, (int, float)) else math.inf
         index = int(summary.get("candidate_index", 0))
@@ -758,7 +765,7 @@ def main() -> None:
         summaries.append(summary)
         experiments_records.extend(raw_records)
 
-    best = select_best(summaries)
+    best = select_best(summaries, objective_spec.maximize)
 
     write_candidate_summaries(args.out, summaries)
     append_experiments_log(pathlib.Path("results") / "experiments.jsonl", experiments_records)


### PR DESCRIPTION
## Summary
- parse the autotune spec to capture the objective direction and use it when picking best and Pareto experiment results
- propagate the objective direction through run_experiments scoring and selection logic without negating scores
- respect the objective maximize flag when choosing the top validated candidate

## Testing
- python -m compileall tools/autotune

------
https://chatgpt.com/codex/tasks/task_e_68e3e642ddb4832bb64570ad4fc515dd