### PR TITLE
cpp-rt-car: synchronize portfolio harness

### DIFF
--- a/.portfolio-harness.json
+++ b/.portfolio-harness.json
@@ -1,6 +1,6 @@
 {
   "control_repository": "kpbianco/portfolio-control",
-  "control_revision": "git:048c26e8-656a4cfc-e7afd176-bafa1476-ab11195b",
+  "control_revision": "git:9878923e-6d34d138-181deaea-9ed81fd4-24c8ab28",
   "harness_version": 2,
   "managed_paths": {
     ".agents/skills/ci-diagnose/SKILL.md": "sha256:93a7ce82-51786852-39d6f3f1-24e5670f-648b7f6a-242be771-6e86fd8b-10f653b0",
@@ -26,9 +26,9 @@
     ".github/codex/schemas/planner-review.schema.json": "sha256:0b6e73da-860c4c6d-9024f6e2-c2889162-f4d49813-e4c50691-87f68ef7-9183eba9",
     ".github/codex/schemas/product.schema.json": "sha256:0c01a565-e795a00f-9532a55b-dc2fc1d5-1aa20d8b-2af2f594-1b8be117-23fd4191",
     ".gitignore": "sha256:a55b5990-61dfcc0c-7a818cf5-3ef865ee-1d68dd9b-e83bffab-f72143c1-8254dfa3",
-    "AGENTS.md": "sha256:4e7c8ded-53d9e12a-95a54edc-45a2a45a-cd62f545-ce020008-1fc08dfb-40ae832e",
+    "AGENTS.md": "sha256:905a26ba-1819f723-dc169cc9-bdedf02b-79e398f5-598a5847-6ee1c67e-e5b192c5",
     "contracts/profile-requirements.yaml": "sha256:36a421b8-53f07496-95b773da-201489f7-b17e0d49-3baa4787-482d9f49-715d8bc1",
-    "contracts/repo-profile.yaml": "sha256:79cbebdb-9dec55dc-e7822a8a-d66f9fba-b22878aa-b27c2151-3b9bd70f-952b525f"
+    "contracts/repo-profile.yaml": "sha256:d975cefa-38a94859-747a059e-e0041766-3f094689-d20c0e79-138c1888-caaa3317"
   },
   "product": "cpp-rt-car",
   "profile": "assurance",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ mandatory hardware/RT evidence, signing, release, or deployment gate. See
 ## Governed agentic delivery
 
 - Product: `cpp-rt-car`; delivery profile: `assurance`.
-- Control revision: `048c26e8656a4cfce7afd176bafa1476ab11195b`; harness version: `2`.
+- Control revision: `9878923e6d34d138181deaea9ed81fd424c8ab28`; harness version: `2`.
 - Read `contracts/profile-requirements.yaml` and the approved
   `contracts/active-batch.yaml` before implementation.
 - Stay inside active-batch allowed paths and preserve every forbidden path.

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: 048c26e8656a4cfce7afd176bafa1476ab11195b  # pragma: allowlist secret
+  source_revision: 9878923e6d34d138181deaea9ed81fd424c8ab28  # pragma: allowlist secret
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2


### PR DESCRIPTION
## Governed harness

Synchronizes explicitly managed harness content from control revision `9878923e6d34d138181deaea9ed81fd424c8ab28` and harness version `2`.

Target-owned source and repository-native workflows outside managed paths are preserved. No product batch is implemented.
