### PR TITLE
cpp-rt-car: synchronize portfolio harness

### DIFF
--- a/.portfolio-harness.json
+++ b/.portfolio-harness.json
@@ -1,6 +1,6 @@
 {
   "control_repository": "kpbianco/portfolio-control",
-  "control_revision": "git:879a72bb-7059141a-2377c60b-c53fda4d-39101d04",
+  "control_revision": "git:a201f8ae-0863f650-127aac78-4dfb047e-a4e848dc",
   "harness_version": 2,
   "managed_paths": {
     ".agents/skills/ci-diagnose/SKILL.md": "sha256:93a7ce82-51786852-39d6f3f1-24e5670f-648b7f6a-242be771-6e86fd8b-10f653b0",
@@ -26,9 +26,9 @@
     ".github/codex/schemas/planner-review.schema.json": "sha256:0b6e73da-860c4c6d-9024f6e2-c2889162-f4d49813-e4c50691-87f68ef7-9183eba9",
     ".github/codex/schemas/product.schema.json": "sha256:18d0bd3f-439c1050-33309579-43c6daa8-b28aaccb-d8f7613f-0901b3aa-35535cfe",
     ".gitignore": "sha256:a55b5990-61dfcc0c-7a818cf5-3ef865ee-1d68dd9b-e83bffab-f72143c1-8254dfa3",
-    "AGENTS.md": "sha256:367e7016-90ceb57d-20c23dcd-afb7898e-99e8dfdc-437d6bcb-9187b6b2-9b3fad6c",
+    "AGENTS.md": "sha256:de239d81-1ef56738-8e6418a4-7368b9e3-780783cf-0019821e-2298b129-d36619da",
     "contracts/profile-requirements.yaml": "sha256:36a421b8-53f07496-95b773da-201489f7-b17e0d49-3baa4787-482d9f49-715d8bc1",
-    "contracts/repo-profile.yaml": "sha256:e5a84026-ba213dbd-cb17c6e6-3c069b93-f6c49837-93b7c760-ae48bea1-ad73846c"
+    "contracts/repo-profile.yaml": "sha256:b223f81e-76796491-df8581de-78b9db44-938a5036-e4a7ef15-445ba792-8ddf891d"
   },
   "product": "cpp-rt-car",
   "profile": "assurance",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ mandatory hardware/RT evidence, signing, release, or deployment gate. See
 ## Governed agentic delivery
 
 - Product: `cpp-rt-car`; delivery profile: `assurance`.
-- Control revision: `879a72bb7059141a2377c60bc53fda4d39101d04`; harness version: `2`.
+- Control revision: `a201f8ae0863f650127aac784dfb047ea4e848dc`; harness version: `2`.
 - Read `contracts/profile-requirements.yaml` and the approved
   `contracts/active-batch.yaml` before implementation.
 - Stay inside active-batch allowed paths and preserve every forbidden path.

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: 879a72bb7059141a2377c60bc53fda4d39101d04  # pragma: allowlist secret
+  source_revision: a201f8ae0863f650127aac784dfb047ea4e848dc  # pragma: allowlist secret
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2


### PR DESCRIPTION
## Governed harness

Synchronizes explicitly managed harness content from control revision `a201f8ae0863f650127aac784dfb047ea4e848dc` and harness version `2`.

Target-owned source and repository-native workflows outside managed paths are preserved. No product batch is implemented.
