### PR TITLE
Add RaceChrono BLE link priority helper

### DIFF
--- a/include/racechrono/ble_link_priority.hpp
+++ b/include/racechrono/ble_link_priority.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+// BLE link priority helper for RaceChrono sketches.
+//
+// These helpers wrap a NimBLE server callback that requests a short
+// connection interval and negotiates a larger MTU when a central connects.
+// They are written so the same sketch can still build in non-Arduino
+// configurations: every function becomes a no-op unless ARDUINO is defined.
+
+namespace racechrono::ble_link_priority
+{
+
+/**
+ * Initialise the optional BLE link priority helpers.
+ *
+ * Call this early in your sketch (before bringing the RaceChrono BLE
+ * service online). When running on Arduino it sets the preferred MTU and
+ * attaches the connection callbacks as soon as the NimBLE server exists.
+ */
+void setup();
+
+/**
+ * Periodic maintenance. Invoke from loop() so the helper can attach to a
+ * server that came up late and fire the one-shot retry timer.
+ */
+void loop();
+
+/**
+ * Notify the helper that the RaceChrono BLE server is ready. This is safe to
+ * call repeatedly. It simply gives the helper an opportunity to attach its
+ * callbacks immediately instead of waiting for the next loop() poll.
+ */
+void notifyServerReady();
+
+/** Enable or disable the link priority feature at runtime. */
+void setEnabled(bool enabled);
+
+/** Returns the current enabled state. */
+bool isEnabled();
+
+} // namespace racechrono::ble_link_priority
+

--- a/src/ble_link_priority.cpp
+++ b/src/ble_link_priority.cpp
@@ -1,0 +1,178 @@
+#include <racechrono/ble_link_priority.hpp>
+
+#ifdef ARDUINO
+
+#include <Arduino.h>
+#include <NimBLEDevice.h>
+
+#include <cstdint>
+
+namespace racechrono::ble_link_priority
+{
+namespace
+{
+
+constexpr std::uint16_t kConnIntervalMin = 6;   // 7.5 ms (1.25 ms units)
+constexpr std::uint16_t kConnIntervalMax = 12;  // 15 ms
+constexpr std::uint16_t kConnLatency = 0;
+constexpr std::uint16_t kSupervisionTimeout = 400; // 4 s (10 ms units)
+constexpr std::uint16_t kInvalidConnHandle = 0xFFFF;
+
+bool gEnabled = true;
+bool gRetryScheduled = false;
+std::uint32_t gRetryDeadlineMs = 0;
+std::uint16_t gPendingHandle = kInvalidConnHandle;
+std::uint16_t gLastReportedMtu = 0;
+NimBLEServer* gServer = nullptr;
+
+class LinkPriorityCallbacks : public NimBLEServerCallbacks
+{
+public:
+    void onConnect(NimBLEServer* server, NimBLEConnInfo& connInfo) override
+    {
+        gServer = server;
+        gPendingHandle = connInfo.getConnHandle();
+        logMtu(connInfo.getMTU());
+        requestUpdate("ConnParams req", gPendingHandle);
+        scheduleRetry();
+    }
+
+    void onConnect(NimBLEServer* server) override
+    {
+        // Fallback for older NimBLE versions that do not provide NimBLEConnInfo
+        gServer = server;
+        scheduleRetry();
+    }
+
+    void onDisconnect(NimBLEServer* /*server*/) override
+    {
+        gPendingHandle = kInvalidConnHandle;
+        gRetryScheduled = false;
+    }
+
+    void onMTUChange(std::uint16_t mtu, NimBLEConnInfo& /*connInfo*/) override
+    {
+        logMtu(mtu);
+    }
+
+private:
+    static void logMtu(std::uint16_t mtu)
+    {
+        if (mtu == 0 || mtu == gLastReportedMtu)
+            return;
+        gLastReportedMtu = mtu;
+        Serial.printf("MTU negotiated: %u\n", static_cast<unsigned>(mtu));
+    }
+
+    static void requestUpdate(const char* prefix, std::uint16_t connHandle)
+    {
+        if (!gEnabled || gServer == nullptr || connHandle == kInvalidConnHandle)
+            return;
+
+        const bool sent = gServer->updateConnParams(connHandle,
+                                                    kConnIntervalMin,
+                                                    kConnIntervalMax,
+                                                    kConnLatency,
+                                                    kSupervisionTimeout);
+        Serial.printf("%s: min=7.50 ms max=15.00 ms latency=%u timeout=%.2f s -> %s\n",
+                      prefix,
+                      static_cast<unsigned>(kConnLatency),
+                      static_cast<float>(kSupervisionTimeout) * 0.01f,
+                      sent ? "sent" : "rejected");
+    }
+
+    static void scheduleRetry()
+    {
+        if (!gEnabled || gPendingHandle == kInvalidConnHandle)
+            return;
+        gRetryScheduled = true;
+        gRetryDeadlineMs = millis() + 2000u;
+    }
+
+public:
+    static void maybeRetry()
+    {
+        if (!gRetryScheduled)
+            return;
+        if (static_cast<std::int32_t>(millis() - gRetryDeadlineMs) < 0)
+            return;
+        gRetryScheduled = false;
+        requestUpdate("ConnParams retry", gPendingHandle);
+    }
+};
+
+LinkPriorityCallbacks gCallbacks;
+
+void attachIfReady()
+{
+    NimBLEServer* server = NimBLEDevice::getServer();
+    if (server == nullptr)
+        return;
+    if (gServer == server)
+        return;
+    gServer = server;
+    gLastReportedMtu = 0;
+    server->setCallbacks(&gCallbacks, false);
+}
+
+} // namespace
+
+void setup()
+{
+    NimBLEDevice::setMTU(185);
+    attachIfReady();
+}
+
+void loop()
+{
+    attachIfReady();
+    LinkPriorityCallbacks::maybeRetry();
+}
+
+void notifyServerReady()
+{
+    attachIfReady();
+}
+
+void setEnabled(bool enabled)
+{
+    if (gEnabled == enabled)
+        return;
+    gEnabled = enabled;
+    if (!enabled)
+    {
+        gRetryScheduled = false;
+    }
+    else if (gPendingHandle != kInvalidConnHandle)
+    {
+        requestUpdate("ConnParams req", gPendingHandle);
+        scheduleRetry();
+    }
+}
+
+bool isEnabled()
+{
+    return gEnabled;
+}
+
+} // namespace racechrono::ble_link_priority
+
+#else  // !ARDUINO
+
+namespace racechrono::ble_link_priority
+{
+namespace
+{
+bool gEnabled = true;
+}
+
+void setup() {}
+void loop() {}
+void notifyServerReady() {}
+void setEnabled(bool enabled) { gEnabled = enabled; }
+bool isEnabled() { return gEnabled; }
+
+} // namespace racechrono::ble_link_priority
+
+#endif
+


### PR DESCRIPTION
## Summary
- add an optional RaceChrono BLE link priority helper interface for sketches
- implement NimBLE server callbacks that request low-latency connection params, log MTU changes, and retry once
- provide runtime enable/disable support plus polling hooks so the helper can attach when the server becomes available

## Testing
- not run (helper only)


------
https://chatgpt.com/codex/tasks/task_e_6904d0f9e754832ba4de9694f9efa319