### PR TITLE
cpp-rt-car: synchronize portfolio harness

### DIFF
--- a/.portfolio-harness.json
+++ b/.portfolio-harness.json
@@ -1,6 +1,6 @@
 {
   "control_repository": "kpbianco/portfolio-control",
-  "control_revision": "3754cab3114fdf276627bf1837f5abe41a2e921e",
+  "control_revision": "98e867d489d1644983797e0e389f921e6601fb64",
   "harness_version": 2,
   "managed_paths": {
     ".agents/skills/ci-diagnose/SKILL.md": "93a7ce825178685239d6f3f124e5670f648b7f6a242be7716e86fd8b10f653b0",
@@ -26,9 +26,9 @@
     ".github/codex/schemas/planner-review.schema.json": "0b6e73da860c4c6d9024f6e2c2889162f4d49813e4c5069187f68ef79183eba9",
     ".github/codex/schemas/product.schema.json": "0c01a565e795a00f9532a55bdc2fc1d51aa20d8b2af2f5941b8be11723fd4191",
     ".gitignore": "a55b599061dfcc0c7a818cf53ef865ee1d68dd9be83bffabf72143c18254dfa3",
-    "AGENTS.md": "99861385425875ca99230f246e3dbf6666012bd4bf7d540e9b7150b71109cee9",
+    "AGENTS.md": "3f90ec0a100de52a078dca222f84e5c5321444d2542478f1788711b7d5089697",
     "contracts/profile-requirements.yaml": "36a421b853f0749695b773da201489f7b17e0d493baa4787482d9f49715d8bc1",
-    "contracts/repo-profile.yaml": "de0bcb8478198ee50128193de0936efad275833c752ff49b85f88385721debd6"
+    "contracts/repo-profile.yaml": "f3b8917b670cd74ca34402e355b9eca78a0885579ff7f7202a12618e871c44df"
   },
   "product": "cpp-rt-car",
   "profile": "assurance",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ mandatory hardware/RT evidence, signing, release, or deployment gate. See
 ## Governed agentic delivery
 
 - Product: `cpp-rt-car`; delivery profile: `assurance`.
-- Control revision: `3754cab3114fdf276627bf1837f5abe41a2e921e`; harness version: `2`.
+- Control revision: `98e867d489d1644983797e0e389f921e6601fb64`; harness version: `2`.
 - Read `contracts/profile-requirements.yaml` and the approved
   `contracts/active-batch.yaml` before implementation.
 - Stay inside active-batch allowed paths and preserve every forbidden path.

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: 3754cab3114fdf276627bf1837f5abe41a2e921e
+  source_revision: 98e867d489d1644983797e0e389f921e6601fb64
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2


### PR DESCRIPTION
## Governed harness

Synchronizes explicitly managed harness content from control revision `98e867d489d1644983797e0e389f921e6601fb64` and harness version `2`.

Target-owned source and repository-native workflows outside managed paths are preserved. No product batch is implemented.
