### PR TITLE
cpp-rt-car: synchronize portfolio harness

### DIFF
--- a/.portfolio-harness.json
+++ b/.portfolio-harness.json
@@ -1,6 +1,6 @@
 {
   "control_repository": "kpbianco/portfolio-control",
-  "control_revision": "git:e00e41f0-67672bfe-98209746-ce4fc307-80fdd160",
+  "control_revision": "git:97fe0e62-1adb2bfb-f492523d-9c4527e5-ede78141",
   "harness_version": 2,
   "managed_paths": {
     ".agents/skills/ci-diagnose/SKILL.md": "sha256:93a7ce82-51786852-39d6f3f1-24e5670f-648b7f6a-242be771-6e86fd8b-10f653b0",
@@ -26,9 +26,9 @@
     ".github/codex/schemas/planner-review.schema.json": "sha256:0b6e73da-860c4c6d-9024f6e2-c2889162-f4d49813-e4c50691-87f68ef7-9183eba9",
     ".github/codex/schemas/product.schema.json": "sha256:0c01a565-e795a00f-9532a55b-dc2fc1d5-1aa20d8b-2af2f594-1b8be117-23fd4191",
     ".gitignore": "sha256:a55b5990-61dfcc0c-7a818cf5-3ef865ee-1d68dd9b-e83bffab-f72143c1-8254dfa3",
-    "AGENTS.md": "sha256:8db0d39b-0e0ab90a-9140cd63-d920f1a7-ff63e412-8e2ab9bd-5defc212-db0f5b5a",
+    "AGENTS.md": "sha256:b62a7980-b7039157-272530d3-db72d717-c14eb64f-6e76a257-e4f664b0-3e962219",
     "contracts/profile-requirements.yaml": "sha256:36a421b8-53f07496-95b773da-201489f7-b17e0d49-3baa4787-482d9f49-715d8bc1",
-    "contracts/repo-profile.yaml": "sha256:044de46f-96030d93-93b38d3e-9bced285-5eb19bb0-7c5c2530-42957000-16bf81ad"
+    "contracts/repo-profile.yaml": "sha256:2a046f4c-f80bbf24-772df631-ad82efe5-70c514f2-78e36a93-d01d6316-5346c6fa"
   },
   "product": "cpp-rt-car",
   "profile": "assurance",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ mandatory hardware/RT evidence, signing, release, or deployment gate. See
 ## Governed agentic delivery
 
 - Product: `cpp-rt-car`; delivery profile: `assurance`.
-- Control revision: `e00e41f067672bfe98209746ce4fc30780fdd160`; harness version: `2`.
+- Control revision: `97fe0e621adb2bfbf492523d9c4527e5ede78141`; harness version: `2`.
 - Read `contracts/profile-requirements.yaml` and the approved
   `contracts/active-batch.yaml` before implementation.
 - Stay inside active-batch allowed paths and preserve every forbidden path.

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: 7726a89440df85ce9ff4b2e4af77deb173b9fda2  # pragma: allowlist secret
+  source_revision: 97fe0e621adb2bfbf492523d9c4527e5ede78141  # pragma: allowlist secret
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2


### PR DESCRIPTION
## Governed harness

Synchronizes explicitly managed harness content from control revision `97fe0e621adb2bfbf492523d9c4527e5ede78141` and harness version `2`.

Target-owned source and repository-native workflows outside managed paths are preserved. No product batch is implemented.
