### PR TITLE
ci: allow bounded aggregate suite headroom

### DIFF
--- a/release/rtfw-release-contract.json
+++ b/release/rtfw-release-contract.json
@@ -241,7 +241,7 @@
     "samples/CMakeLists.txt": "e2eb451eeff9a79dca27b46300dc46e1b8d4be4c320c29f41d6ab0bd8f075e4b",
     "samples/embed_cpp/mini_app.cpp": "5ce18e5af708434b02b918cf821e3401ff16179163cb132065cbdd087aa25e08",
     "src/runtime_profile_demo.cpp": "d8b7d00ea3bca701deac84a4ced1b72cd9c9cd3bfc9a33bf72e39fb2d50a02a1",
-    "tests/CMakeLists.txt": "1a896be63607f411ccfb1f55bd3d51f9ff4f18cd6b72649c76dcd41cd737be10",
+    "tests/CMakeLists.txt": "5e5eaac2f750ade9c99709ff40cdc6a24922b084ae901b996e439e9b0a74d9a3",
     "tests/add_subdirectory_consumer/CMakeLists.txt": "99aead1a31e943b8993635dfa2995697ad98227c587e685890287973d382b29e",
     "tests/add_subdirectory_consumer/main.cpp": "698d47ec1edbceeb0c72821ae0c8a49ecc2dc9f5e57a1ee9e11e7115e2554f42",
     "tests/determinism_artifact.cpp": "9ab84eccc085eea6d2ebc5055e524f4ea7f0f15104d98604eecd37b34e8569ab",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -210,7 +210,11 @@ if (SIM_GTEST_AVAILABLE)
     rtfw_enable_project_warnings(simcore_tests)
 
     add_test(NAME simcore_all COMMAND simcore_tests)
-    set_tests_properties(simcore_all PROPERTIES TIMEOUT 180)
+    # This aggregate executes the complete suite, including the bounded
+    # timing/concurrency cases that are also exposed as focused CTest targets.
+    # Keep a finite guard while allowing slower Debug and contended CI hosts to
+    # finish the assertions instead of terminating the process at 180 seconds.
+    set_tests_properties(simcore_all PROPERTIES TIMEOUT 300)
     add_test(
         NAME m19_extension_registration
         COMMAND simcore_tests


### PR DESCRIPTION
## What changed

- raise the finite `simcore_all` aggregate CTest guard from 180 to 300 seconds
- retain every test and assertion
- refresh the required frozen release-contract digest for `tests/CMakeLists.txt`

## Root cause

The complete aggregate contains 397 timing and concurrency cases. It reached the 180-second process timeout under a contended local clean-room run and once on Windows Debug, while the same exact test head passed on rerun. No assertion failed; CTest terminated the still-running aggregate at the guard.

## Validation

- `./scripts/agent-verify.sh full`
- full profile: 28/28 CTest targets passed
- `simcore_all`: passed in 38.36 seconds on the validation run
- release contract and C ABI v8 checks passed

This changes only the aggregate resource guard; it does not skip tests, relax assertions, alter ABI, or claim performance qualification.