### PR TITLE
Add Portfolio Control roadmap wrapper

### DIFF
--- a/scripts/roadmap-autopilot.sh
+++ b/scripts/roadmap-autopilot.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT="$(git rev-parse --show-toplevel)"
+CONTROL_REPO="${CONTROL_REPO:-$(realpath "$ROOT/../portfolio-control")}"
+[[ -x "$CONTROL_REPO/scripts/run-product-roadmap.sh" ]] || {
+  echo "missing portfolio-control autopilot: $CONTROL_REPO/scripts/run-product-roadmap.sh" >&2
+  exit 2
+}
+export AUTOPILOT_MODE="${AUTOPILOT_MODE:-merge-software}"
+exec "$CONTROL_REPO/scripts/run-product-roadmap.sh" cpp-rt-car "$@"


### PR DESCRIPTION
## Summary

Adds the repository-local entry point for the governed Portfolio Control roadmap runner.

## Behavior

- Resolves the sibling `portfolio-control` checkout.
- Invokes the canonical `cpp-rt-car` product roadmap.
- Defaults to the software merge mode.
- Does not execute automatically.
- Does not alter implementation, API, ABI, release, or hardware behavior.

## Validation

- Shell syntax passed.
- Staged diff check passed.
- Canonical Portfolio Control runner and product contracts are present.
