### PR TITLE
cpp-rt-car: synchronize portfolio harness

### DIFF
--- a/.portfolio-harness.json
+++ b/.portfolio-harness.json
@@ -1,6 +1,6 @@
 {
   "control_repository": "kpbianco/portfolio-control",
-  "control_revision": "git:a201f8ae-0863f650-127aac78-4dfb047e-a4e848dc",
+  "control_revision": "git:0938ce04-1907cf27-d72561ec-af5f33b2-a0556c36",
   "harness_version": 2,
   "managed_paths": {
     ".agents/skills/ci-diagnose/SKILL.md": "sha256:93a7ce82-51786852-39d6f3f1-24e5670f-648b7f6a-242be771-6e86fd8b-10f653b0",
@@ -26,9 +26,9 @@
     ".github/codex/schemas/planner-review.schema.json": "sha256:0b6e73da-860c4c6d-9024f6e2-c2889162-f4d49813-e4c50691-87f68ef7-9183eba9",
     ".github/codex/schemas/product.schema.json": "sha256:18d0bd3f-439c1050-33309579-43c6daa8-b28aaccb-d8f7613f-0901b3aa-35535cfe",
     ".gitignore": "sha256:a55b5990-61dfcc0c-7a818cf5-3ef865ee-1d68dd9b-e83bffab-f72143c1-8254dfa3",
-    "AGENTS.md": "sha256:de239d81-1ef56738-8e6418a4-7368b9e3-780783cf-0019821e-2298b129-d36619da",
+    "AGENTS.md": "sha256:89c43696-fc00d035-6c61076c-780a2b93-d16fc970-5fed8f39-6535fb21-0341f552",
     "contracts/profile-requirements.yaml": "sha256:36a421b8-53f07496-95b773da-201489f7-b17e0d49-3baa4787-482d9f49-715d8bc1",
-    "contracts/repo-profile.yaml": "sha256:b223f81e-76796491-df8581de-78b9db44-938a5036-e4a7ef15-445ba792-8ddf891d"
+    "contracts/repo-profile.yaml": "sha256:ca9b4fb8-4f031d19-4150b706-d5d18ebf-a21b8113-9818e3b9-90de7f01-25951382"
   },
   "product": "cpp-rt-car",
   "profile": "assurance",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ mandatory hardware/RT evidence, signing, release, or deployment gate. See
 ## Governed agentic delivery
 
 - Product: `cpp-rt-car`; delivery profile: `assurance`.
-- Control revision: `a201f8ae0863f650127aac784dfb047ea4e848dc`; harness version: `2`.
+- Control revision: `0938ce041907cf27d72561ecaf5f33b2a0556c36`; harness version: `2`.
 - Read `contracts/profile-requirements.yaml` and the approved
   `contracts/active-batch.yaml` before implementation.
 - Stay inside active-batch allowed paths and preserve every forbidden path.

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: a201f8ae0863f650127aac784dfb047ea4e848dc  # pragma: allowlist secret
+  source_revision: 0938ce041907cf27d72561ecaf5f33b2a0556c36  # pragma: allowlist secret
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2


### PR DESCRIPTION
## Governed harness

Synchronizes explicitly managed harness content from control revision `0938ce041907cf27d72561ecaf5f33b2a0556c36` and harness version `2`.

Target-owned source and repository-native workflows outside managed paths are preserved. No product batch is implemented.
