### PR TITLE
M2.1: harden C ABI access validation

### DIFF
--- a/rt/include/rt/c_api.h
+++ b/rt/include/rt/c_api.h
@@ -114,10 +114,13 @@ typedef uint64_t rtfw_resource_id;
 #define RTFW_INVALID_PHASE_ID UINT64_MAX
 #define RTFW_INVALID_RESOURCE_ID UINT64_MAX
 
-typedef enum rtfw_resource_access {
-    RTFW_RESOURCE_READ = 0,
-    RTFW_RESOURCE_WRITE = 1
-} rtfw_resource_access;
+/*
+ * Fixed-width rather than an enum so the C boundary can validate malformed
+ * numeric input without first loading an out-of-range enum value.
+ */
+typedef uint32_t rtfw_resource_access;
+#define RTFW_RESOURCE_READ ((rtfw_resource_access)0u)
+#define RTFW_RESOURCE_WRITE ((rtfw_resource_access)1u)
 
 typedef rtfw_callback_result (*rtfw_frame_callback)(
     void* user_data,


### PR DESCRIPTION
## Summary

- represent the C ABI resource-access discriminator as fixed-width `uint32_t` values
- preserve the existing `RTFW_RESOURCE_READ` / `RTFW_RESOURCE_WRITE` source API
- allow malformed numeric input to be rejected without first loading an out-of-range C enum value

## Why

PR #179's dynamic C ABI negative test passes `(rtfw_resource_access)99`. Under Clang UBSan, reading that invalid enum value is already undefined behavior before validation can reject it. This keeps validation at the ABI boundary well-defined.

## Validation

- strict C11/C++20 compile
- ASan + UBSan dynamic C ABI test, including invalid access value
- documentation contract
- exact tree differs from merged M2 by one header only

License remains Apache-2.0; no dependency added.