### PR TITLE
Normalize autotune host token handling

### DIFF
--- a/docs/DOE_AUTOTUNE.md
+++ b/docs/DOE_AUTOTUNE.md
@@ -39,7 +39,7 @@ The workflow writes three directories at the repository root:
 
 | Directory | Purpose | Key files |
 | --- | --- | --- |
-| `profiles/` | Drop-in machine profiles named `<cpu>-<os>.json`. The runtime auto-loads these alongside stock `default_safe`/`default_fast`. | `profiles/x86_64-Linux.json` (example) |
+| `profiles/` | Drop-in machine profiles named `<cpu>-<os>.json`. The runtime auto-loads these alongside stock `default_safe`/`default_fast`. | `profiles/zen3_linux-linux.json` (example) |
 | `results/` | Raw experiment log and orchestration breadcrumbs suitable for CI diffing or ad-hoc plots. | `experiments.jsonl`, `summary.json`, `top_candidates.json`, `validation_summary.json` |
 | `reports/` | Aggregated analytics from `tools/autotune/analyze.py` — Pareto sets, CSV summaries, best run report. | `pareto.json`, `summary.csv`, `best.json` |
 
@@ -61,7 +61,13 @@ For one-off sweeps or custom analytics, inspect `results/experiments.jsonl` with
 After the run finishes, copy the generated profile into your deployment target or point `RTFW_PROFILE` at the emitted JSON. The runtime loads this alongside existing configs:
 
 ```bash
-RTFW_PROFILE=$(uname -m)-$(uname -s) ./build/bin/rtfw_demo --rt --metrics-json
+PROFILE_NAME=$(python3 - <<'PY'
+from tools.autotune import common_host
+tokens = common_host.host_tokens()
+print(f"{tokens['cpu_slug']}-{tokens['os_name']}.json")
+PY
+)
+RTFW_PROFILE=$PROFILE_NAME ./build/bin/rtfw_demo --rt --metrics-json
 ```
 
 Because the profile was derived from interval metrics, keep monitoring both cumulative and interval outputs in production to ensure no long-horizon drift.

--- a/tools/autotune/common_host.py
+++ b/tools/autotune/common_host.py
@@ -121,13 +121,32 @@ def slugify_cpu(cpu_model: str) -> str:
     return text or "unknown_cpu"
 
 
-@lru_cache(maxsize=1)
-def host_tokens() -> Dict[str, str]:
+@lru_cache(maxsize=None)
+def _host_tokens_cached(cpu_override: str, os_override: str) -> tuple[str, str, str]:
+    """Internal helper to memoise host token detection and overrides."""
+
+    cpu_model = cpu_override or detect_cpu_model()
+    if cpu_model:
+        cpu_model = cpu_model.strip() or detect_cpu_model()
+    else:
+        cpu_model = detect_cpu_model()
+
+    os_name = os_override or detect_os_name()
+    if os_name:
+        os_name = normalise_os_name(os_name)
+    else:
+        os_name = detect_os_name()
+
+    cpu_slug = slugify_cpu(cpu_model)
+    return cpu_model, cpu_slug, os_name
+
+
+def host_tokens(cpu_override: str | None = None, os_override: str | None = None) -> Dict[str, str]:
     """Return the detected host CPU/OS identifiers used across tools."""
 
-    cpu_model = detect_cpu_model()
-    os_name = detect_os_name()
-    cpu_slug = slugify_cpu(cpu_model)
+    cpu_arg = (cpu_override or "").strip()
+    os_arg = (os_override or "").strip()
+    cpu_model, cpu_slug, os_name = _host_tokens_cached(cpu_arg, os_arg)
     return {
         "cpu_model": cpu_model,
         "cpu_slug": cpu_slug,

--- a/tools/autotune/install_profile.py
+++ b/tools/autotune/install_profile.py
@@ -128,17 +128,12 @@ def main() -> None:
     params = load_best_params(search_paths)
     config = build_config(params)
 
-    tokens = common_host.host_tokens().copy()
-    if args.cpu_override:
-        override = args.cpu_override.strip()
-        tokens["cpu_model"] = override or tokens["cpu_model"]
-        tokens["cpu_slug"] = common_host.slugify_cpu(override or tokens["cpu_model"])
-    if args.os_override:
-        override_os = args.os_override.strip()
-        if override_os:
-            tokens["os_name"] = common_host.normalise_os_name(override_os)
-
-    destination = args.profiles_dir / f"{tokens['cpu_slug']}-{tokens['os_name']}.json"
+    tokens = common_host.host_tokens(
+        cpu_override=args.cpu_override,
+        os_override=args.os_override,
+    )
+    profile_filename = f"{tokens['cpu_slug']}-{tokens['os_name']}.json"
+    destination = args.profiles_dir / profile_filename
 
     if args.dry_run:
         print(destination)

--- a/tools/autotune/run_experiments.py
+++ b/tools/autotune/run_experiments.py
@@ -291,12 +291,10 @@ def detect_baseline_source(app: AppSpec, results_dir: pathlib.Path) -> Optional[
                 )
 
     tokens = common_host.host_tokens()
-    cpu_slug = tokens["cpu_slug"]
-    os_name = tokens["os_name"]
-    machine_candidates = [
-        f"{cpu_slug}-{os_name}.json",
-        f"{cpu_slug}-{os_name}",
-    ]
+    profile_filename = f"{tokens['cpu_slug']}-{tokens['os_name']}.json"
+    machine_candidates = [profile_filename]
+    if profile_filename.endswith(".json"):
+        machine_candidates.append(profile_filename[:-5])
     for name in machine_candidates:
         for directory in directories:
             candidate = directory / name
@@ -1122,7 +1120,8 @@ def main() -> None:
         best_params_final = {}
 
     tokens = common_host.host_tokens()
-    profile_path = profiles_dir / f"{tokens['cpu_slug']}-{tokens['os_name']}.json"
+    profile_filename = f"{tokens['cpu_slug']}-{tokens['os_name']}.json"
+    profile_path = profiles_dir / profile_filename
 
     subprocess.run(
         [


### PR DESCRIPTION
## Summary
- extend common_host.host_tokens to centralize CPU/OS overrides and slug generation
- update run_experiments and install_profile to share the same profile filename logic
- refresh documentation snippets to show the new canonical host token usage

## Testing
- python3 -m compileall tools/autotune/common_host.py tools/autotune/install_profile.py tools/autotune/run_experiments.py

------
https://chatgpt.com/codex/tasks/task_e_68e5e417e4ec832b92c63df2dda7846c