### PR TITLE
cpp-rt-car: synchronize portfolio harness

### DIFF
--- a/.portfolio-harness.json
+++ b/.portfolio-harness.json
@@ -1,6 +1,6 @@
 {
   "control_repository": "kpbianco/portfolio-control",
-  "control_revision": "git:603c5963-4532e0c6-ff9feff3-50d308eb-50074130",
+  "control_revision": "git:ec3ad1d6-431dd1c0-46622d43-ea65fd52-4f4c57a5",
   "harness_version": 2,
   "managed_paths": {
     ".agents/skills/ci-diagnose/SKILL.md": "sha256:93a7ce82-51786852-39d6f3f1-24e5670f-648b7f6a-242be771-6e86fd8b-10f653b0",
@@ -26,9 +26,9 @@
     ".github/codex/schemas/planner-review.schema.json": "sha256:0b6e73da-860c4c6d-9024f6e2-c2889162-f4d49813-e4c50691-87f68ef7-9183eba9",
     ".github/codex/schemas/product.schema.json": "sha256:18d0bd3f-439c1050-33309579-43c6daa8-b28aaccb-d8f7613f-0901b3aa-35535cfe",
     ".gitignore": "sha256:a55b5990-61dfcc0c-7a818cf5-3ef865ee-1d68dd9b-e83bffab-f72143c1-8254dfa3",
-    "AGENTS.md": "sha256:08fd52dc-cb9eba33-bf0d9548-72fc9417-1f31fc73-b6a539cc-ccc80196-f9d4c678",
+    "AGENTS.md": "sha256:809a9790-848e8e3a-86f83e13-f4e88b59-c179ce1f-7376d7f8-d2e76174-c8dfbd37",
     "contracts/profile-requirements.yaml": "sha256:36a421b8-53f07496-95b773da-201489f7-b17e0d49-3baa4787-482d9f49-715d8bc1",
-    "contracts/repo-profile.yaml": "sha256:681302da-41f3f946-b246a355-d1322972-03d4c099-e4fd4a4f-4073c4a3-fb0a021b"
+    "contracts/repo-profile.yaml": "sha256:aa595cd9-1ef3e1ae-f0f321aa-af82c784-824f7db3-2423da56-da78c08f-5e90cb8d"
   },
   "product": "cpp-rt-car",
   "profile": "assurance",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ mandatory hardware/RT evidence, signing, release, or deployment gate. See
 ## Governed agentic delivery
 
 - Product: `cpp-rt-car`; delivery profile: `assurance`.
-- Control revision: `603c59634532e0c6ff9feff350d308eb50074130`; harness version: `2`.
+- Control revision: `ec3ad1d6431dd1c046622d43ea65fd524f4c57a5`; harness version: `2`.
 - Read `contracts/profile-requirements.yaml` and the approved
   `contracts/active-batch.yaml` before implementation.
 - Stay inside active-batch allowed paths and preserve every forbidden path.

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: 603c59634532e0c6ff9feff350d308eb50074130  # pragma: allowlist secret
+  source_revision: ec3ad1d6431dd1c046622d43ea65fd524f4c57a5  # pragma: allowlist secret
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2


### PR DESCRIPTION
## Governed harness

Synchronizes explicitly managed harness content from control revision `ec3ad1d6431dd1c046622d43ea65fd524f4c57a5` and harness version `2`.

Target-owned source and repository-native workflows outside managed paths are preserved. No product batch is implemented.
