### PR TITLE
Enforce crash-safe JSONL appends

### DIFF
--- a/tools/autotune/common_io.py
+++ b/tools/autotune/common_io.py
@@ -1,0 +1,22 @@
+"""Common IO helpers for autotune tooling."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Mapping, Union
+
+PathLike = Union[str, os.PathLike[str]]
+
+
+def append_jsonl(path: PathLike, obj: Mapping[str, object], *, sort_keys: bool = False) -> None:
+    """Append a JSON object to a JSON Lines file crash-safely."""
+    path_str = os.fspath(path)
+    directory = os.path.dirname(path_str)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    with open(path_str, "a", encoding="utf-8") as fh:
+        fh.write(json.dumps(obj, sort_keys=sort_keys))
+        fh.write("\n")
+        fh.flush()
+        os.fsync(fh.fileno())

--- a/tools/autotune/run_experiments.py
+++ b/tools/autotune/run_experiments.py
@@ -27,6 +27,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from tools.autotune import screening  # noqa: E402
+from tools.autotune.common_io import append_jsonl as append_jsonl_record  # noqa: E402
 from tools.autotune.make_config import (  # noqa: E402
     build_config,
     load_simple_yaml,
@@ -183,12 +184,7 @@ class ExperimentLog:
         self._index_runs_from_record(record)
 
     def append(self, record: Mapping[str, Any]) -> None:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        with self.path.open("a", encoding="utf-8") as fh:
-            fh.write(json.dumps(record, sort_keys=True))
-            fh.write("\n")
-            fh.flush()
-            os.fsync(fh.fileno())
+        append_jsonl_record(self.path, record, sort_keys=True)
 
     def all_entries(self) -> List[Dict[str, Any]]:
         return list(self.entries.values())
@@ -662,13 +658,8 @@ def write_json_file(path: pathlib.Path, payload: Any) -> None:
 def append_jsonl(path: pathlib.Path, records: Sequence[Mapping[str, Any]]) -> None:
     if not records:
         return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as fh:
-        for record in records:
-            fh.write(json.dumps(record, sort_keys=True))
-            fh.write("\n")
-            fh.flush()
-            os.fsync(fh.fileno())
+    for record in records:
+        append_jsonl_record(path, record, sort_keys=True)
 
 
 def sanitise_filename(text: str) -> str:

--- a/tools/autotune/validate.py
+++ b/tools/autotune/validate.py
@@ -35,6 +35,7 @@ from tools.autotune.optimize import (  # noqa: E402
     parse_app_spec,
     parse_objective_spec,
 )
+from tools.autotune.common_io import append_jsonl as append_jsonl_record  # noqa: E402
 
 RUN_ONE = REPO_ROOT / "tools" / "autotune" / "run_one.py"
 
@@ -694,13 +695,8 @@ def select_best(
 
 
 def append_experiments_log(path: pathlib.Path, records: Sequence[Mapping[str, Any]]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as fh:
-        for record in records:
-            fh.write(json.dumps(record))
-            fh.write("\n")
-            fh.flush()
-            os.fsync(fh.fileno())
+    for record in records:
+        append_jsonl_record(path, record)
 
 
 def write_candidate_summaries(path: pathlib.Path, summaries: Sequence[Mapping[str, Any]]) -> None:


### PR DESCRIPTION
## Summary
- add a shared crash-safe JSONL append helper for autotune tooling
- update experiment and validation writers to use the helper so interrupted runs keep readable logs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4009384dc832b882874d3c13c92b7