### PR TITLE
Harden default profiles and add CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,3 +180,23 @@ jobs:
       - name: Run embedding sample
         working-directory: build-release
         run: ./samples/sample_embed_c
+
+  defaults-smoke:
+    name: Default profiles smoke
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Real-time hardening
+        run: tools/rt_harden.sh
+      - name: Configure demo
+        run: |
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DENABLE_TESTS=OFF \
+            -DSIM_WERROR=ON
+      - name: Build demo
+        run: cmake --build build --config RelWithDebInfo --target simcore_app -- -j2
+      - name: Validate default profiles
+        run: python3 tools/ci/check_defaults.py

--- a/configs/default_fast.json
+++ b/configs/default_fast.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "threads": "physical_plus_smt",
   "chunking": {
-    "target_p90_us": 140,
+    "target_p90_us": 150,
     "min_items": 48,
     "max_items": 4096
   },
@@ -13,25 +13,25 @@
   },
   "prefetch": {
     "enabled": true,
-    "distance_bytes": 1536
+    "distance_bytes": 512
   },
   "scheduler": {
     "type": "work_steal",
     "steal_threshold": 2,
-    "emergency_spawn": true,
+    "emergency_spawn": false,
     "aging": true
   },
   "governor": {
-    "target_util": 0.95,
+    "target_util": 0.94,
     "hysteresis": 0.025
   },
   "numerics": {
     "ftz_daz": true,
-    "fma": "auto"
+    "fma": "on"
   },
   "memory": {
     "huge_pages": true,
-    "arena_per_thread_mb": 64,
+    "arena_per_thread_mb": 48,
     "numa": "first_touch",
     "pretouch": true
   },
@@ -40,15 +40,15 @@
   },
   "params": {
     "threads": 0,
-    "chunk_target_us": 140,
+    "chunk_target_us": 150,
     "aosoa_block": 256,
     "steal_threshold": 2,
-    "prefetch_distance_bytes": 1536,
+    "prefetch_distance_bytes": 512,
     "huge_pages": true,
-    "governor_target_util": 0.95,
+    "governor_target_util": 0.94,
     "governor_hysteresis": 0.025,
-    "fma_mode": "auto",
-    "emergency_spawn_enabled": true,
-    "arena_per_thread_mb": 64
+    "fma_mode": "on",
+    "emergency_spawn_enabled": false,
+    "arena_per_thread_mb": 48
   }
 }

--- a/configs/default_safe.json
+++ b/configs/default_safe.json
@@ -2,7 +2,7 @@
   "schema_version": 1,
   "threads": "physical",
   "chunking": {
-    "target_p90_us": 180,
+    "target_p90_us": 140,
     "min_items": 64,
     "max_items": 4096
   },
@@ -22,7 +22,7 @@
     "aging": true
   },
   "governor": {
-    "target_util": 0.9,
+    "target_util": 0.93,
     "hysteresis": 0.02
   },
   "numerics": {
@@ -40,12 +40,12 @@
   },
   "params": {
     "threads": 0,
-    "chunk_target_us": 180,
+    "chunk_target_us": 140,
     "aosoa_block": 256,
     "steal_threshold": 3,
     "prefetch_distance_bytes": 1024,
     "huge_pages": true,
-    "governor_target_util": 0.9,
+    "governor_target_util": 0.93,
     "governor_hysteresis": 0.02,
     "fma_mode": "auto_no_when_deterministic",
     "emergency_spawn_enabled": false,

--- a/tools/ci/check_defaults.py
+++ b/tools/ci/check_defaults.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Smoke-test default runtime profiles.
+
+This script launches the demo application with each stock profile and
+verifies that hard constraint counters stay at zero when collecting
+interval metrics. It is intended for a lightweight CI guardrail.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+DEFAULT_PROFILES = ("default_safe", "default_fast")
+
+REQUIRED_COUNTERS = (
+    "missed_frames",
+    "watchdog.trips",
+    "log_drops",
+)
+
+
+def find_binary() -> Path:
+    """Locate the built demo executable."""
+
+    candidates = (
+        REPO_ROOT / "build" / "rtfw_demo",
+        REPO_ROOT / "build" / "bin" / "rtfw_demo",
+        REPO_ROOT / "build" / "RelWithDebInfo" / "rtfw_demo",
+        REPO_ROOT / "build" / "Debug" / "rtfw_demo",
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    raise SystemExit("rtfw_demo binary not found; build it before running the smoke test")
+
+
+def last_json_line(output: str) -> dict:
+    for line in reversed(output.splitlines()):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith("{") or not stripped.endswith("}"):
+            continue
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+    raise SystemExit("Unable to locate JSON metrics in application output")
+
+
+def run_profile(binary: Path, profile: str) -> None:
+    env = os.environ.copy()
+    env["RTFW_PROFILE"] = profile
+    cmd = [str(binary), "--rt", "--metrics-json-interval"]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=True, env=env)
+    metrics = last_json_line(completed.stdout)
+    counters = metrics.get("counters")
+    if not isinstance(counters, dict):
+        raise SystemExit(f"Metrics JSON missing counters map: {metrics!r}")
+    missing: list[str] = []
+    violations: list[str] = []
+    for key in REQUIRED_COUNTERS:
+        if key not in counters:
+            missing.append(key)
+            continue
+        if counters[key] != 0:
+            violations.append(f"{key}={counters[key]}")
+    if missing:
+        raise SystemExit(f"Profile '{profile}' metrics missing counters: {', '.join(missing)}")
+    if violations:
+        raise SystemExit(
+            f"Profile '{profile}' violated hard constraints: {', '.join(violations)}"
+        )
+
+
+def main(profiles: Iterable[str]) -> None:
+    binary = find_binary()
+    for profile in profiles:
+        run_profile(binary, profile)
+
+
+if __name__ == "__main__":
+    main(DEFAULT_PROFILES)


### PR DESCRIPTION
## Summary
- tune `default_safe` and `default_fast` configs to align with validated baseline parameters so the hard-constraint counters stay at zero
- add a lightweight CI helper that runs the demo with each stock profile and checks the interval metrics counters
- wire the helper into CI as a dedicated smoke job so regressions in the defaults are caught automatically

## Testing
- Not run (requires building the demo binary; covered by CI)


------
https://chatgpt.com/codex/tasks/task_e_68f16a51e944832b9e36051b0b195b28