### PR TITLE
Add schema enforcement for autotune configs

### DIFF
--- a/tools/autotune/config.schema.json
+++ b/tools/autotune/config.schema.json
@@ -6,96 +6,116 @@
     "threads",
     "chunking",
     "layout",
-    "scheduler",
     "prefetch",
-    "memory",
-    "numerics",
+    "scheduler",
     "governor",
-    "params"
+    "numerics",
+    "memory",
+    "tracing"
   ],
   "properties": {
     "threads": {
-      "type": "string"
+      "type": ["string", "integer"]
     },
     "chunking": {
       "type": "object",
-      "required": ["target_p90_us"],
+      "required": [
+        "target_p90_us",
+        "min_items",
+        "max_items"
+      ],
       "properties": {
-        "target_p90_us": {
-          "type": "integer"
-        }
+        "target_p90_us": { "type": "integer" },
+        "min_items": { "type": "integer" },
+        "max_items": { "type": "integer" }
       },
       "additionalProperties": true
     },
     "layout": {
       "type": "object",
-      "required": ["aosoa_block"],
+      "required": [
+        "aosoa_block",
+        "align_bytes",
+        "pad_to_simd"
+      ],
       "properties": {
-        "aosoa_block": {
-          "type": "integer"
-        }
-      },
-      "additionalProperties": true
-    },
-    "scheduler": {
-      "type": "object",
-      "required": ["steal_threshold"],
-      "properties": {
-        "steal_threshold": {
-          "type": "integer"
-        },
-        "emergency_spawn": {
-          "type": "boolean"
-        }
+        "aosoa_block": { "type": "integer" },
+        "align_bytes": { "type": "integer" },
+        "pad_to_simd": { "type": "boolean" }
       },
       "additionalProperties": true
     },
     "prefetch": {
       "type": "object",
-      "required": ["distance_bytes", "enabled"],
+      "required": [
+        "enabled",
+        "distance_bytes"
+      ],
       "properties": {
-        "distance_bytes": {
-          "type": "integer"
-        },
-        "enabled": {
-          "type": "boolean"
-        }
+        "enabled": { "type": "boolean" },
+        "distance_bytes": { "type": "integer" }
       },
       "additionalProperties": true
     },
-    "memory": {
+    "scheduler": {
       "type": "object",
-      "required": ["arena_per_thread_mb", "huge_pages"],
+      "required": [
+        "steal_threshold",
+        "emergency_spawn"
+      ],
       "properties": {
-        "arena_per_thread_mb": {
-          "type": "integer"
-        },
-        "huge_pages": {
-          "type": "boolean"
-        }
-      },
-      "additionalProperties": true
-    },
-    "numerics": {
-      "type": "object",
-      "required": ["fma"],
-      "properties": {
-        "fma": {
-          "type": "string"
-        }
+        "steal_threshold": { "type": "integer" },
+        "emergency_spawn": { "type": "boolean" }
       },
       "additionalProperties": true
     },
     "governor": {
       "type": "object",
-      "required": ["target_util", "hysteresis"],
+      "required": [
+        "target_util",
+        "hysteresis"
+      ],
       "properties": {
-        "target_util": {
-          "type": "number"
-        },
-        "hysteresis": {
-          "type": "number"
-        }
+        "target_util": { "type": "number" },
+        "hysteresis": { "type": "number" }
+      },
+      "additionalProperties": true
+    },
+    "numerics": {
+      "type": "object",
+      "required": [
+        "ftz_daz",
+        "fma"
+      ],
+      "properties": {
+        "ftz_daz": { "type": "boolean" },
+        "fma": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "memory": {
+      "type": "object",
+      "required": [
+        "arena_per_thread_mb",
+        "huge_pages",
+        "numa",
+        "pretouch"
+      ],
+      "properties": {
+        "arena_per_thread_mb": { "type": "integer" },
+        "huge_pages": { "type": "boolean" },
+        "numa": { "type": "string" },
+        "pretouch": { "type": "boolean" }
+      },
+      "additionalProperties": true
+    },
+    "tracing": {
+      "type": "object",
+      "required": [
+        "bintrace"
+      ],
+      "properties": {
+        "bintrace": { "type": "boolean" }
       },
       "additionalProperties": true
     },

--- a/tools/autotune/make_config.py
+++ b/tools/autotune/make_config.py
@@ -393,6 +393,41 @@ def build_config(params: Mapping[str, Any]) -> Dict[str, Any]:
         enabled = params["prefetch_distance_bytes"] > 0
         set_path(config, ("prefetch", "enabled"), enabled)
 
+    chunking_cfg = config.setdefault("chunking", {})
+    chunking_cfg.setdefault("min_items", 1)
+    chunking_cfg.setdefault("max_items", 4096)
+
+    layout_cfg = config.setdefault("layout", {})
+    layout_cfg.setdefault("align_bytes", 64)
+    layout_cfg.setdefault("pad_to_simd", True)
+
+    prefetch_cfg = config.setdefault("prefetch", {})
+    prefetch_cfg.setdefault("enabled", False)
+    prefetch_cfg.setdefault("distance_bytes", 0)
+
+    scheduler_cfg = config.setdefault("scheduler", {})
+    scheduler_cfg.setdefault("steal_threshold", 0)
+    scheduler_cfg.setdefault("emergency_spawn", False)
+
+    governor_cfg = config.setdefault("governor", {})
+    governor_cfg.setdefault("target_util", 0.0)
+    governor_cfg.setdefault("hysteresis", 0.0)
+
+    numerics_cfg = config.setdefault("numerics", {})
+    numerics_cfg.setdefault("ftz_daz", True)
+    numerics_cfg.setdefault("fma", "auto")
+
+    memory_cfg = config.setdefault("memory", {})
+    memory_cfg.setdefault("arena_per_thread_mb", 0)
+    memory_cfg.setdefault("huge_pages", False)
+    memory_cfg.setdefault("numa", "first_touch")
+    memory_cfg.setdefault("pretouch", True)
+
+    tracing_cfg = config.setdefault("tracing", {})
+    tracing_cfg.setdefault("bintrace", False)
+
+    config.setdefault("threads", "physical")
+
     # Emit the original params alongside the resolved config for traceability.
     config["params"] = dict(params)
     return config

--- a/tools/autotune/validate_config_mapping.py
+++ b/tools/autotune/validate_config_mapping.py
@@ -7,13 +7,10 @@ import argparse
 import json
 import pathlib
 import sys
-from typing import Any, Mapping
+from collections.abc import Iterable, Mapping
+from typing import Any
 
 DEFAULT_SCHEMA_PATH = pathlib.Path(__file__).with_name("config.schema.json")
-
-
-class ValidationError(Exception):
-    """Raised when a payload does not satisfy the schema."""
 
 
 def parse_args() -> argparse.Namespace:
@@ -44,93 +41,115 @@ def load_json(path: pathlib.Path) -> Any:
     except json.JSONDecodeError as exc:
         raise SystemExit(f"Failed to parse JSON from {path}: {exc}") from exc
 
-
-def _is_number(value: Any) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
-
-
 def _is_integer(value: Any) -> bool:
     return isinstance(value, int) and not isinstance(value, bool)
 
 
-def _validate_type(value: Any, expected: str, path: str) -> None:
+def _is_number(value: Any) -> bool:
+    return (isinstance(value, (int, float)) and not isinstance(value, bool))
+
+
+def _describe_type(value: Any) -> str:
+    if isinstance(value, bool):
+        return "boolean"
+    if value is None:
+        return "null"
+    if isinstance(value, Mapping):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    if _is_integer(value):
+        return "integer"
+    if _is_number(value):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    return type(value).__name__
+
+
+def _type_matches(value: Any, expected: str) -> bool:
     if expected == "object":
-        if not isinstance(value, Mapping):
-            raise ValidationError(f"{path} must be an object")
-        return
+        return isinstance(value, Mapping)
     if expected == "array":
-        if not isinstance(value, list):
-            raise ValidationError(f"{path} must be an array")
-        return
+        return isinstance(value, list)
     if expected == "string":
-        if not isinstance(value, str):
-            raise ValidationError(f"{path} must be a string")
-        return
+        return isinstance(value, str)
     if expected == "integer":
-        if not _is_integer(value):
-            raise ValidationError(f"{path} must be an integer")
-        return
+        return _is_integer(value)
     if expected == "number":
-        if not _is_number(value):
-            raise ValidationError(f"{path} must be a number")
-        return
+        return _is_number(value)
     if expected == "boolean":
-        if not isinstance(value, bool):
-            raise ValidationError(f"{path} must be a boolean")
-        return
+        return isinstance(value, bool)
     if expected == "null":
-        if value is not None:
-            raise ValidationError(f"{path} must be null")
-        return
-    raise ValidationError(f"{path} uses unsupported schema type '{expected}'")
+        return value is None
+    raise ValueError(f"Unsupported schema type '{expected}'")
 
 
-def validate(instance: Any, schema: Mapping[str, Any], path: str = "$") -> None:
-    schema_type = schema.get("type")
+def _as_type_list(schema_type: Any) -> Iterable[str]:
     if isinstance(schema_type, str):
-        _validate_type(instance, schema_type, path)
-    if "enum" in schema:
-        options = schema["enum"]
+        return [schema_type]
+    if isinstance(schema_type, Iterable):
+        return [str(item) for item in schema_type]
+    return []
+
+
+def validate(instance: Any, schema: Mapping[str, Any], path: str = "$") -> list[str]:
+    errors: list[str] = []
+
+    schema_types = list(_as_type_list(schema.get("type")))
+    if schema_types:
+        if not any(_type_matches(instance, expected) for expected in schema_types):
+            expected_label = " or ".join(schema_types)
+            errors.append(f"{path} expected {expected_label}, got {_describe_type(instance)}")
+            return errors
+
+    if schema.get("enum") is not None:
+        options = list(schema["enum"])
         if instance not in options:
-            raise ValidationError(f"{path} must be one of {options!r}")
-    if schema_type == "object" or (
-        schema_type is None and "properties" in schema
-    ):
+            errors.append(f"{path} must be one of {options!r}")
+            return errors
+
+    is_object = "object" in schema_types or (
+        not schema_types and "properties" in schema
+    )
+    if is_object:
         if not isinstance(instance, Mapping):
-            raise ValidationError(f"{path} must be an object")
+            errors.append(f"{path} expected object, got {_describe_type(instance)}")
+            return errors
+
         required = schema.get("required", [])
         for name in required:
             if name not in instance:
-                raise ValidationError(f"{path}.{name} is a required property")
+                errors.append(f"Missing required property: {path}.{name}")
+
         properties = schema.get("properties", {})
         additional = schema.get("additionalProperties", True)
         for key, value in instance.items():
+            child_path = f"{path}.{key}"
             if key in properties:
-                child_path = f"{path}.{key}"
-                validate(value, properties[key], child_path)
+                errors.extend(validate(value, properties[key], child_path))
             else:
                 if isinstance(additional, Mapping):
-                    child_path = f"{path}.{key}"
-                    validate(value, additional, child_path)
+                    errors.extend(validate(value, additional, child_path))
                 elif additional is False:
-                    raise ValidationError(f"{path}.{key} is not an allowed property")
-        return
-    if schema_type == "array" or (
-        schema_type is None and "items" in schema
-    ):
+                    errors.append(f"{child_path} is not allowed")
+        return errors
+
+    is_array = "array" in schema_types or (
+        not schema_types and "items" in schema
+    )
+    if is_array:
         if not isinstance(instance, list):
-            raise ValidationError(f"{path} must be an array")
+            errors.append(f"{path} expected array, got {_describe_type(instance)}")
+            return errors
         item_schema = schema.get("items")
         if item_schema is not None:
             for index, item in enumerate(instance):
                 child_path = f"{path}[{index}]"
-                validate(item, item_schema, child_path)
-        return
-    if schema_type in {"string", "integer", "number", "boolean", "null"}:
-        return
-    if schema_type is None:
-        return
-    raise ValidationError(f"{path} uses unsupported schema construction")
+                errors.extend(validate(item, item_schema, child_path))
+        return errors
+
+    return errors
 
 
 def main() -> None:
@@ -138,10 +157,11 @@ def main() -> None:
     schema_payload = load_json(args.schema)
     config_payload = load_json(args.config)
 
-    try:
-        validate(config_payload, schema_payload, "$")
-    except ValidationError as exc:
-        print(f"Validation failed: {exc}", file=sys.stderr)
+    errors = validate(config_payload, schema_payload, "$")
+    if errors:
+        print("Validation failed:", file=sys.stderr)
+        for issue in errors:
+            print(f" - {issue}", file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary
- expand the autotune config schema to cover all required sections and field types
- populate default values in make_config so generated configs satisfy the stricter schema
- enhance the validator to report all missing or mistyped fields instead of stopping at the first error

## Testing
- python tools/autotune/mapping_smoke.py


------
https://chatgpt.com/codex/tasks/task_e_68e5e431029c832ba08a0f8b2b46aae0