### PR TITLE
Docs: document autotune mapping coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,16 @@ The orchestration script screens the parameter space, runs local search, validat
 
 See [`docs/DOE_AUTOTUNE.md`](docs/DOE_AUTOTUNE.md) for pre-flight checks, interpreting objectives, and extending the factor space.
 
+### Autotune Mapping Tests
+
+Run the lightweight mapping checks before committing spec or tooling changes to
+ensure the generated configs still satisfy the JSON Schema guard rails:
+
+```bash
+python tools/autotune/make_config.py --self-test
+python tools/autotune/mapping_smoke.py
+```
+
 ---
 
 ## 16. C-ABI Embedding

--- a/docs/DOE_AUTOTUNE.md
+++ b/docs/DOE_AUTOTUNE.md
@@ -10,7 +10,41 @@ Before launching autotune runs, stabilise the platform so every replicate produc
 - **CPU isolation**: reserve cores for realtime work (cpuset, IRQ affinity, SMT policy) matching your production target.
 - **Build artifacts**: ensure `./build/bin/rtfw_demo` exists — the orchestration script assumes a Release-equivalent binary is ready.
 
-## 2. Run the full workflow
+## 2. Parameter mapping & validation
+
+The autotuner parameters map directly onto runtime configuration keys. Use the
+table below when you add new knobs to `spec.yaml` or sanity-check generated
+profiles:
+
+| Param | Config path |
+| --- | --- |
+| `threads` | `threads`
+| `chunk_target_us` | `chunking.target_p90_us`
+| `aosoa_block` | `layout.aosoa_block`
+| `steal_threshold` | `scheduler.steal_threshold`
+| `prefetch_distance_bytes` | `prefetch.distance_bytes`
+| `fma_mode` | `numerics.fma`
+| `ftz_daz` | `numerics.ftz_daz`
+| `arena_per_thread_mb` | `memory.arena_per_thread_mb`
+| `huge_pages` | `memory.huge_pages`
+| `emergency_spawn_enabled` | `scheduler.emergency_spawn`
+| `priority_policy` | `scheduler.priority_policy`
+| `governor_target_util` | `governor.target_util`
+| `governor_hysteresis` | `governor.hysteresis`
+
+Schema validation protects these mappings. The JSON Schema in
+`tools/autotune/config.schema.json` enforces the type, required keys, and
+allowed enum values for every generated mapping file so profiles stay
+compatible with the runtime loader.
+
+### Run mapping checks
+
+```bash
+python tools/autotune/make_config.py --self-test
+python tools/autotune/mapping_smoke.py
+```
+
+## 3. Run the full workflow
 
 ```bash
 python3 tools/autotune/run_experiments.py \
@@ -33,7 +67,7 @@ python3 tools/autotune/run_experiments.py \
 
 > **Interval metrics only.** The runner always calls `rtfw_demo` with `--metrics-json-interval`. Cumulative stats (`--metrics-json`) are intentionally ignored because they hide short-lived regressions and make comparisons between runs ambiguous.
 
-## 3. Generated artifacts
+## 4. Generated artifacts
 
 The workflow writes three directories at the repository root:
 
@@ -45,7 +79,7 @@ The workflow writes three directories at the repository root:
 
 All JSON files use UTF-8 + newline for easy `jq`/Python ingestion.
 
-## 4. Tweaking the design space
+## 5. Tweaking the design space
 
 The YAML spec drives every stage. To change what the tuner explores:
 
@@ -56,7 +90,7 @@ The YAML spec drives every stage. To change what the tuner explores:
 
 For one-off sweeps or custom analytics, inspect `results/experiments.jsonl` with `jq` or re-run `tools/autotune/analyze.py` against the saved log.
 
-## 5. Consuming the profile
+## 6. Consuming the profile
 
 After the run finishes, copy the generated profile into your deployment target or point `RTFW_PROFILE` at the emitted JSON. The runtime loads this alongside existing configs:
 


### PR DESCRIPTION
## Summary
- document how autotune parameters map onto runtime config keys
- describe the schema guard rails and mapping check commands in the workflow doc
- surface the autotune mapping smoke commands from the README

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e5f386b0f8832bbac71b7fe5512eed