### PR TITLE
Add guardrails for autotune objective evaluation

### DIFF
--- a/tools/autotune/common_eval.py
+++ b/tools/autotune/common_eval.py
@@ -9,6 +9,13 @@ SAFE_GLOBALS = {"__builtins__": {}}
 SAFE_FUNCTIONS = {"min": min, "max": max, "abs": abs, "math": math}
 
 
+class ObjectiveEvaluationError(ValueError):
+    """Raised when the objective expression cannot be evaluated safely."""
+
+
+OBJECTIVE_ERROR_EXIT_CODE = 97
+
+
 class ExpressionEvaluator:
     def __init__(self, expression: str, *, label: str = "<expression>") -> None:
         prepared = (expression or "").strip()
@@ -177,7 +184,7 @@ def evaluate_constraints(
 
 def compute_objective(spec: Mapping[str, Any], metrics: Mapping[str, Any]) -> float:
     if not isinstance(metrics, Mapping):
-        return math.inf
+        raise ObjectiveEvaluationError("Objective metrics payload must be a mapping")
     frame_budget = _resolve_frame_budget(spec, metrics)
     context: Dict[str, Any] = dict(metrics)
     if frame_budget is not None and "frame_budget_ms" not in context:
@@ -190,12 +197,28 @@ def compute_objective(spec: Mapping[str, Any], metrics: Mapping[str, Any]) -> fl
             return math.inf
     expr = _objective_expression(spec)
     evaluator = ExpressionEvaluator(expr, label="<objective>")
+
+    referenced_names = {
+        name
+        for name in getattr(evaluator, "_code").co_names
+        if name not in SAFE_FUNCTIONS
+    }
+    missing = sorted(name for name in referenced_names if name not in context)
+    if missing:
+        formatted = ", ".join(missing)
+        raise ObjectiveEvaluationError(
+            f"Objective expression '{expr}' references unknown identifiers: {formatted}"
+        )
     try:
         value = evaluator(context)
-    except (NameError, ValueError, TypeError, ZeroDivisionError, OverflowError):
-        return math.inf
-    if math.isnan(value):
-        return math.inf
+    except (NameError, ValueError, TypeError, ZeroDivisionError, OverflowError) as exc:
+        raise ObjectiveEvaluationError(
+            f"Objective expression '{expr}' could not be evaluated: {exc}"
+        ) from exc
+    if math.isnan(value) or math.isinf(value):
+        raise ObjectiveEvaluationError(
+            "Objective evaluated to NaN/Inf; check spec or metrics keys"
+        )
     return float(value)
 
 
@@ -205,4 +228,6 @@ __all__ = [
     "parse_hard_constraints",
     "evaluate_constraints",
     "compute_objective",
+    "ObjectiveEvaluationError",
+    "OBJECTIVE_ERROR_EXIT_CODE",
 ]

--- a/tools/autotune/run_experiments.py
+++ b/tools/autotune/run_experiments.py
@@ -37,6 +37,10 @@ from tools.autotune.make_config import (  # noqa: E402
 )
 from tools.autotune.optimize import AppSpec, ObjectiveSpec, parse_app_spec, parse_objective_spec  # noqa: E402
 from tools.autotune.optimize import ExpressionEvaluator  # type: ignore[attr-defined]  # noqa: E402
+from tools.autotune.common_eval import (  # noqa: E402
+    OBJECTIVE_ERROR_EXIT_CODE,
+    ObjectiveEvaluationError,
+)
 from tools.autotune.validate import (  # noqa: E402
     RobustnessSpec,
     parse_robustness,
@@ -677,6 +681,9 @@ def run_single(app: AppSpec, config_path: pathlib.Path, spec_path: pathlib.Path)
     except subprocess.CalledProcessError as exc:
         stdout = exc.stdout.strip() if exc.stdout else ""
         stderr = exc.stderr.strip() if exc.stderr else ""
+        if exc.returncode == OBJECTIVE_ERROR_EXIT_CODE:
+            message = stderr or stdout or "Objective evaluation failed"
+            raise ObjectiveEvaluationError(message) from exc
         reason_parts = ["run_one failed"]
         if stdout:
             reason_parts.append(f"stdout: {stdout}")
@@ -843,10 +850,11 @@ def compute_spec_digest(
     return digest.hexdigest()
 
 
-def main() -> None:
-    args = parse_args()
-
-    spec_path = args.spec.resolve()
+def _run_pipeline(
+    args: argparse.Namespace,
+    spec_path: pathlib.Path,
+    error_context: Dict[str, Optional[str]],
+) -> None:
     if not spec_path.is_file():
         raise SystemExit(f"Spec file not found: {spec_path}")
 
@@ -871,6 +879,7 @@ def main() -> None:
     metadata_overrides = {"app_overrides": dict(app_overrides)} if app_overrides else {}
 
     objective_spec = parse_objective_spec(spec_data)
+    error_context["objective_expr"] = objective_spec.expression
     objective_eval = ExpressionEvaluator(objective_spec.expression)
     tiebreakers_eval = [ExpressionEvaluator(expr) for expr in objective_spec.tiebreakers]
 
@@ -897,7 +906,13 @@ def main() -> None:
         rng=rng,
     )
     screen_candidates_path = results_dir / "screening_candidates.json"
-    write_json_file(screen_candidates_path, {"generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(), "candidates": screen_candidates})
+    write_json_file(
+        screen_candidates_path,
+        {
+            "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "candidates": screen_candidates,
+        },
+    )
 
     for index, candidate in enumerate(screen_candidates):
         metadata = {**metadata_overrides, "source": "screen", "index": index}
@@ -1055,7 +1070,13 @@ def main() -> None:
                         ordered_runs.append(run)
             run_records = ordered_runs
             runs = ordered_runs
-            aggregated = aggregate_runs(runs, objective_spec, objective_eval, tiebreakers_eval, app_spec.frame_budget_ms)
+            aggregated = aggregate_runs(
+                runs,
+                objective_spec,
+                objective_eval,
+                tiebreakers_eval,
+                app_spec.frame_budget_ms,
+            )
             record = {
                 "stage": "validate",
                 "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
@@ -1168,6 +1189,22 @@ def main() -> None:
         "app_overrides": app_overrides,
     }
     print(json.dumps(ci_summary, sort_keys=True))
+
+
+def main() -> None:
+    args = parse_args()
+    spec_path = args.spec.resolve()
+    error_context: Dict[str, Optional[str]] = {"objective_expr": None}
+    try:
+        _run_pipeline(args, spec_path, error_context)
+    except ObjectiveEvaluationError as exc:
+        expression = error_context.get("objective_expr") or "<unknown>"
+        message = str(exc).strip() or "Objective evaluation failed"
+        print(
+            f"Objective evaluation error for spec '{spec_path}': expression '{expression}' failed: {message}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2) from exc
 
 
 if __name__ == "__main__":

--- a/tools/autotune/run_one.py
+++ b/tools/autotune/run_one.py
@@ -21,6 +21,8 @@ if str(REPO_ROOT) not in sys.path:
 from tools.autotune.make_config import load_simple_yaml  # noqa: E402
 from tools.autotune import common_host  # noqa: E402
 from tools.autotune.common_eval import (  # noqa: E402
+    OBJECTIVE_ERROR_EXIT_CODE,
+    ObjectiveEvaluationError,
     compute_objective,
     evaluate_constraints,
 )
@@ -340,7 +342,11 @@ def main() -> None:
     constraint_metrics.update(metrics_summary)
 
     ok, failures = evaluate_constraints(spec_data, constraint_metrics)
-    objective = compute_objective(spec_data, constraint_metrics)
+    try:
+        objective = compute_objective(spec_data, constraint_metrics)
+    except ObjectiveEvaluationError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(OBJECTIVE_ERROR_EXIT_CODE) from exc
     failure_messages = [details["message"] for details in failures.values()]
     if failures:
         objective = math.inf


### PR DESCRIPTION
## Summary
- fail fast when objective expressions reference missing data or evaluate to NaN/Inf by raising `ObjectiveEvaluationError`
- propagate objective evaluation failures from `run_one` through `run_experiments` and emit a clear message with the spec path and expression

## Testing
- python -m compileall tools/autotune

------
https://chatgpt.com/codex/tasks/task_e_68e5e4089594832bbf546f2760213692