### PR TITLE
Add rtfw_demo alias target to CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -569,6 +569,7 @@ simcore_link_sanitizer_runtime(rtfw_shared)
 add_executable(simcore_app src/main.cpp)
 target_link_libraries(simcore_app PRIVATE simcore_platform)
 set_target_properties(simcore_app PROPERTIES OUTPUT_NAME rtfw_demo)
+add_executable(rtfw_demo ALIAS simcore_app)
 
 # Sample trace dump utility
 add_executable(trace_dump src/trace_dump.cpp)


### PR DESCRIPTION
## Summary
- add an executable alias so `cmake --build` can accept `--target rtfw_demo`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904e2c711a4832ba26c9fce8a3b4fe9