### PR TITLE
Add on-ramp structure review note

### DIFF
--- a/docs/notes/onramp-structure-review.md
+++ b/docs/notes/onramp-structure-review.md
@@ -1,0 +1,31 @@
+# Beginner On-Ramp structure review
+
+## Source context
+
+The current on-ramp guide is a single, long document that begins with "what this page is" and "how to use" instructions, then presents a large set of skill ramps (roughly 40 sections). This means users learn the usage pattern and then scroll to find the relevant ramp.
+
+## Recommended structure options
+
+### Preferred: modular + landing page
+
+Create an `OnRamp/` folder that contains:
+
+- `README.md` ("How to use" + short overview)
+- `template.md` (example/template for new ramps)
+- `toc.md` (table of contents)
+- One file per ramp (e.g., `01-requirements-writing.md`, `02-block-diagram-interfaces.md`, etc.)
+
+Benefits:
+
+- Better navigation and deep linking.
+- Easier ownership and smaller diffs.
+- Clearer modular intent for each skill ramp.
+- Scales cleanly as more ramps are added.
+
+### Acceptable: single file + TOC
+
+A single monolithic file is acceptable when the guide is short, rarely updated, or primarily consumed linearly, but it is less maintainable and harder to navigate once there are dozens of sections.
+
+## Recommendation
+
+For professionalism and long-term maintainability, prefer the modular approach with a landing page and TOC that links to separate ramp files. This preserves a single entry point while keeping each topic self-contained.


### PR DESCRIPTION
### Motivation
- Recommend a more maintainable, navigable structure for the long "Beginner On‑Ramp & Skill Bridges" guide by breaking it into modular ramp files and a landing TOC.

### Description
- Add `docs/notes/onramp-structure-review.md` which outlines a preferred modular layout (landing `README.md`, `toc.md`, `template.md`, and one file per ramp) and an acceptable single-file alternative for short guides.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69835a008a54832b8e64fc6b7dca9c44)