### PR TITLE
feat: centralize autotune host fingerprinting

### DIFF
--- a/tools/autotune/common_host.py
+++ b/tools/autotune/common_host.py
@@ -1,0 +1,144 @@
+"""Helpers for detecting and normalising host CPU/OS information."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import platform
+import re
+from functools import lru_cache
+from typing import Dict
+
+
+def _read_cpuinfo() -> list[str]:
+    cpuinfo_path = pathlib.Path("/proc/cpuinfo")
+    if not cpuinfo_path.exists():
+        return []
+    try:
+        return cpuinfo_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError:
+        return []
+
+
+def detect_cpu_model() -> str:
+    """Attempt to detect a descriptive CPU model string."""
+
+    candidates: list[str] = []
+
+    if (platform.system() or "").lower() == "linux":
+        for line in _read_cpuinfo():
+            key, sep, value = line.partition(":")
+            if not sep:
+                continue
+            lower_key = key.strip().lower()
+            candidate = value.strip()
+            if not candidate:
+                continue
+            if lower_key in {"model name", "hardware", "cpu part", "cpu model"}:
+                return candidate
+            if lower_key == "processor" and not candidate.isdigit():
+                candidates.append(candidate)
+
+    for getter in (
+        platform.processor,
+        platform.machine,
+        lambda: platform.uname().processor,
+        lambda: os.uname().machine if hasattr(os, "uname") else "",
+    ):
+        try:
+            value = getter()
+        except OSError:
+            continue
+        if value:
+            candidates.append(str(value))
+
+    for candidate in candidates:
+        cleaned = str(candidate).strip()
+        if cleaned:
+            return cleaned
+    return "unknown-cpu"
+
+
+def _normalise_os_token(value: str) -> str:
+    token = (value or "").strip().lower()
+    if token.startswith("linux") or token == "posix":
+        return "linux"
+    if token.startswith("win"):
+        return "windows"
+    if token.startswith("mac") or token.startswith("darwin") or token.startswith("osx"):
+        return "darwin"
+    if token == "nt":
+        return "windows"
+    if token in {"msys", "cygwin"}:
+        return "windows"
+    return token or "unknown-os"
+
+
+def detect_os_name() -> str:
+    """Return a normalised operating-system token."""
+
+    try:
+        primary = platform.system()
+    except OSError:
+        primary = ""
+    token = _normalise_os_token(primary)
+    if token != "unknown-os":
+        return token
+
+    if hasattr(os, "name"):
+        token = _normalise_os_token(os.name)
+        if token != "unknown-os":
+            return token
+
+    if hasattr(os, "uname"):
+        try:
+            uname_token = _normalise_os_token(os.uname().sysname)  # type: ignore[attr-defined]
+            if uname_token != "unknown-os":
+                return uname_token
+        except OSError:
+            pass
+
+    return "unknown-os"
+
+
+_slug_re = re.compile(r"[^a-z0-9_]+")
+_repeat_re = re.compile(r"_+")
+
+
+def normalise_os_name(name: str) -> str:
+    """Normalise an arbitrary OS string to a canonical token."""
+
+    return _normalise_os_token(name)
+
+
+def slugify_cpu(cpu_model: str) -> str:
+    """Convert a CPU model string to a filesystem-safe slug."""
+
+    text = (cpu_model or "unknown-cpu").lower()
+    text = text.replace("-", "_").replace(" ", "_")
+    text = _slug_re.sub("_", text)
+    text = _repeat_re.sub("_", text).strip("_")
+    return text or "unknown_cpu"
+
+
+@lru_cache(maxsize=1)
+def host_tokens() -> Dict[str, str]:
+    """Return the detected host CPU/OS identifiers used across tools."""
+
+    cpu_model = detect_cpu_model()
+    os_name = detect_os_name()
+    cpu_slug = slugify_cpu(cpu_model)
+    return {
+        "cpu_model": cpu_model,
+        "cpu_slug": cpu_slug,
+        "os_name": os_name,
+    }
+
+
+__all__ = [
+    "detect_cpu_model",
+    "detect_os_name",
+    "slugify_cpu",
+    "normalise_os_name",
+    "host_tokens",
+]

--- a/tools/autotune/install_profile.py
+++ b/tools/autotune/install_profile.py
@@ -6,18 +6,17 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import pathlib
-import platform
-import re
 import sys
 from typing import Any, Iterable, Mapping, Sequence
 
 if __package__ is None or __package__ == "":
     sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
     from tools.autotune.make_config import build_config
+    from tools.autotune import common_host
 else:
     from .make_config import build_config
+    from . import common_host
 
 
 
@@ -59,65 +58,6 @@ def parse_args() -> argparse.Namespace:
         help="Show the resolved destination without writing files.",
     )
     return parser.parse_args()
-
-
-def detect_cpu_model() -> str:
-    candidates: list[str] = []
-
-    cpuinfo = pathlib.Path("/proc/cpuinfo")
-    if cpuinfo.exists():
-        try:
-            for line in cpuinfo.read_text(encoding="utf-8", errors="ignore").splitlines():
-                key, sep, value = line.partition(":")
-                if not sep:
-                    continue
-                lower_key = key.strip().lower()
-                candidate = value.strip()
-                if lower_key in {"model name", "hardware", "cpu part"} and candidate:
-                    return candidate
-                if lower_key == "processor" and candidate and not candidate.isdigit():
-                    candidates.append(candidate)
-        except OSError:
-            pass
-
-    fallbacks = (
-        platform.processor,
-        platform.machine,
-        lambda: platform.uname().processor,
-    )
-    for getter in fallbacks:
-        try:
-            value = getter()
-        except OSError:
-            continue
-        if value:
-            candidates.append(str(value))
-
-    if candidates:
-        return candidates[0]
-    return "unknown-cpu"
-
-
-def detect_os_name() -> str:
-    try:
-        name = platform.system()
-    except OSError:
-        name = ""
-    if name:
-        return name
-    try:
-        return os.uname().sysname
-    except OSError:
-        return "unknown-os"
-
-
-def normalise_token(value: str) -> str:
-    cleaned = value.strip()
-    cleaned = "".join(
-        ch if ch.isalnum() or ch in {"-", "_"} else "-" for ch in cleaned
-    )
-    cleaned = re.sub(r"-+", "-", cleaned).strip("-")
-    return cleaned or "unknown"
 
 
 def extract_params(payload: Any) -> Mapping[str, Any] | None:
@@ -188,13 +128,17 @@ def main() -> None:
     params = load_best_params(search_paths)
     config = build_config(params)
 
-    cpu_name = args.cpu_override or detect_cpu_model()
-    os_name = args.os_override or detect_os_name()
+    tokens = common_host.host_tokens().copy()
+    if args.cpu_override:
+        override = args.cpu_override.strip()
+        tokens["cpu_model"] = override or tokens["cpu_model"]
+        tokens["cpu_slug"] = common_host.slugify_cpu(override or tokens["cpu_model"])
+    if args.os_override:
+        override_os = args.os_override.strip()
+        if override_os:
+            tokens["os_name"] = common_host.normalise_os_name(override_os)
 
-    cpu_token = normalise_token(cpu_name)
-    os_token = normalise_token(os_name)
-
-    destination = args.profiles_dir / f"{cpu_token}-{os_token}.json"
+    destination = args.profiles_dir / f"{tokens['cpu_slug']}-{tokens['os_name']}.json"
 
     if args.dry_run:
         print(destination)

--- a/tools/autotune/run_experiments.py
+++ b/tools/autotune/run_experiments.py
@@ -10,7 +10,6 @@ import json
 import math
 import os
 import pathlib
-import platform
 import random
 import statistics
 import subprocess
@@ -27,6 +26,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from tools.autotune import screening  # noqa: E402
+from tools.autotune import common_host  # noqa: E402
 from tools.autotune.common_io import append_jsonl as append_jsonl_record  # noqa: E402
 from tools.autotune.make_config import (  # noqa: E402
     build_config,
@@ -290,9 +290,13 @@ def detect_baseline_source(app: AppSpec, results_dir: pathlib.Path) -> Optional[
                     params=params,
                 )
 
-    cpu = sanitise_filename(platform.machine() or "cpu")
-    system = sanitise_filename(platform.system() or "os")
-    machine_candidates = [f"{cpu}-{system}.json", f"{cpu}-{system}"]
+    tokens = common_host.host_tokens()
+    cpu_slug = tokens["cpu_slug"]
+    os_name = tokens["os_name"]
+    machine_candidates = [
+        f"{cpu_slug}-{os_name}.json",
+        f"{cpu_slug}-{os_name}",
+    ]
     for name in machine_candidates:
         for directory in directories:
             candidate = directory / name
@@ -1117,9 +1121,8 @@ def main() -> None:
     if not isinstance(best_params_final, Mapping):
         best_params_final = {}
 
-    cpu = sanitise_filename(platform.machine() or "cpu")
-    system = sanitise_filename(platform.system() or "os")
-    profile_path = profiles_dir / f"{cpu}-{system}.json"
+    tokens = common_host.host_tokens()
+    profile_path = profiles_dir / f"{tokens['cpu_slug']}-{tokens['os_name']}.json"
 
     subprocess.run(
         [

--- a/tools/autotune/run_one.py
+++ b/tools/autotune/run_one.py
@@ -9,7 +9,6 @@ import json
 import math
 import os
 import pathlib
-import platform
 import subprocess
 import sys
 from typing import Any, Dict, Iterable, List, Mapping, Optional
@@ -20,6 +19,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from tools.autotune.make_config import load_simple_yaml  # noqa: E402
+from tools.autotune import common_host  # noqa: E402
 from tools.autotune.common_eval import (  # noqa: E402
     compute_objective,
     evaluate_constraints,
@@ -221,15 +221,9 @@ def extract_scenario(config_data: Dict[str, Any], config_path: pathlib.Path) -> 
 
 
 def collect_env_info() -> Dict[str, Any]:
-    uname = platform.uname()
-    cpu_name = uname.processor or uname.machine or "unknown"
+    tokens = common_host.host_tokens()
     cores = os.cpu_count() or 0
-    os_name = platform.platform()
-    return {
-        "cpu": str(cpu_name),
-        "cores": int(cores),
-        "os": str(os_name),
-    }
+    return {**tokens, "cores": int(cores)}
 
 
 def extract_metrics(payload: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add a shared autotune.common_host helper to detect CPU/OS info and provide slugs
- refactor run_one, run_experiments, and install_profile to rely on the shared host tokens for env metadata and profile paths

## Testing
- python -m compileall tools/autotune/common_host.py tools/autotune/run_one.py tools/autotune/run_experiments.py tools/autotune/install_profile.py

------
https://chatgpt.com/codex/tasks/task_e_68e5af5dbb80832bac887b7f534b100f