### PR TITLE
Add mapping smoke checks and schema validation

### DIFF
--- a/tools/autotune/config.schema.json
+++ b/tools/autotune/config.schema.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Autotune runtime configuration",
+  "type": "object",
+  "required": [
+    "threads",
+    "chunking",
+    "layout",
+    "scheduler",
+    "prefetch",
+    "memory",
+    "numerics",
+    "governor",
+    "params"
+  ],
+  "properties": {
+    "threads": {
+      "type": "string"
+    },
+    "chunking": {
+      "type": "object",
+      "required": ["target_p90_us"],
+      "properties": {
+        "target_p90_us": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": true
+    },
+    "layout": {
+      "type": "object",
+      "required": ["aosoa_block"],
+      "properties": {
+        "aosoa_block": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": true
+    },
+    "scheduler": {
+      "type": "object",
+      "required": ["steal_threshold"],
+      "properties": {
+        "steal_threshold": {
+          "type": "integer"
+        },
+        "emergency_spawn": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
+    "prefetch": {
+      "type": "object",
+      "required": ["distance_bytes", "enabled"],
+      "properties": {
+        "distance_bytes": {
+          "type": "integer"
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
+    "memory": {
+      "type": "object",
+      "required": ["arena_per_thread_mb", "huge_pages"],
+      "properties": {
+        "arena_per_thread_mb": {
+          "type": "integer"
+        },
+        "huge_pages": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": true
+    },
+    "numerics": {
+      "type": "object",
+      "required": ["fma"],
+      "properties": {
+        "fma": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true
+    },
+    "governor": {
+      "type": "object",
+      "required": ["target_util", "hysteresis"],
+      "properties": {
+        "target_util": {
+          "type": "number"
+        },
+        "hysteresis": {
+          "type": "number"
+        }
+      },
+      "additionalProperties": true
+    },
+    "params": {
+      "type": "object"
+    }
+  },
+  "additionalProperties": true
+}

--- a/tools/autotune/make_config.py
+++ b/tools/autotune/make_config.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import math
 import pathlib
+import tempfile
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Tuple
 
@@ -112,9 +113,15 @@ def parse_args() -> argparse.Namespace:
             "Useful for coverage checks."
         ),
     )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run internal sanity checks and exit",
+    )
+
     args = parser.parse_args()
 
-    if not args.dump_mapped_params:
+    if not args.dump_mapped_params and not args.self_test:
         missing = [
             flag
             for flag in ("spec", "params_json", "out")
@@ -398,11 +405,56 @@ def write_json(path: pathlib.Path, data: Mapping[str, Any]) -> None:
         fh.write("\n")
 
 
+def run_self_test() -> None:
+    spec_path = pathlib.Path(__file__).with_name("spec.yaml")
+    specs = load_spec(spec_path)
+
+    sample_params = {
+        "threads": "physical",
+        "chunk_target_us": 140,
+        "aosoa_block": 256,
+        "steal_threshold": 3,
+        "prefetch_distance_bytes": 256,
+        "huge_pages": True,
+        "governor_target_util": 0.9,
+        "governor_hysteresis": 0.02,
+        "fma_mode": "on",
+        "emergency_spawn_enabled": False,
+        "arena_per_thread_mb": 64,
+    }
+
+    payload = json.dumps(sample_params)
+    parsed = parse_params(payload)
+    validated = validate_params(parsed, specs)
+    config = build_config(validated)
+
+    prefetch_enabled = config.get("prefetch", {}).get("enabled")
+    if prefetch_enabled is not True:
+        raise SystemExit("prefetch.enabled should be true when distance_bytes > 0")
+
+    zero_params = dict(validated)
+    zero_params["prefetch_distance_bytes"] = 0
+    zero_config = build_config(zero_params)
+    zero_prefetch = zero_config.get("prefetch", {}).get("enabled")
+    if zero_prefetch is not False:
+        raise SystemExit("prefetch.enabled should be false when distance_bytes == 0")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = pathlib.Path(tmpdir) / "config.json"
+        write_json(path, config)
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    if loaded != config:
+        raise SystemExit("write_json did not round-trip configuration data")
+
+
 def main() -> None:
     args = parse_args()
     if args.dump_mapped_params:
         for name in sorted(MAPPED_PARAMS):
             print(name)
+        return
+    if args.self_test:
+        run_self_test()
         return
     specs = load_spec(args.spec)
     params = parse_params(args.params_json)

--- a/tools/autotune/mapping_smoke.py
+++ b/tools/autotune/mapping_smoke.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Fast integration checks for autotune parameter mapping."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+from typing import Any, Dict, Iterable, Tuple
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+TOOLS_DIR = pathlib.Path(__file__).resolve().parent
+MAKE_CONFIG = TOOLS_DIR / "make_config.py"
+VALIDATE_MAPPING = TOOLS_DIR / "validate_config_mapping.py"
+CONFIG_SCHEMA = TOOLS_DIR / "config.schema.json"
+SPEC_PATH = TOOLS_DIR / "spec.yaml"
+
+
+class StepError(RuntimeError):
+    """Raised when a smoke step fails."""
+
+
+def _run_command(name: str, args: Iterable[str]) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            list(args),
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        return result
+    except subprocess.CalledProcessError as exc:
+        output = exc.stderr.strip() or exc.stdout.strip()
+        detail = f"{name} failed with exit code {exc.returncode}"
+        if output:
+            detail = f"{detail}: {output}"
+        raise StepError(detail) from exc
+
+
+def run_make_config_self_test() -> None:
+    _run_command("make_config self-test", [sys.executable, str(MAKE_CONFIG), "--self-test"])
+
+
+def generate_config(params: Dict[str, Any], output_path: pathlib.Path) -> None:
+    payload = json.dumps(params, sort_keys=True)
+    _run_command(
+        "make_config", 
+        [
+            sys.executable,
+            str(MAKE_CONFIG),
+            "--spec",
+            str(SPEC_PATH),
+            "--params-json",
+            payload,
+            "--out",
+            str(output_path),
+        ],
+    )
+
+
+def validate_config(path: pathlib.Path) -> None:
+    _run_command(
+        "validate_config_mapping",
+        [
+            sys.executable,
+            str(VALIDATE_MAPPING),
+            "--schema",
+            str(CONFIG_SCHEMA),
+            "--config",
+            str(path),
+        ],
+    )
+
+
+def check_prefetch_disabled(path: pathlib.Path) -> None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    enabled = data.get("prefetch", {}).get("enabled")
+    if enabled is not False:
+        raise StepError("prefetch.enabled should be false when distance_bytes == 0")
+
+
+def run_mapping_coverage_check() -> None:
+    script = TOOLS_DIR / "check_mapping_coverage.py"
+    _run_command("check_mapping_coverage", [sys.executable, str(script)])
+
+
+def main() -> int:
+    try:
+        run_make_config_self_test()
+        param_sets: Tuple[Tuple[str, Dict[str, Any]], ...] = (
+            (
+                "prefetch-positive",
+                {
+                    "threads": "physical",
+                    "chunk_target_us": 140,
+                    "aosoa_block": 256,
+                    "steal_threshold": 3,
+                    "prefetch_distance_bytes": 256,
+                    "huge_pages": True,
+                    "governor_target_util": 0.9,
+                    "governor_hysteresis": 0.02,
+                    "fma_mode": "on",
+                    "emergency_spawn_enabled": False,
+                    "arena_per_thread_mb": 64,
+                },
+            ),
+            (
+                "prefetch-zero",
+                {
+                    "threads": "physical",
+                    "chunk_target_us": 140,
+                    "aosoa_block": 256,
+                    "steal_threshold": 3,
+                    "prefetch_distance_bytes": 0,
+                    "huge_pages": True,
+                    "governor_target_util": 0.9,
+                    "governor_hysteresis": 0.02,
+                    "fma_mode": "on",
+                    "emergency_spawn_enabled": False,
+                    "arena_per_thread_mb": 64,
+                },
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir_path = pathlib.Path(tmpdir)
+            for name, params in param_sets:
+                out_path = tmpdir_path / f"{name}.json"
+                generate_config(params, out_path)
+                validate_config(out_path)
+                if name == "prefetch-zero":
+                    check_prefetch_disabled(out_path)
+        run_mapping_coverage_check()
+    except StepError as exc:
+        print(f"MAPPING SMOKE FAILED: {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive guard
+        print(f"MAPPING SMOKE FAILED: unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+    print("MAPPING SMOKE OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/autotune/validate_config_mapping.py
+++ b/tools/autotune/validate_config_mapping.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Validate generated mapping configs against a JSON schema."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+from typing import Any, Mapping
+
+DEFAULT_SCHEMA_PATH = pathlib.Path(__file__).with_name("config.schema.json")
+
+
+class ValidationError(Exception):
+    """Raised when a payload does not satisfy the schema."""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate mapping configuration files against a schema",
+    )
+    parser.add_argument(
+        "--schema",
+        type=pathlib.Path,
+        default=DEFAULT_SCHEMA_PATH,
+        help=f"Path to config schema (default: {DEFAULT_SCHEMA_PATH})",
+    )
+    parser.add_argument(
+        "--config",
+        type=pathlib.Path,
+        required=True,
+        help="Path to the generated configuration JSON",
+    )
+    return parser.parse_args()
+
+
+def load_json(path: pathlib.Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except FileNotFoundError as exc:
+        raise SystemExit(f"File not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Failed to parse JSON from {path}: {exc}") from exc
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _is_integer(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _validate_type(value: Any, expected: str, path: str) -> None:
+    if expected == "object":
+        if not isinstance(value, Mapping):
+            raise ValidationError(f"{path} must be an object")
+        return
+    if expected == "array":
+        if not isinstance(value, list):
+            raise ValidationError(f"{path} must be an array")
+        return
+    if expected == "string":
+        if not isinstance(value, str):
+            raise ValidationError(f"{path} must be a string")
+        return
+    if expected == "integer":
+        if not _is_integer(value):
+            raise ValidationError(f"{path} must be an integer")
+        return
+    if expected == "number":
+        if not _is_number(value):
+            raise ValidationError(f"{path} must be a number")
+        return
+    if expected == "boolean":
+        if not isinstance(value, bool):
+            raise ValidationError(f"{path} must be a boolean")
+        return
+    if expected == "null":
+        if value is not None:
+            raise ValidationError(f"{path} must be null")
+        return
+    raise ValidationError(f"{path} uses unsupported schema type '{expected}'")
+
+
+def validate(instance: Any, schema: Mapping[str, Any], path: str = "$") -> None:
+    schema_type = schema.get("type")
+    if isinstance(schema_type, str):
+        _validate_type(instance, schema_type, path)
+    if "enum" in schema:
+        options = schema["enum"]
+        if instance not in options:
+            raise ValidationError(f"{path} must be one of {options!r}")
+    if schema_type == "object" or (
+        schema_type is None and "properties" in schema
+    ):
+        if not isinstance(instance, Mapping):
+            raise ValidationError(f"{path} must be an object")
+        required = schema.get("required", [])
+        for name in required:
+            if name not in instance:
+                raise ValidationError(f"{path}.{name} is a required property")
+        properties = schema.get("properties", {})
+        additional = schema.get("additionalProperties", True)
+        for key, value in instance.items():
+            if key in properties:
+                child_path = f"{path}.{key}"
+                validate(value, properties[key], child_path)
+            else:
+                if isinstance(additional, Mapping):
+                    child_path = f"{path}.{key}"
+                    validate(value, additional, child_path)
+                elif additional is False:
+                    raise ValidationError(f"{path}.{key} is not an allowed property")
+        return
+    if schema_type == "array" or (
+        schema_type is None and "items" in schema
+    ):
+        if not isinstance(instance, list):
+            raise ValidationError(f"{path} must be an array")
+        item_schema = schema.get("items")
+        if item_schema is not None:
+            for index, item in enumerate(instance):
+                child_path = f"{path}[{index}]"
+                validate(item, item_schema, child_path)
+        return
+    if schema_type in {"string", "integer", "number", "boolean", "null"}:
+        return
+    if schema_type is None:
+        return
+    raise ValidationError(f"{path} uses unsupported schema construction")
+
+
+def main() -> None:
+    args = parse_args()
+    schema_payload = load_json(args.schema)
+    config_payload = load_json(args.config)
+
+    try:
+        validate(config_payload, schema_payload, "$")
+    except ValidationError as exc:
+        print(f"Validation failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a --self-test mode to make_config.py to validate prefetched mapping logic
- add a JSON schema and validator for generated runtime configs
- wire the new mapping_smoke.py script to run the self-test, schema validation, and coverage checks

## Testing
- python tools/autotune/mapping_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68e5d85da918832bb98ed3ddcc24bddb