### PR TITLE
Add one-command continuous roadmap autopilot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,13 @@ Do not commit, push, open or merge a PR, release, deploy, change secrets, or
 modify repository settings unless explicitly instructed. When publication is
 authorized, use a scoped branch and draft PR; deterministic CI remains
 authoritative and no agent may waive a failing gate.
+
+## Governed continuous delivery
+
+Invoking `./scripts/product-autopilot.sh` is the explicit instruction to plan,
+implement, verify, publish, and merge only the bounded control/target PRs created
+by that run, then continue through dependency-ready software batches. The
+wrapper still cannot release, deploy, change secrets/settings, waive a gate, or
+manufacture hardware/RT qualification. It stops at a genuine product decision,
+mandatory hardware/RT evidence, signing, release, or deployment gate. See
+`docs/runbooks/continuous-autopilot.md`.

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: 52b6cb59ac8c55cc65b91aaf7037ac94273989f7
+  source_revision: 61504ea903578cafa9e7878ba582f1ecb08850cb
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: 50897876440a8fdb84a5c5942abb4339cfd792d6
+  source_revision: 52b6cb59ac8c55cc65b91aaf7037ac94273989f7
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2
@@ -16,18 +16,21 @@ autonomy:
     - run deterministic verification
     - commit and push scoped changes
     - open a draft pull request
+    - merge only autopilot-created PRs after all gates pass
   forbidden:
-    - merge protected branch
+    - merge a protected branch with failing checks
     - publish release
     - deploy
     - change secrets or repository settings
     - waive a failing gate
+    - claim hardware or RT qualification without named evidence
 source_of_truth:
   portfolio_control:
     - product outcomes
     - milestone state
     - approved batch scope
     - cross-repository traceability
+    - continuous autopilot policy
   repository:
     - public API and ABI semantics
     - implementation architecture

--- a/docs/runbooks/continuous-autopilot.md
+++ b/docs/runbooks/continuous-autopilot.md
@@ -1,0 +1,29 @@
+# Continuous autopilot
+
+From the repository root, with `portfolio-control` cloned beside this repository:
+
+```bash
+./scripts/product-autopilot.sh
+```
+
+The command is resumable. It selects or generates one dependency-ready canonical
+batch, validates and merges the control-plane contract, activates it here,
+implements the complete batch through Codex, runs the full local verification,
+performs a final adversarial audit, opens the target PR, waits for GitHub CI,
+performs bounded causal repairs, merges, and repeats.
+
+It may skip a hardware-blocked M18 qualification node and continue a dependency-
+independent M19 software node. It cannot mark M18 complete, promote support
+matrices, publish releases, sign artifacts, deploy, or claim CUDA/XDMA/RT1/RT2
+without exact retained evidence.
+
+State and logs live under the sibling control repository at
+`.autopilot/cpp-rt-car/`. Rerun the same command after a machine interruption,
+authentication outage, or repairable external failure. Use `--reset-state` only
+after manually reconciling saved branches and PRs.
+
+Useful bounded run:
+
+```bash
+./scripts/product-autopilot.sh --max-batches 1
+```

--- a/scripts/product-autopilot.sh
+++ b/scripts/product-autopilot.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+TARGET_ROOT="$(git rev-parse --show-toplevel)"
+WORKSPACE="$(dirname "$TARGET_ROOT")"
+CONTROL_REPO="${CONTROL_REPO:-$WORKSPACE/portfolio-control}"
+
+[[ -x "$CONTROL_REPO/scripts/product-autopilot.sh" ]] || {
+  echo "missing executable control-plane autopilot: $CONTROL_REPO/scripts/product-autopilot.sh" >&2
+  exit 2
+}
+
+# This invocation is the explicit one-time authorization to merge only the
+# scoped PRs created by the current resumable product run after all gates pass.
+exec "$CONTROL_REPO/scripts/product-autopilot.sh" cpp-rt-car --auto-merge "$@"


### PR DESCRIPTION
## Summary

Adds the thin repository-local entry point for the shared, resumable `portfolio-control` product autopilot.

Running:

```bash
./scripts/product-autopilot.sh
```

is the one-time authorization for the deterministic wrapper to continue through dependency-ready M15–M20 software batches without requiring a new prompt for every feature. The wrapper plans or refreshes one bounded batch, implements it through Codex, runs full local verification, performs an adversarial audit, opens the PR, waits for GitHub CI, performs bounded causal repairs, merges after gates pass, and repeats.

## Boundaries

- Codex itself does not commit, push, open or merge PRs, release, deploy, change settings/secrets, or waive checks.
- The wrapper merges only PRs created by its current resumable product run.
- Stable C ABI v8, SONAME 8, device ABI v1, package isolation, compatibility aliases, exact SDK inventory, bounded RT-lane behavior, and truthful qualification language remain protected.
- M18 hardware/RT qualification cannot be fabricated; the planner may continue a dependency-independent M19 software path while M18 awaits named hardware evidence.
- Releases, signing, deployment, and support-matrix promotion remain outside the autopilot.

## Scope

- extend `AGENTS.md` with the explicit continuous-delivery authorization boundary;
- pin the hardened shared control-plane revision;
- add the operator runbook;
- add the executable repository wrapper.

No runtime source, tests, ABI, package, release, support-matrix, or existing workflow file is modified.

## Validation

The wrapper passes shell syntax checks and delegates to the control-plane schema, unit-test, Python-compile, and ShellCheck validation introduced by `kpbianco/portfolio-control#2`.

## Merge order

Merge `kpbianco/portfolio-control#2` first. This PR is pinned to control commit `61504ea903578cafa9e7878ba582f1ecb08850cb`.