### PR TITLE
cpp-rt-car: synchronize portfolio harness

### DIFF
--- a/.portfolio-harness.json
+++ b/.portfolio-harness.json
@@ -1,6 +1,6 @@
 {
   "control_repository": "kpbianco/portfolio-control",
-  "control_revision": "git:04d26300-a7f3a1a5-4b4240d2-4fa91df7-b665975b",
+  "control_revision": "git:0dd41167-bac9b0fd-d863d730-5d9bd850-0e341cb7",
   "harness_version": 2,
   "managed_paths": {
     ".agents/skills/ci-diagnose/SKILL.md": "sha256:93a7ce82-51786852-39d6f3f1-24e5670f-648b7f6a-242be771-6e86fd8b-10f653b0",
@@ -26,9 +26,9 @@
     ".github/codex/schemas/planner-review.schema.json": "sha256:0b6e73da-860c4c6d-9024f6e2-c2889162-f4d49813-e4c50691-87f68ef7-9183eba9",
     ".github/codex/schemas/product.schema.json": "sha256:0c01a565-e795a00f-9532a55b-dc2fc1d5-1aa20d8b-2af2f594-1b8be117-23fd4191",
     ".gitignore": "sha256:a55b5990-61dfcc0c-7a818cf5-3ef865ee-1d68dd9b-e83bffab-f72143c1-8254dfa3",
-    "AGENTS.md": "sha256:5c79f653-53103330-4d72acb3-c721a6ee-b97656bb-91849181-a6116a58-a8015f2f",
+    "AGENTS.md": "sha256:cc1cf476-59372440-a31f07bd-b2cb6c13-1ef89354-926e7b09-07254e11-cb2bb9a0",
     "contracts/profile-requirements.yaml": "sha256:36a421b8-53f07496-95b773da-201489f7-b17e0d49-3baa4787-482d9f49-715d8bc1",
-    "contracts/repo-profile.yaml": "sha256:b6b6ee80-1532ffbb-9adedb6c-470877ba-b9230120-932b8119-71c579b5-1d6b8d77"
+    "contracts/repo-profile.yaml": "sha256:a115dd4f-c947ec1b-3f4c506f-862ad878-95bb9168-e7f06ffb-b0501738-2ec2d9ae"
   },
   "product": "cpp-rt-car",
   "profile": "assurance",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ mandatory hardware/RT evidence, signing, release, or deployment gate. See
 ## Governed agentic delivery
 
 - Product: `cpp-rt-car`; delivery profile: `assurance`.
-- Control revision: `04d26300a7f3a1a54b4240d24fa91df7b665975b`; harness version: `2`.
+- Control revision: `0dd41167bac9b0fdd863d7305d9bd8500e341cb7`; harness version: `2`.
 - Read `contracts/profile-requirements.yaml` and the approved
   `contracts/active-batch.yaml` before implementation.
 - Stay inside active-batch allowed paths and preserve every forbidden path.

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: 04d26300a7f3a1a54b4240d24fa91df7b665975b  # pragma: allowlist secret
+  source_revision: 0dd41167bac9b0fdd863d7305d9bd8500e341cb7  # pragma: allowlist secret
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2


### PR DESCRIPTION
## Governed harness

Synchronizes explicitly managed harness content from control revision `0dd41167bac9b0fdd863d7305d9bd8500e341cb7` and harness version `2`.

Target-owned source and repository-native workflows outside managed paths are preserved. No product batch is implemented.
