### PR TITLE
cpp-rt-car: synchronize portfolio harness

### DIFF
--- a/.portfolio-harness.json
+++ b/.portfolio-harness.json
@@ -1,6 +1,6 @@
 {
   "control_repository": "kpbianco/portfolio-control",
-  "control_revision": "git:44dbd047-bec4dca4-7775ff17-145ff3e9-ce3e5abb",
+  "control_revision": "git:c2077902-2286e2f9-f45eb433-760f4886-df70e68f",
   "harness_version": 2,
   "managed_paths": {
     ".agents/skills/ci-diagnose/SKILL.md": "sha256:93a7ce82-51786852-39d6f3f1-24e5670f-648b7f6a-242be771-6e86fd8b-10f653b0",
@@ -26,9 +26,9 @@
     ".github/codex/schemas/planner-review.schema.json": "sha256:0b6e73da-860c4c6d-9024f6e2-c2889162-f4d49813-e4c50691-87f68ef7-9183eba9",
     ".github/codex/schemas/product.schema.json": "sha256:0c01a565-e795a00f-9532a55b-dc2fc1d5-1aa20d8b-2af2f594-1b8be117-23fd4191",
     ".gitignore": "sha256:a55b5990-61dfcc0c-7a818cf5-3ef865ee-1d68dd9b-e83bffab-f72143c1-8254dfa3",
-    "AGENTS.md": "sha256:c1513bbc-8c3e358f-15bcaeb6-a34cd49b-21ac749d-bfd91997-f9921e3e-85f0b59e",
+    "AGENTS.md": "sha256:c691f368-76c2ac45-030482dd-98845033-4a71973e-819a94f3-b5c24d0a-e8284b6f",
     "contracts/profile-requirements.yaml": "sha256:36a421b8-53f07496-95b773da-201489f7-b17e0d49-3baa4787-482d9f49-715d8bc1",
-    "contracts/repo-profile.yaml": "sha256:43f43ee8-2ba591e8-d3973440-a67225f9-217c8d8f-f1065cc6-58a5e1a9-a8c3d085"
+    "contracts/repo-profile.yaml": "sha256:5150cd7c-517b2a4d-e0a4078c-2e2ec4b6-ede1a31d-5c06b0b0-5fb36b46-232869e2"
   },
   "product": "cpp-rt-car",
   "profile": "assurance",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ mandatory hardware/RT evidence, signing, release, or deployment gate. See
 ## Governed agentic delivery
 
 - Product: `cpp-rt-car`; delivery profile: `assurance`.
-- Control revision: `44dbd047bec4dca47775ff17145ff3e9ce3e5abb`; harness version: `2`.
+- Control revision: `c20779022286e2f9f45eb433760f4886df70e68f`; harness version: `2`.
 - Read `contracts/profile-requirements.yaml` and the approved
   `contracts/active-batch.yaml` before implementation.
 - Stay inside active-batch allowed paths and preserve every forbidden path.

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: 6d7945e8b905cc7b6bb38ad0f8b997afba981626  # pragma: allowlist secret
+  source_revision: c20779022286e2f9f45eb433760f4886df70e68f  # pragma: allowlist secret
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2


### PR DESCRIPTION
## Governed harness

Synchronizes explicitly managed harness content from control revision `c20779022286e2f9f45eb433760f4886df70e68f` and harness version `2`.

Target-owned source and repository-native workflows outside managed paths are preserved. No product batch is implemented.
