### PR TITLE
Synchronize harness and stabilize live guard verification

### DIFF
--- a/.portfolio-harness.json
+++ b/.portfolio-harness.json
@@ -1,6 +1,6 @@
 {
   "control_repository": "kpbianco/portfolio-control",
-  "control_revision": "git:32bce880-0bd3c145-18f33678-d3ee01e2-cdeae58",
+  "control_revision": "git:44dbd047-bec4dca4-7775ff17-145ff3e9-ce3e5abb",
   "harness_version": 2,
   "managed_paths": {
     ".agents/skills/ci-diagnose/SKILL.md": "sha256:93a7ce82-51786852-39d6f3f1-24e5670f-648b7f6a-242be771-6e86fd8b-10f653b0",
@@ -26,9 +26,9 @@
     ".github/codex/schemas/planner-review.schema.json": "sha256:0b6e73da-860c4c6d-9024f6e2-c2889162-f4d49813-e4c50691-87f68ef7-9183eba9",
     ".github/codex/schemas/product.schema.json": "sha256:0c01a565-e795a00f-9532a55b-dc2fc1d5-1aa20d8b-2af2f594-1b8be117-23fd4191",
     ".gitignore": "sha256:a55b5990-61dfcc0c-7a818cf5-3ef865ee-1d68dd9b-e83bffab-f72143c1-8254dfa3",
-    "AGENTS.md": "sha256:55355a84-29283a3a-ef681bc4-485d24b9-7a095ac0-90b835b2-8be1e6aa-6697b532",
+    "AGENTS.md": "sha256:c1513bbc-8c3e358f-15bcaeb6-a34cd49b-21ac749d-bfd91997-f9921e3e-85f0b59e",
     "contracts/profile-requirements.yaml": "sha256:36a421b8-53f07496-95b773da-201489f7-b17e0d49-3baa4787-482d9f49-715d8bc1",
-    "contracts/repo-profile.yaml": "sha256:aeca4cf7-88a53956-f7883017-424058ef-563a6088-c72c4e65-e536679a-1a63cfec"
+    "contracts/repo-profile.yaml": "sha256:43f43ee8-2ba591e8-d3973440-a67225f9-217c8d8f-f1065cc6-58a5e1a9-a8c3d085"
   },
   "product": "cpp-rt-car",
   "profile": "assurance",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ mandatory hardware/RT evidence, signing, release, or deployment gate. See
 ## Governed agentic delivery
 
 - Product: `cpp-rt-car`; delivery profile: `assurance`.
-- Control revision: `32bce8800bd3c14518f336786d3ee01e2cdeae58`; harness version: `2`.
+- Control revision: `44dbd047bec4dca47775ff17145ff3e9ce3e5abb`; harness version: `2`.
 - Read `contracts/profile-requirements.yaml` and the approved
   `contracts/active-batch.yaml` before implementation.
 - Stay inside active-batch allowed paths and preserve every forbidden path.

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: c7dd248a2899a61a2be5cbbc4ca196bd2d499b23  # pragma: allowlist secret
+  source_revision: 44dbd047bec4dca47775ff17145ff3e9ce3e5abb  # pragma: allowlist secret
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2

--- a/docs/evidence/M15-03-2026-08-04.md
+++ b/docs/evidence/M15-03-2026-08-04.md
@@ -93,7 +93,26 @@ The bounded repair changes only the test and its reviewed release digest:
   inaccessible-guard assertion;
 - suppress only MSVC C4324 around the deliberately over-aligned test fixture;
 - update the `tests/test_memory_policy.cpp` release-contract SHA-256 to
-  `c6925de2923a2b02614b53c4d6211d53d681a165a87bbae8a2fc24e9c91f4b89`.
+  `c66eb29e451d7b3392327f9cec23d331db74bc57180e3334f567251ec13b5eff`.
+
+Post-merge isolated verification exposed one further test-harness race: the
+ordinary Linux raw-guard death checks used GoogleTest's fast death-test style
+while runtime worker threads were live. Mandatory GitHub CI completed 27/27,
+but a fresh isolated full verification later stalled at `simcore_all` until
+the 10-minute harness timeout. The follow-up repair selects GoogleTest's
+thread-safe re-exec death-test style only around those two checks and restores
+the prior flag afterward. The production runtime and the guard assertions are
+unchanged.
+
+Focused follow-up validation:
+
+```text
+$ cmake --build build/agent-full --target simcore_tests --parallel 2
+exit 0
+
+$ for iteration in 1 2 3 4 5; do timeout 60s ./build/agent-full/tests/simcore_tests --gtest_filter='MemoryPolicy.NativeLinuxPageBackingIsRoundedGuardedAndObserved'; done
+exit 0: 5/5 repetitions passed; each completed in 6-11 ms.
+```
 
 No runtime implementation, public C++ API, stable C ABI v8, SONAME 8, device
 ABI v1, schema, installed inventory, support matrix, or qualification claim
@@ -452,11 +471,12 @@ support promotion, release, or deployment to undo.
 
 ## Unperformed validation
 
-- Mandatory GitHub run `30958522623` ran against the pre-repair source and
-  failed as described above. A post-repair GCC 11, Clang 14, MSVC v143, ASan,
-  UBSan, TSan, determinism/artifact-exchange, embedding, package, archive-
-  relocation, and compatibility CI rerun was **not performed and remains
-  required before merge**.
+- Mandatory GitHub run `30959951881` passed 27/27 checks against repaired
+  commit `ba0c0061e9a41a586f1b5154ee7a1809313c8b52`, including GCC 11,
+  Clang 14, MSVC v143, ASan/UBSan, TSan, determinism/artifact exchange,
+  embedding, package, archive relocation, and compatibility. The post-merge
+  thread-safe death-test follow-up still requires its own GitHub CI before it
+  may merge.
 - Independent Linux lock readback, successful explicit huge-page pool, and
   fixed-topology NUMA binding: **not available/performed**.
 - Physical CUDA GPU, FPGA/XDMA, combined accelerator, HIL, Unreal, field,

--- a/release/rtfw-release-contract.json
+++ b/release/rtfw-release-contract.json
@@ -222,7 +222,7 @@
     "tests/runtime_profile_tests.cpp": "6a81d25172de67b60d676bfc5abefbaac333a26b485a6d4d2c324b68e6c39669",
     "tests/test_cpu_memory_policy.cpp": "c4f21914a9245b4be37b3e985a304695682c941dbab441056efa6d5392d22e89",
     "tests/test_determinism_replay.cpp": "e6152b9ac4540f5582f9a452f5fcaa08d7c7bfafd40e4f787f509ac3f049db27",
-    "tests/test_memory_policy.cpp": "c6925de2923a2b02614b53c4d6211d53d681a165a87bbae8a2fc24e9c91f4b89",
+    "tests/test_memory_policy.cpp": "c66eb29e451d7b3392327f9cec23d331db74bc57180e3334f567251ec13b5eff",
     "tests/test_periodic_runtime.cpp": "8121b33f3f18f58239d4ac53587532deafabb555cb3e8e2c7ab8c1ba3f070229",
     "tests/test_release_tools.py": "548341cb7b693b9a1c1981441383a302494c198f736f97182aa3c0f2f1af7d26",
     "tests/test_rt_pipeline.cpp": "1d0f6dc159572a580b5a2364ec3590bb393e1706189a0292970c55d0f9c93a3f",

--- a/tests/test_memory_policy.cpp
+++ b/tests/test_memory_policy.cpp
@@ -1512,6 +1512,9 @@ TEST(MemoryPolicy, NativeLinuxPageBackingIsRoundedGuardedAndObserved) {
         -1);
     EXPECT_EQ(errno, EFAULT);
 #elif GTEST_HAS_DEATH_TEST
+    const auto previous_death_test_style =
+        ::testing::GTEST_FLAG(death_test_style);
+    ::testing::GTEST_FLAG(death_test_style) = "threadsafe";
     auto* before_guard = reinterpret_cast<volatile std::byte*>(
         usable_address - 1);
     auto* after_guard = reinterpret_cast<volatile std::byte*>(
@@ -1532,6 +1535,7 @@ TEST(MemoryPolicy, NativeLinuxPageBackingIsRoundedGuardedAndObserved) {
         },
         ::testing::KilledBySignal(SIGSEGV),
         "");
+    ::testing::GTEST_FLAG(death_test_style) = previous_death_test_style;
 #endif
     ASSERT_EQ(runtime.stop(), rt::Status::ok);
 #else


### PR DESCRIPTION
## Summary
- synchronize the managed Portfolio Control harness provenance to control revision `44dbd047`
- make the ordinary Linux live-guard death checks use GoogleTest's thread-safe re-exec mode while runtime workers are active
- update the reviewed release digest and retained M15-03 evidence

## Verification
- focused guard test: 5/5 repetitions passed (6-11 ms each)
- `./scripts/agent-verify.sh full`: contract passed, quick 11/11, full 15/15

The runtime implementation and guard assertions are unchanged. This repairs the nondeterministic isolated post-merge verification timeout observed after PR #206.