### PR TITLE
Add autotune mapping CI workflow

### DIFF
--- a/.github/workflows/autotune-mapping.yml
+++ b/.github/workflows/autotune-mapping.yml
@@ -1,0 +1,24 @@
+name: AT-MAP5
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  autotune-mapping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Run autotune mapping self-test
+        run: |
+          python tools/autotune/make_config.py --self-test
+          python tools/autotune/mapping_smoke.py


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that exercises the autotune mapping smoke tests on push and PR

## Testing
- python tools/autotune/make_config.py --self-test
- python tools/autotune/mapping_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68e5e396fa80832babdbf4aeb9baf969