### PR TITLE
Centralize autotune evaluation logic

### DIFF
--- a/tools/autotune/analyze.py
+++ b/tools/autotune/analyze.py
@@ -13,12 +13,13 @@ import sys
 from collections import OrderedDict
 from dataclasses import dataclass
 from statistics import mean
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from tools.autotune.common_eval import compute_objective, evaluate_constraints
 from tools.autotune.make_config import load_simple_yaml
 
 
@@ -26,6 +27,7 @@ from tools.autotune.make_config import load_simple_yaml
 class SpecInfo:
     params: "OrderedDict[str, Any]"
     maximize: bool
+    raw: Mapping[str, Any]
 
 
 @dataclass
@@ -36,11 +38,16 @@ class Experiment:
 
     @property
     def ok(self) -> bool:
+        if "_computed_ok" in self.raw:
+            return bool(self.raw.get("_computed_ok"))
         return bool(self.raw.get("ok"))
 
     @property
     def objective(self) -> float:
-        value = self.raw.get("objective")
+        if "_computed_objective" in self.raw:
+            value = self.raw.get("_computed_objective")
+        else:
+            value = self.raw.get("objective")
         if isinstance(value, (int, float)):
             return float(value)
         raise ValueError("Experiment missing numeric objective")
@@ -52,8 +59,28 @@ class Experiment:
 
     @property
     def metrics(self) -> Dict[str, Any]:
-        metrics = self.raw.get("metrics", {})
-        return metrics if isinstance(metrics, dict) else {}
+        merged: Dict[str, Any] = {}
+        metrics_payload = self.raw.get("metrics")
+        if isinstance(metrics_payload, Mapping):
+            merged.update(metrics_payload)
+        summary = self.raw.get("_summary")
+        if isinstance(summary, Mapping):
+            merged.update(summary)
+        return merged
+
+    def recompute(self, spec: Mapping[str, Any]) -> None:
+        metrics = self.metrics
+        spec_ok, failures = evaluate_constraints(spec, metrics)
+        objective_value = compute_objective(spec, metrics)
+        original_ok = bool(self.raw.get("ok"))
+        overall_ok = original_ok and spec_ok
+        self.raw["_constraints_ok"] = spec_ok
+        self.raw["_computed_ok"] = overall_ok
+        self.raw["_computed_objective"] = objective_value
+        if failures:
+            self.raw["_constraint_failures"] = failures
+            messages = [info["message"] for info in failures.values()]
+            self.raw.setdefault("reason", "; ".join(messages))
 
     def pareto_tuple(self, maximize: bool) -> Tuple[float, float, float, float]:
         metrics = self.metrics
@@ -110,7 +137,7 @@ def load_spec(path: pathlib.Path) -> SpecInfo:
             if isinstance(maximize_value, bool):
                 maximize = maximize_value
 
-    return SpecInfo(params=params, maximize=maximize)
+    return SpecInfo(params=params, maximize=maximize, raw=data)
 
 
 def compute_spec_digest(path: pathlib.Path) -> str:
@@ -313,6 +340,8 @@ def main() -> None:
     params_spec = spec.params
     spec_digest = compute_spec_digest(args.spec)
     experiments = load_experiments(args.in_path, spec_digest)
+    for experiment in experiments:
+        experiment.recompute(spec.raw)
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/tools/autotune/common_eval.py
+++ b/tools/autotune/common_eval.py
@@ -1,0 +1,208 @@
+"""Shared logic for evaluating autotune metrics against a spec."""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+SAFE_GLOBALS = {"__builtins__": {}}
+SAFE_FUNCTIONS = {"min": min, "max": max, "abs": abs, "math": math}
+
+
+class ExpressionEvaluator:
+    def __init__(self, expression: str, *, label: str = "<expression>") -> None:
+        prepared = (expression or "").strip()
+        if not prepared:
+            raise SystemExit(f"Expression for {label} must be a non-empty string")
+        self.expression = prepared
+        self._code = compile(prepared, label, "eval")
+
+    def __call__(self, variables: Mapping[str, Any]) -> float:
+        safe_locals = dict(SAFE_FUNCTIONS)
+        safe_locals.update(variables)
+        result = eval(self._code, SAFE_GLOBALS, safe_locals)
+        if isinstance(result, (int, float)):
+            return float(result)
+        raise ValueError(f"Expression must evaluate to numeric result, got {result!r}")
+
+
+class ConstraintEvaluator:
+    def __init__(self, metric: str, expression: str) -> None:
+        self.metric = metric
+        prepared = (expression or "").strip()
+        if not prepared:
+            raise SystemExit(
+                f"Constraint expression for metric '{metric}' must be a non-empty string"
+            )
+        if prepared[0] in "=<>":
+            prepared = f"value {prepared}"
+        self.expression = prepared
+        self._code = compile(prepared, f"<constraint {metric}>", "eval")
+
+    def evaluate(self, metrics: Mapping[str, Any], frame_budget_ms: Optional[float]) -> bool:
+        if not isinstance(metrics, Mapping):
+            return False
+        if self.metric not in metrics:
+            return False
+        value = metrics[self.metric]
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError):
+            return False
+        context: Dict[str, Any] = dict(metrics)
+        context[self.metric] = numeric_value
+        context["value"] = numeric_value
+        if (
+            frame_budget_ms is not None
+            and "frame_budget_ms" not in context
+            and isinstance(frame_budget_ms, (int, float))
+        ):
+            context["frame_budget_ms"] = float(frame_budget_ms)
+        safe_locals = dict(SAFE_FUNCTIONS)
+        safe_locals.update(context)
+        try:
+            result = eval(self._code, SAFE_GLOBALS, safe_locals)
+        except Exception:
+            return False
+        return bool(result)
+
+
+def parse_hard_constraints(spec_data: Mapping[str, Any]) -> Tuple[ConstraintEvaluator, ...]:
+    metrics_payload = spec_data.get("metrics")
+    if metrics_payload is None:
+        return ()
+    if not isinstance(metrics_payload, Mapping):
+        raise SystemExit("Spec 'metrics' must be a mapping if provided")
+    raw_constraints = metrics_payload.get("hard_constraints")
+    if raw_constraints is None:
+        return ()
+    if not isinstance(raw_constraints, Mapping):
+        raise SystemExit("metrics.hard_constraints must be a mapping if provided")
+    constraints = []
+    for name, expr in raw_constraints.items():
+        if not isinstance(name, str) or not name:
+            raise SystemExit("Constraint metric names must be non-empty strings")
+        if not isinstance(expr, str):
+            raise SystemExit(f"Constraint expression for metric '{name}' must be a string")
+        constraints.append(ConstraintEvaluator(name, expr))
+    return tuple(constraints)
+
+
+def _coerce_float(value: Any) -> Optional[float]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        numeric = float(value)
+        if math.isfinite(numeric):
+            return numeric
+        return None
+    if isinstance(value, str):
+        try:
+            numeric = float(value.strip())
+        except ValueError:
+            return None
+        if math.isfinite(numeric):
+            return numeric
+    return None
+
+
+def _resolve_frame_budget(spec: Mapping[str, Any], metrics: Mapping[str, Any]) -> Optional[float]:
+    if isinstance(metrics, Mapping):
+        candidate = _coerce_float(metrics.get("frame_budget_ms"))
+        if candidate is not None and candidate > 0.0:
+            return candidate
+    app_payload = spec.get("app")
+    if isinstance(app_payload, Mapping):
+        candidate = _coerce_float(app_payload.get("frame_budget_ms"))
+        if candidate is not None and candidate > 0.0:
+            return candidate
+    return None
+
+
+def _objective_expression(spec: Mapping[str, Any]) -> str:
+    metrics_payload = spec.get("metrics")
+    if not isinstance(metrics_payload, Mapping):
+        raise SystemExit("Spec 'metrics' must be a mapping")
+    objective_payload = metrics_payload.get("objective")
+    if not isinstance(objective_payload, Mapping):
+        raise SystemExit("Spec 'metrics.objective' must be a mapping")
+    expr = objective_payload.get("expr")
+    if not isinstance(expr, str) or not expr.strip():
+        raise SystemExit("Objective 'expr' must be a non-empty string")
+    return expr
+
+
+def _format_constraint_failure(metric: str, info: Mapping[str, Any]) -> str:
+    expression = info.get("expression", "")
+    if info.get("missing"):
+        return f"missing metric '{metric}' for constraint '{expression}'"
+    value = info.get("value")
+    return f"constraint '{metric} {expression}' failed (value={value!r})"
+
+
+def evaluate_constraints(
+    spec: Mapping[str, Any], metrics: Mapping[str, Any]
+) -> Tuple[bool, Dict[str, Dict[str, Any]]]:
+    constraints = parse_hard_constraints(spec)
+    if not constraints:
+        return True, {}
+    if not isinstance(metrics, Mapping):
+        info = {
+            "expression": "<metrics>",
+            "missing": True,
+        }
+        info["message"] = "metrics payload is not a mapping"
+        return False, {"<metrics>": info}
+    base_metrics: Dict[str, Any] = dict(metrics)
+    frame_budget = _resolve_frame_budget(spec, base_metrics)
+    if frame_budget is not None and "frame_budget_ms" not in base_metrics:
+        base_metrics["frame_budget_ms"] = frame_budget
+    failures: Dict[str, Dict[str, Any]] = {}
+    for constraint in constraints:
+        try:
+            ok = constraint.evaluate(base_metrics, frame_budget)
+        except Exception:
+            ok = False
+        if ok:
+            continue
+        info: Dict[str, Any] = {"expression": constraint.expression}
+        if constraint.metric in base_metrics:
+            info["value"] = base_metrics[constraint.metric]
+        else:
+            info["missing"] = True
+        info["message"] = _format_constraint_failure(constraint.metric, info)
+        failures[constraint.metric] = info
+    return (len(failures) == 0), failures
+
+
+def compute_objective(spec: Mapping[str, Any], metrics: Mapping[str, Any]) -> float:
+    if not isinstance(metrics, Mapping):
+        return math.inf
+    frame_budget = _resolve_frame_budget(spec, metrics)
+    context: Dict[str, Any] = dict(metrics)
+    if frame_budget is not None and "frame_budget_ms" not in context:
+        context["frame_budget_ms"] = frame_budget
+    for constraint in parse_hard_constraints(spec):
+        try:
+            if not constraint.evaluate(context, frame_budget):
+                return math.inf
+        except Exception:
+            return math.inf
+    expr = _objective_expression(spec)
+    evaluator = ExpressionEvaluator(expr, label="<objective>")
+    try:
+        value = evaluator(context)
+    except (NameError, ValueError, TypeError, ZeroDivisionError, OverflowError):
+        return math.inf
+    if math.isnan(value):
+        return math.inf
+    return float(value)
+
+
+__all__ = [
+    "ExpressionEvaluator",
+    "ConstraintEvaluator",
+    "parse_hard_constraints",
+    "evaluate_constraints",
+    "compute_objective",
+]

--- a/tools/autotune/run_experiments.py
+++ b/tools/autotune/run_experiments.py
@@ -38,9 +38,7 @@ from tools.autotune.make_config import (  # noqa: E402
 from tools.autotune.optimize import AppSpec, ObjectiveSpec, parse_app_spec, parse_objective_spec  # noqa: E402
 from tools.autotune.optimize import ExpressionEvaluator  # type: ignore[attr-defined]  # noqa: E402
 from tools.autotune.validate import (  # noqa: E402
-    ObjectiveEvaluator,
     RobustnessSpec,
-    parse_hard_constraints,
     parse_robustness,
     run_validation,
     select_best,
@@ -707,8 +705,6 @@ def main() -> None:
 
     objective_spec = parse_objective_spec(spec_data)
     objective_eval = ExpressionEvaluator(objective_spec.expression)
-    validation_objective = ObjectiveEvaluator(objective_spec, app_spec.frame_budget_ms)
-    hard_constraints = parse_hard_constraints(spec_data)
     tiebreakers_eval = [ExpressionEvaluator(expr) for expr in objective_spec.tiebreakers]
 
     param_specs = load_param_spec(spec_path)
@@ -917,8 +913,7 @@ def main() -> None:
             {**metadata_overrides, "rank": rank, "stage": candidate.get("stage")},
             params,
             run_records,
-            validation_objective,
-            hard_constraints,
+            spec_data,
         )
         validation_summaries.append(summary)
 

--- a/tools/autotune/run_one.py
+++ b/tools/autotune/run_one.py
@@ -12,7 +12,7 @@ import pathlib
 import platform
 import subprocess
 import sys
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -20,9 +20,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from tools.autotune.make_config import load_simple_yaml  # noqa: E402
-from tools.autotune.validate import (  # noqa: E402
-    ConstraintEvaluator,
-    parse_hard_constraints,
+from tools.autotune.common_eval import (  # noqa: E402
+    compute_objective,
+    evaluate_constraints,
 )
 
 
@@ -278,45 +278,11 @@ def extract_metrics(payload: Dict[str, Any]) -> Dict[str, Any]:
     return metrics
 
 
-def compute_objective(metrics: Dict[str, Any], budget_ms: Optional[float]) -> float:
-    p99 = float(metrics.get("p99_frame_ms", 0.0))
-    if budget_ms and budget_ms > 0.0:
-        return p99 / budget_ms
-    return p99
-
-
 def load_spec(path: pathlib.Path) -> Mapping[str, Any]:
     data = load_simple_yaml(path)
     if not isinstance(data, Mapping):
         raise SystemExit("Spec YAML must contain a mapping at the top level")
     return data
-
-
-def evaluate_constraints(
-    metrics: Mapping[str, Any],
-    frame_budget_ms: Optional[float],
-    constraints: Sequence[ConstraintEvaluator],
-) -> List[str]:
-    failures: List[str] = []
-    if not constraints:
-        return failures
-    for constraint in constraints:
-        try:
-            ok = constraint.evaluate(metrics, frame_budget_ms)
-        except Exception:
-            ok = False
-        if ok:
-            continue
-        if constraint.metric not in metrics:
-            failures.append(
-                f"missing metric '{constraint.metric}' for constraint '{constraint.expression}'"
-            )
-            continue
-        value = metrics.get(constraint.metric)
-        failures.append(
-            f"constraint '{constraint.metric} {constraint.expression}' failed (value={value!r})"
-        )
-    return failures
 
 
 def main() -> None:
@@ -326,8 +292,6 @@ def main() -> None:
     if not spec_path.is_file():
         raise SystemExit(f"Spec file not found: {spec_path}")
     spec_data = load_spec(spec_path)
-    hard_constraints = parse_hard_constraints(spec_data)
-
     app_path = pathlib.Path(args.app)
     if not app_path.exists():
         raise SystemExit(f"Application not found: {app_path}")
@@ -376,15 +340,14 @@ def main() -> None:
     if budget_ms is not None:
         metrics_summary["frame_budget_ms"] = budget_ms
 
-    objective = compute_objective(metrics_summary, budget_ms)
     constraint_metrics: Dict[str, Any] = {}
     if isinstance(payload, dict):
         constraint_metrics.update(payload)
     constraint_metrics.update(metrics_summary)
 
-    failures = evaluate_constraints(constraint_metrics, budget_ms, hard_constraints)
-
-    ok = not failures
+    ok, failures = evaluate_constraints(spec_data, constraint_metrics)
+    objective = compute_objective(spec_data, constraint_metrics)
+    failure_messages = [details["message"] for details in failures.values()]
     if failures:
         objective = math.inf
 
@@ -400,8 +363,9 @@ def main() -> None:
         "env": collect_env_info(),
         "_schema": "v1",
     }
-    if failures:
-        result["reason"] = "; ".join(failures)
+    if failure_messages:
+        result["reason"] = "; ".join(failure_messages)
+        result["constraint_failures"] = failures
 
     json.dump(result, sys.stdout)
     sys.stdout.write("\n")

--- a/tools/autotune/validate.py
+++ b/tools/autotune/validate.py
@@ -21,6 +21,10 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from tools.autotune.common_eval import (  # noqa: E402
+    compute_objective as compute_spec_objective,
+    evaluate_constraints as evaluate_spec_constraints,
+)
 from tools.autotune.make_config import (  # noqa: E402
     build_config,
     load_simple_yaml,
@@ -50,127 +54,11 @@ def get_metrics_summary(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     return {}
 
 
-class ExpressionEvaluator:
-    def __init__(self, expression: str, *, label: str) -> None:
-        self._code = compile(expression, label, "eval")
-
-    def __call__(self, variables: Mapping[str, Any]) -> float:
-        safe_globals = {"__builtins__": {}}
-        safe_locals = {**variables, "min": min, "max": max, "abs": abs, "math": math}
-        result = eval(self._code, safe_globals, safe_locals)
-        if isinstance(result, (int, float)):
-            return float(result)
-        raise ValueError(f"Expression must evaluate to numeric result, got {result!r}")
-
-
-class ObjectiveEvaluator:
-    def __init__(self, spec: ObjectiveSpec, frame_budget_ms: Optional[float]) -> None:
-        self.spec = spec
-        self.frame_budget_ms = frame_budget_ms
-        self._objective = ExpressionEvaluator(spec.expression, label="<objective>")
-        self._tiebreakers = [
-            ExpressionEvaluator(expr, label=f"<objective_tiebreaker_{index}>")
-            for index, expr in enumerate(spec.tiebreakers)
-        ]
-
-    def _context(self, metrics: Mapping[str, Any]) -> Dict[str, Any]:
-        context: Dict[str, Any] = dict(metrics)
-        if (
-            self.frame_budget_ms is not None
-            and "frame_budget_ms" not in context
-            and isinstance(self.frame_budget_ms, (int, float))
-        ):
-            context["frame_budget_ms"] = float(self.frame_budget_ms)
-        return context
-
-    def evaluate(self, metrics: Mapping[str, Any]) -> Tuple[float, List[float]]:
-        context = self._context(metrics)
-        objective_value = self._objective(context)
-        tiebreakers = [evaluator(context) for evaluator in self._tiebreakers]
-        return objective_value, tiebreakers
-
-
-class ConstraintEvaluator:
-    def __init__(self, metric: str, expression: str) -> None:
-        self.metric = metric
-        prepared = expression.strip()
-        if not prepared:
-            raise SystemExit(
-                f"Constraint expression for metric '{metric}' must be a non-empty string"
-            )
-        if prepared[0] in "=<>":
-            prepared = f"value {prepared}"
-        self.expression = prepared
-        self._code = compile(prepared, f"<constraint {metric}>", "eval")
-
-    def evaluate(self, metrics: Mapping[str, Any], frame_budget_ms: Optional[float]) -> bool:
-        if not isinstance(metrics, Mapping):
-            return False
-        if self.metric not in metrics:
-            return False
-        value = metrics[self.metric]
-        try:
-            numeric_value = float(value)
-        except (TypeError, ValueError):
-            return False
-        context: Dict[str, Any] = dict(metrics)
-        context[self.metric] = numeric_value
-        context["value"] = numeric_value
-        if (
-            frame_budget_ms is not None
-            and "frame_budget_ms" not in context
-            and isinstance(frame_budget_ms, (int, float))
-        ):
-            context["frame_budget_ms"] = float(frame_budget_ms)
-        safe_globals = {"__builtins__": {}}
-        safe_locals = {**context, "min": min, "max": max, "abs": abs, "math": math}
-        try:
-            result = eval(self._code, safe_globals, safe_locals)
-        except Exception:
-            return False
-        return bool(result)
-
-
-def parse_hard_constraints(spec_data: Mapping[str, Any]) -> Tuple[ConstraintEvaluator, ...]:
-    metrics_payload = ensure_mapping(spec_data.get("metrics"), "metrics")
-    raw_constraints = metrics_payload.get("hard_constraints")
-    if raw_constraints is None:
-        return ()
-    if not isinstance(raw_constraints, Mapping):
-        raise SystemExit("metrics.hard_constraints must be a mapping if provided")
-    constraints: List[ConstraintEvaluator] = []
-    for name, expr in raw_constraints.items():
-        if not isinstance(name, str) or not name:
-            raise SystemExit("Constraint metric names must be non-empty strings")
-        if not isinstance(expr, str):
-            raise SystemExit(
-                f"Constraint expression for metric '{name}' must be a string"
-            )
-        constraints.append(ConstraintEvaluator(name, expr))
-    return tuple(constraints)
-
-
-def recompute_run_objective(
-    run: Mapping[str, Any],
-    objective: ObjectiveEvaluator,
-    constraints: Sequence[ConstraintEvaluator],
-) -> Optional[float]:
+def recompute_run_objective(run: Mapping[str, Any], spec: Mapping[str, Any]) -> float:
     metrics = run.get("metrics")
     if not isinstance(metrics, Mapping):
-        return None
-    try:
-        objective_value, _ = objective.evaluate(metrics)
-    except (NameError, ValueError, TypeError, ZeroDivisionError, OverflowError):
         return math.inf
-    frame_budget_ms = getattr(objective, "frame_budget_ms", None)
-    for constraint in constraints:
-        try:
-            ok = constraint.evaluate(metrics, frame_budget_ms)
-        except Exception:
-            ok = False
-        if not ok:
-            return math.inf
-    return float(objective_value)
+    return compute_spec_objective(spec, metrics)
 
 
 @dataclass(frozen=True)
@@ -616,31 +504,49 @@ def summarise_candidate(
     entry: Mapping[str, Any],
     params: Mapping[str, Any],
     runs: Sequence[Mapping[str, Any]],
-    objective: ObjectiveEvaluator,
-    constraints: Sequence[ConstraintEvaluator],
+    spec: Mapping[str, Any],
 ) -> Dict[str, Any]:
     total_runs = len(runs)
-    failures = sum(1 for run in runs if not run.get("ok", False))
-    fail_rate = float(failures / total_runs) if total_runs else 1.0
+    failure_count = 0
 
     objectives: List[float] = []
-    for run in runs:
-        recomputed = recompute_run_objective(run, objective, constraints)
-        if isinstance(run, MutableMapping):
-            run["computed_objective"] = recomputed
-        if isinstance(recomputed, (int, float)) and not math.isnan(float(recomputed)):
-            objectives.append(float(recomputed))
-    median_objective = float(statistics.median(objectives)) if objectives else None
-    _, _, iqr_objective = quantile_range(objectives)
-
     metrics_samples: Dict[str, List[float]] = {}
+
     for run in runs:
-        metrics = run.get("metrics")
-        if not isinstance(metrics, Mapping):
-            continue
+        metrics_payload = run.get("metrics") if isinstance(run, Mapping) else None
+        metrics: Dict[str, Any] = {}
+        if isinstance(metrics_payload, Mapping):
+            metrics.update(metrics_payload)
+        summary_payload = run.get("_summary") if isinstance(run, Mapping) else None
+        if isinstance(summary_payload, Mapping):
+            metrics.update(summary_payload)
+
+        spec_ok, failures = evaluate_spec_constraints(spec, metrics)
+        objective_value = recompute_run_objective(run, spec)
+        original_ok = bool(run.get("ok", False)) if isinstance(run, Mapping) else False
+        overall_ok = spec_ok and original_ok
+
+        if isinstance(run, MutableMapping):
+            run["computed_objective"] = objective_value
+            run["computed_ok"] = overall_ok
+            run["constraints_ok"] = spec_ok
+            if failures:
+                run["constraint_failures"] = failures
+                messages = [info["message"] for info in failures.values()]
+                run.setdefault("reason", "; ".join(messages))
+
+        if not overall_ok:
+            failure_count += 1
+
+        if isinstance(objective_value, (int, float)) and not math.isnan(float(objective_value)):
+            objectives.append(float(objective_value))
+
         for key, value in metrics.items():
             if isinstance(value, (int, float)) and not math.isnan(float(value)):
                 metrics_samples.setdefault(key, []).append(float(value))
+
+    median_objective = float(statistics.median(objectives)) if objectives else None
+    _, _, iqr_objective = quantile_range(objectives)
 
     metrics_summary: Dict[str, Any] = {}
     for name, samples in sorted(metrics_samples.items()):
@@ -657,12 +563,14 @@ def summarise_candidate(
 
     metadata = {k: v for k, v in entry.items() if k != "params"}
 
+    fail_rate = float(failure_count / total_runs) if total_runs else 1.0
+
     summary = {
         "candidate_index": index,
         "params": params,
         "metadata": metadata,
         "num_runs": total_runs,
-        "num_failures": failures,
+        "num_failures": failure_count,
         "fail_rate": fail_rate,
         "median_objective": median_objective,
         "iqr_objective": iqr_objective,
@@ -736,8 +644,6 @@ def main() -> None:
     app_spec = parse_app_spec(spec_data, args.spec.parent)
     robustness_spec = parse_robustness(spec_data)
     objective_spec = parse_objective_spec(spec_data)
-    objective_evaluator = ObjectiveEvaluator(objective_spec, app_spec.frame_budget_ms)
-    hard_constraints = parse_hard_constraints(spec_data)
 
     param_specs = load_param_spec(args.spec)
 
@@ -750,14 +656,7 @@ def main() -> None:
         params_raw = candidate_params(entry)
         validated = validate_params(params_raw, param_specs)
         runs, raw_records = run_validation(app_spec, robustness_spec, validated, entry)
-        summary = summarise_candidate(
-            index,
-            entry,
-            validated,
-            runs,
-            objective_evaluator,
-            hard_constraints,
-        )
+        summary = summarise_candidate(index, entry, validated, runs, spec_data)
         summaries.append(summary)
         experiments_records.extend(raw_records)
 


### PR DESCRIPTION
## Summary
- add a shared common_eval module that centralizes constraint evaluation and objective computation for autotune specs
- update run_one, validate, and analyze to rely on the shared evaluation routines and surface constraint failures consistently
- adjust run_experiments to use the revised validation summary API

## Testing
- python -m compileall tools/autotune

------
https://chatgpt.com/codex/tasks/task_e_68e42d78128c832bbba1cfc9b975ff69