### PR TITLE
Add autotune mapping coverage check

### DIFF
--- a/tools/autotune/check_mapping_coverage.py
+++ b/tools/autotune/check_mapping_coverage.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Validate that every autotune spec parameter is mapped into the runtime config.
+
+When introducing new knobs in spec.yaml, extend tools.autotune.make_config.MAPPED_PARAMS
+so this check continues to pass (or add well-justified entries to IGNORED_PARAMS).
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+from typing import Set
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.autotune.make_config import MAPPED_PARAMS, load_spec  # noqa: E402
+
+
+DEFAULT_SPEC_PATH = pathlib.Path(__file__).with_name("spec.yaml")
+
+# Parameters that are intentionally left unmapped. Keep this list small and
+# document the reason for each ignore entry if used.
+IGNORED_PARAMS: Set[str] = set()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Ensure autotune spec parameters have config mappings"
+    )
+    parser.add_argument(
+        "--spec",
+        type=pathlib.Path,
+        default=DEFAULT_SPEC_PATH,
+        help=f"Path to spec.yaml (default: {DEFAULT_SPEC_PATH})",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    specs = load_spec(args.spec)
+    spec_params = set(specs.keys())
+    mapped_params = set(MAPPED_PARAMS)
+
+    extra_ignored = IGNORED_PARAMS - spec_params
+    if extra_ignored:
+        print(
+            "IGNORED_PARAMS references names not present in the spec: "
+            f"{', '.join(sorted(extra_ignored))}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    uncovered = spec_params - mapped_params - IGNORED_PARAMS
+    if uncovered:
+        print("Unmapped autotune parameters detected:", file=sys.stderr)
+        for name in sorted(uncovered):
+            print(f"  - {name}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/autotune/make_config.py
+++ b/tools/autotune/make_config.py
@@ -101,10 +101,32 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Convert autotune parameters into runtime configuration JSON."
     )
-    parser.add_argument("--spec", required=True, type=pathlib.Path)
-    parser.add_argument("--params-json", required=True)
-    parser.add_argument("--out", required=True, type=pathlib.Path)
-    return parser.parse_args()
+    parser.add_argument("--spec", type=pathlib.Path)
+    parser.add_argument("--params-json")
+    parser.add_argument("--out", type=pathlib.Path)
+    parser.add_argument(
+        "--dump-mapped-params",
+        action="store_true",
+        help=(
+            "Print the names of parameters mapped by build_config and exit. "
+            "Useful for coverage checks."
+        ),
+    )
+    args = parser.parse_args()
+
+    if not args.dump_mapped_params:
+        missing = [
+            flag
+            for flag in ("spec", "params_json", "out")
+            if getattr(args, flag) is None
+        ]
+        if missing:
+            parser.error(
+                "--spec, --params-json and --out are required unless "
+                "--dump-mapped-params is provided"
+            )
+
+    return args
 
 
 def parse_scalar(token: str) -> Any:
@@ -332,23 +354,30 @@ def set_path(target: MutableMapping[str, Any], path: Iterable[str], value: Any) 
     current[leaf] = value
 
 
+PARAM_TO_CONFIG_PATH: Mapping[str, Tuple[str, ...]] = {
+    "threads": ("threads",),
+    "chunk_target_us": ("chunking", "target_p90_us"),
+    "aosoa_block": ("layout", "aosoa_block"),
+    "steal_threshold": ("scheduler", "steal_threshold"),
+    "prefetch_distance_bytes": ("prefetch", "distance_bytes"),
+    "fma_mode": ("numerics", "fma"),
+    "arena_per_thread_mb": ("memory", "arena_per_thread_mb"),
+    "huge_pages": ("memory", "huge_pages"),
+    "emergency_spawn_enabled": ("scheduler", "emergency_spawn"),
+    "governor_target_util": ("governor", "target_util"),
+    "governor_hysteresis": ("governor", "hysteresis"),
+}
+
+#: Names of autotune parameters that build_config knows how to translate. When
+#: adding new knobs to spec.yaml, extend this set (and PARAM_TO_CONFIG_PATH) so
+#: coverage checks continue to pass.
+MAPPED_PARAMS = frozenset(PARAM_TO_CONFIG_PATH.keys())
+
+
 def build_config(params: Mapping[str, Any]) -> Dict[str, Any]:
     config: Dict[str, Any] = {}
-    mapping = {
-        "threads": ("threads",),
-        "chunk_target_us": ("chunking", "target_p90_us"),
-        "aosoa_block": ("layout", "aosoa_block"),
-        "steal_threshold": ("scheduler", "steal_threshold"),
-        "prefetch_distance_bytes": ("prefetch", "distance_bytes"),
-        "fma_mode": ("numerics", "fma"),
-        "arena_per_thread_mb": ("memory", "arena_per_thread_mb"),
-        "huge_pages": ("memory", "huge_pages"),
-        "emergency_spawn_enabled": ("scheduler", "emergency_spawn"),
-        "governor_target_util": ("governor", "target_util"),
-        "governor_hysteresis": ("governor", "hysteresis"),
-    }
 
-    for name, path in mapping.items():
+    for name, path in PARAM_TO_CONFIG_PATH.items():
         if name not in params:
             continue
         set_path(config, path, params[name])
@@ -371,6 +400,10 @@ def write_json(path: pathlib.Path, data: Mapping[str, Any]) -> None:
 
 def main() -> None:
     args = parse_args()
+    if args.dump_mapped_params:
+        for name in sorted(MAPPED_PARAMS):
+            print(name)
+        return
     specs = load_spec(args.spec)
     params = parse_params(args.params_json)
     validated = validate_params(params, specs)


### PR DESCRIPTION
## Summary
- add a tooling script that fails when spec.yaml parameters are not mapped
- expose the mapped parameter list from make_config.py for reuse by tooling

## Testing
- python tools/autotune/make_config.py --dump-mapped-params
- python tools/autotune/check_mapping_coverage.py

------
https://chatgpt.com/codex/tasks/task_e_68e5cf54be98832b86a4aeec5e101959