### PR TITLE
cpp-rt-car: synchronize portfolio harness

### DIFF
--- a/.portfolio-harness.json
+++ b/.portfolio-harness.json
@@ -1,6 +1,6 @@
 {
   "control_repository": "kpbianco/portfolio-control",
-  "control_revision": "git:b64611ea-561b0d81-5ec9c5e4-27ac468e-83b4b308",
+  "control_revision": "git:7dd40365-fb62c8f3-fe222a72-bdc2ca4d-07a0cf1d",
   "harness_version": 2,
   "managed_paths": {
     ".agents/skills/ci-diagnose/SKILL.md": "sha256:93a7ce82-51786852-39d6f3f1-24e5670f-648b7f6a-242be771-6e86fd8b-10f653b0",
@@ -26,9 +26,9 @@
     ".github/codex/schemas/planner-review.schema.json": "sha256:0b6e73da-860c4c6d-9024f6e2-c2889162-f4d49813-e4c50691-87f68ef7-9183eba9",
     ".github/codex/schemas/product.schema.json": "sha256:18d0bd3f-439c1050-33309579-43c6daa8-b28aaccb-d8f7613f-0901b3aa-35535cfe",
     ".gitignore": "sha256:a55b5990-61dfcc0c-7a818cf5-3ef865ee-1d68dd9b-e83bffab-f72143c1-8254dfa3",
-    "AGENTS.md": "sha256:3ba0d677-3c43d071-7e1f4270-0c40a016-862eeb65-2d77c830-4856cf47-1a328e5e",
+    "AGENTS.md": "sha256:f09a0e91-6caabec5-bf042d12-2af2b5c5-7d396185-ecf01f7f-9eba4493-242e1b83",
     "contracts/profile-requirements.yaml": "sha256:36a421b8-53f07496-95b773da-201489f7-b17e0d49-3baa4787-482d9f49-715d8bc1",
-    "contracts/repo-profile.yaml": "sha256:2cf5bd3d-6e34729f-6fb89f9d-397283b6-8612a19c-39548812-165f88f0-5e82807c"
+    "contracts/repo-profile.yaml": "sha256:52d9c50a-2d1785f6-093ae56f-74b99da3-8c779533-820f5391-4d802812-a594b2e7"
   },
   "product": "cpp-rt-car",
   "profile": "assurance",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ mandatory hardware/RT evidence, signing, release, or deployment gate. See
 ## Governed agentic delivery
 
 - Product: `cpp-rt-car`; delivery profile: `assurance`.
-- Control revision: `b64611ea561b0d815ec9c5e427ac468e83b4b308`; harness version: `2`.
+- Control revision: `7dd40365fb62c8f3fe222a72bdc2ca4d07a0cf1d`; harness version: `2`.
 - Read `contracts/profile-requirements.yaml` and the approved
   `contracts/active-batch.yaml` before implementation.
 - Stay inside active-batch allowed paths and preserve every forbidden path.

--- a/contracts/repo-profile.yaml
+++ b/contracts/repo-profile.yaml
@@ -6,7 +6,7 @@ control_plane:
   repository: kpbianco/portfolio-control
   profile_path: profiles/assurance.yaml
   product_path: products/cpp-rt-car
-  source_revision: b64611ea561b0d815ec9c5e427ac468e83b4b308  # pragma: allowlist secret
+  source_revision: 7dd40365fb62c8f3fe222a72bdc2ca4d07a0cf1d  # pragma: allowlist secret
 audited_baseline: c5220de1ccfceca4d1584c3df5e0ddb17da171eb
 autonomy:
   level: 2


### PR DESCRIPTION
## Governed harness

Synchronizes explicitly managed harness content from control revision `7dd40365fb62c8f3fe222a72bdc2ca4d07a0cf1d` and harness version `2`.

Target-owned source and repository-native workflows outside managed paths are preserved. No product batch is implemented.
